### PR TITLE
fix(react-popover): prevent incorrect non-modal screen reader announcement

### DIFF
--- a/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
+++ b/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "omit role=group from PopoverSurface when no accessible name is provided, fixing Narrator announcing contains style group on non-modal popovers",
+  "packageName": "@fluentui/react-popover",
+  "email": "paulmardling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
+++ b/change/@fluentui-react-popover-bd6da173-2885-437a-98d5-f1c9a6e312c1.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "omit role=group from PopoverSurface when no accessible name is provided, fixing Narrator announcing contains style group on non-modal popovers",
+  "comment": "fix: omit group role from PopoverSurface when no accessible name is provided",
   "packageName": "@fluentui/react-popover",
   "email": "paulmardling@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -420,7 +420,6 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -640,7 +639,6 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div
@@ -900,7 +898,6 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -1120,7 +1117,6 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div

--- a/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/DonutChart/__snapshots__/DonutChart.test.tsx.snap
@@ -420,6 +420,7 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -639,6 +640,7 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div
@@ -898,6 +900,7 @@ Object {
           <div
             class="fui-PopoverSurface"
             data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+            role="group"
             style="position: fixed; left: 0px; top: 0px; margin: 0px;"
           >
             <div
@@ -1117,6 +1120,7 @@ Object {
         <div
           class="fui-PopoverSurface"
           data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+          role="group"
           style="position: fixed; left: 0px; top: 0px; margin: 0px;"
         >
           <div

--- a/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
@@ -427,7 +427,6 @@ exports[`GanttChart interaction and accessibility tests should render custom cal
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div
@@ -4762,7 +4761,6 @@ exports[`GanttChart rendering and behavior tests should render callout correctly
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GanttChart/__snapshots__/GanttChart.test.tsx.snap
@@ -427,6 +427,7 @@ exports[`GanttChart interaction and accessibility tests should render custom cal
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div
@@ -4761,6 +4762,7 @@ exports[`GanttChart rendering and behavior tests should render callout correctly
         data-popper-placement="top"
         data-popper-reference-hidden=""
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: absolute; left: 0px; top: 0px; margin: 0px; box-sizing: border-box; max-width: 0px; max-height: -20px; overflow-y: auto; transform: translate(-10px, -40px); --fui-positioning-slide-direction-x: 0px; --fui-positioning-slide-direction-y: 1px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
@@ -873,6 +873,7 @@ exports[`Gauge chart interactions Should hide callout on mouse leave 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1558,6 +1559,7 @@ exports[`Gauge chart interactions Should show callout on focus 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1857,6 +1859,7 @@ exports[`Gauge chart interactions Should show callout on mouse over 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/__snapshots__/GaugeChart.test.tsx.snap
@@ -873,7 +873,6 @@ exports[`Gauge chart interactions Should hide callout on mouse leave 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1559,7 +1558,6 @@ exports[`Gauge chart interactions Should show callout on focus 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -1859,7 +1857,6 @@ exports[`Gauge chart interactions Should show callout on mouse over 1`] = `
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -1309,6 +1309,7 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/__snapshots__/GroupedVerticalBarChart.test.tsx.snap
@@ -1309,7 +1309,6 @@ exports[`GroupedVerticalBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -1878,7 +1878,6 @@ exports[`LineChart - mouse events Should render callout correctly on mouseover 1
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2553,7 +2552,6 @@ exports[`LineChart - mouse events Should render customized callout per stack on 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/LineChart/__snapshots__/LineChart.test.tsx.snap
@@ -1878,6 +1878,7 @@ exports[`LineChart - mouse events Should render callout correctly on mouseover 1
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2552,6 +2553,7 @@ exports[`LineChart - mouse events Should render customized callout per stack on 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
@@ -11596,6 +11596,7 @@ exports[`SankeyChart - mouse events Should render callout correctly on mouseover
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/SankeyChart/__snapshots__/SankeyChart.test.tsx.snap
@@ -11596,7 +11596,6 @@ exports[`SankeyChart - mouse events Should render callout correctly on mouseover
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -4983,6 +4983,7 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -5608,6 +5609,7 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -4983,7 +4983,6 @@ exports[`VerticalBarChart - mouse events Should render callout correctly on mous
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -5609,7 +5608,6 @@ exports[`VerticalBarChart - mouse events Should render customized callout on mou
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>

--- a/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -2152,6 +2152,7 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2723,6 +2724,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>
@@ -3336,6 +3338,7 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
+        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
+++ b/packages/charts/react-charts/library/src/components/VerticalStackedBarChart/__snapshots__/VerticalStackedBarChart.test.tsx.snap
@@ -2152,7 +2152,6 @@ exports[`VerticalStackedBarChart - mouse events Should render callout correctly 
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div
@@ -2724,7 +2723,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div>
@@ -3338,7 +3336,6 @@ exports[`VerticalStackedBarChart - mouse events Should render customized callout
       <div
         class="fui-PopoverSurface"
         data-tabster="{\\"restorer\\":{\\"type\\":0}}"
-        role="group"
         style="position: fixed; left: 0px; top: 0px; margin: 0px;"
       >
         <div

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.cy.tsx
@@ -13,7 +13,7 @@ const mount = (element: JSXElement) => {
 };
 
 const popoverTriggerSelector = '[aria-expanded]';
-const popoverContentSelector = '[role="group"]';
+const popoverContentSelector = '.fui-PopoverSurface';
 const popoverInteractiveContentSelector = '[role="dialog"]';
 
 describe('Popover', () => {

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
@@ -5,6 +5,21 @@ import { usePopover_unstable } from './usePopover';
 import { isConformant } from '../../testing/isConformant';
 import type { PopoverProps } from './Popover.types';
 
+// useFocusFinders requires tabster to be initialized on the document (via FluentProvider),
+// which does not happen in unit tests. Mock it with a real DOM-based implementation
+// so findFirstFocusable works correctly in jsdom.
+jest.mock('@fluentui/react-tabster', () => {
+  const FOCUSABLE_SELECTOR =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return {
+    ...jest.requireActual('@fluentui/react-tabster'),
+    useFocusFinders: () => ({
+      findFirstFocusable: (container: HTMLElement | null) =>
+        container?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? undefined,
+    }),
+  };
+});
+
 describe('Popover', () => {
   isConformant({
     Component: Popover,

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
@@ -3,12 +3,10 @@ import { Popover } from './Popover';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { usePopover_unstable } from './usePopover';
 import { isConformant } from '../../testing/isConformant';
+import { nonInteractiveContentWarning } from './constants';
 import type { PopoverProps } from './Popover.types';
 
 describe('Popover', () => {
-  const nonInteractiveContentWarning =
-    'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.';
-
   isConformant({
     Component: Popover,
     displayName: 'Popover',

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
@@ -3,7 +3,6 @@ import { Popover } from './Popover';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { usePopover_unstable } from './usePopover';
 import { isConformant } from '../../testing/isConformant';
-import { nonInteractiveContentWarning } from './constants';
 import type { PopoverProps } from './Popover.types';
 
 describe('Popover', () => {
@@ -248,7 +247,9 @@ describe('Popover', () => {
 
       rerender({ open: true });
 
-      expect(warnSpy).toHaveBeenCalledWith(nonInteractiveContentWarning);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
+      );
     });
 
     it('does not warn when popover opens with focusable content', () => {
@@ -273,7 +274,9 @@ describe('Popover', () => {
 
       rerender({ open: true });
 
-      expect(warnSpy).not.toHaveBeenCalledWith(nonInteractiveContentWarning);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
+      );
 
       document.body.removeChild(content);
     });
@@ -299,7 +302,11 @@ describe('Popover', () => {
       rerender({ open: false });
       rerender({ open: true });
 
-      const matchingWarnings = warnSpy.mock.calls.filter(call => call[0] === nonInteractiveContentWarning);
+      const matchingWarnings = warnSpy.mock.calls.filter(
+        call =>
+          call[0] ===
+          'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
+      );
 
       expect(matchingWarnings).toHaveLength(1);
     });

--- a/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/Popover/Popover.test.tsx
@@ -6,6 +6,9 @@ import { isConformant } from '../../testing/isConformant';
 import type { PopoverProps } from './Popover.types';
 
 describe('Popover', () => {
+  const nonInteractiveContentWarning =
+    'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.';
+
   isConformant({
     Component: Popover,
     displayName: 'Popover',
@@ -214,6 +217,93 @@ describe('Popover', () => {
 
       document.body.removeChild(triggerButton);
       document.body.removeChild(popoverContent);
+    });
+  });
+
+  describe('dev warning for non-focusable content', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns when popover opens without focusable content', () => {
+      const content = document.createElement('div');
+      content.textContent = 'Static content';
+
+      const { result, rerender } = renderHook(
+        ({ open }) =>
+          usePopover_unstable({
+            open,
+            children: <div />,
+          }),
+        { initialProps: { open: false } },
+      );
+
+      act(() => {
+        (result.current.contentRef as React.RefObject<HTMLElement | null>).current = content;
+      });
+
+      rerender({ open: true });
+
+      expect(warnSpy).toHaveBeenCalledWith(nonInteractiveContentWarning);
+    });
+
+    it('does not warn when popover opens with focusable content', () => {
+      const content = document.createElement('div');
+      const button = document.createElement('button');
+      button.textContent = 'Focusable';
+      content.appendChild(button);
+      document.body.appendChild(content);
+
+      const { result, rerender } = renderHook(
+        ({ open }) =>
+          usePopover_unstable({
+            open,
+            children: <div />,
+          }),
+        { initialProps: { open: false } },
+      );
+
+      act(() => {
+        (result.current.contentRef as React.RefObject<HTMLElement | null>).current = content;
+      });
+
+      rerender({ open: true });
+
+      expect(warnSpy).not.toHaveBeenCalledWith(nonInteractiveContentWarning);
+
+      document.body.removeChild(content);
+    });
+
+    it('warns only once per popover instance', () => {
+      const content = document.createElement('div');
+      content.textContent = 'Static content';
+
+      const { result, rerender } = renderHook(
+        ({ open }) =>
+          usePopover_unstable({
+            open,
+            children: <div />,
+          }),
+        { initialProps: { open: false } },
+      );
+
+      act(() => {
+        (result.current.contentRef as React.RefObject<HTMLElement | null>).current = content;
+      });
+
+      rerender({ open: true });
+      rerender({ open: false });
+      rerender({ open: true });
+
+      const matchingWarnings = warnSpy.mock.calls.filter(call => call[0] === nonInteractiveContentWarning);
+
+      expect(matchingWarnings).toHaveLength(1);
     });
   });
 });

--- a/packages/react-components/react-popover/library/src/components/Popover/constants.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/constants.ts
@@ -8,3 +8,6 @@
  * @internal
  */
 export const popoverSurfaceBorderRadius = 4;
+
+export const nonInteractiveContentWarning =
+  'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.';

--- a/packages/react-components/react-popover/library/src/components/Popover/constants.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/constants.ts
@@ -8,6 +8,3 @@
  * @internal
  */
 export const popoverSurfaceBorderRadius = 4;
-
-export const nonInteractiveContentWarning =
-  'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.';

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -184,19 +184,21 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   }, [findFirstFocusable, activateModal, open, positioningRefs.contentRef, props.unstable_disableAutoFocus]);
 
   React.useEffect(() => {
-    if (process.env.NODE_ENV === 'production' || hasWarnedForNonFocusableContent.current || !open) {
-      return;
+    if (process.env.NODE_ENV !== 'production') {
+      if (hasWarnedForNonFocusableContent.current || !open) {
+        return;
+      }
+
+      const contentElement = positioningRefs.contentRef.current;
+
+      if (!contentElement || hasFocusableContent(contentElement)) {
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn(nonInteractiveContentWarning);
+      hasWarnedForNonFocusableContent.current = true;
     }
-
-    const contentElement = positioningRefs.contentRef.current;
-
-    if (!contentElement || hasFocusableContent(contentElement)) {
-      return;
-    }
-
-    // eslint-disable-next-line no-console
-    console.warn(nonInteractiveContentWarning);
-    hasWarnedForNonFocusableContent.current = true;
   }, [findFirstFocusable, open, positioningRefs.contentRef]);
 
   return {

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -35,6 +35,7 @@ import { PopoverSurfaceMotion } from './PopoverSurfaceMotion';
 export const usePopover_unstable = (props: PopoverProps): PopoverState => {
   const [contextTarget, setContextTarget] = usePositioningMouseTarget();
   const { targetDocument } = useFluent();
+  const hasWarnedForNonFocusableContent = React.useRef(false);
 
   const positioning = resolvePositioningShorthand(props.positioning);
   const handlePositionEnd = usePositioningSlideDirection({
@@ -182,6 +183,24 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     }
   }, [findFirstFocusable, activateModal, open, positioningRefs.contentRef, props.unstable_disableAutoFocus]);
 
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production' || hasWarnedForNonFocusableContent.current || !open) {
+      return;
+    }
+
+    const contentElement = positioningRefs.contentRef.current;
+
+    if (!contentElement || hasFocusableContent(contentElement)) {
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
+    );
+    hasWarnedForNonFocusableContent.current = true;
+  }, [findFirstFocusable, open, positioningRefs.contentRef]);
+
   return {
     components: {
       surfaceMotion: PopoverSurfaceMotion,
@@ -208,6 +227,13 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     }),
   };
 };
+
+function hasFocusableContent(contentElement: HTMLElement): boolean {
+  const focusableSelector =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  return contentElement.matches(focusableSelector) || contentElement.querySelector(focusableSelector) !== null;
+}
 
 /**
  * Creates and manages the Popover open state

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -191,7 +191,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
 
       const contentElement = positioningRefs.contentRef.current;
 
-      if (!contentElement || hasFocusableContent(contentElement)) {
+      if (!contentElement || findFirstFocusable(contentElement)) {
         return;
       }
 
@@ -229,13 +229,6 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     }),
   };
 };
-
-function hasFocusableContent(contentElement: HTMLElement): boolean {
-  const focusableSelector =
-    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
-  return contentElement.matches(focusableSelector) || contentElement.querySelector(focusableSelector) !== null;
-}
 
 /**
  * Creates and manages the Popover open state

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -20,7 +20,7 @@ import {
 import { useFocusFinders, useActivateModal } from '@fluentui/react-tabster';
 import { arrowHeights } from '../PopoverSurface/index';
 import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.types';
-import { popoverSurfaceBorderRadius } from './constants';
+import { nonInteractiveContentWarning, popoverSurfaceBorderRadius } from './constants';
 import { presenceMotionSlot } from '@fluentui/react-motion';
 import { PopoverSurfaceMotion } from './PopoverSurfaceMotion';
 
@@ -195,9 +195,7 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
     }
 
     // eslint-disable-next-line no-console
-    console.warn(
-      'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
-    );
+    console.warn(nonInteractiveContentWarning);
     hasWarnedForNonFocusableContent.current = true;
   }, [findFirstFocusable, open, positioningRefs.contentRef]);
 

--- a/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-popover/library/src/components/Popover/usePopover.ts
@@ -20,7 +20,7 @@ import {
 import { useFocusFinders, useActivateModal } from '@fluentui/react-tabster';
 import { arrowHeights } from '../PopoverSurface/index';
 import type { OpenPopoverEvents, PopoverProps, PopoverState } from './Popover.types';
-import { nonInteractiveContentWarning, popoverSurfaceBorderRadius } from './constants';
+import { popoverSurfaceBorderRadius } from './constants';
 import { presenceMotionSlot } from '@fluentui/react-motion';
 import { PopoverSurfaceMotion } from './PopoverSurfaceMotion';
 
@@ -196,7 +196,9 @@ export const usePopover_unstable = (props: PopoverProps): PopoverState => {
       }
 
       // eslint-disable-next-line no-console
-      console.warn(nonInteractiveContentWarning);
+      console.warn(
+        'Non-modal Popover with non-interactive content may not be announced by screen readers because focus remains on the trigger. Consider using Tooltip for informational content, or make the Popover content focusable if user interaction is expected.',
+      );
       hasWarnedForNonFocusableContent.current = true;
     }
   }, [findFirstFocusable, open, positioningRefs.contentRef]);

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -1,6 +1,7 @@
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { PopoverSurface } from './PopoverSurface';
+import { getPopoverSurfaceAriaAttributes } from './usePopoverSurface';
 import { render, fireEvent } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { mockPopoverContext } from '../../testing/mockUsePopoverContext';
@@ -72,12 +73,47 @@ describe('PopoverSurface', () => {
     expect(queryByRole('dialog')).not.toBeNull();
   });
 
-  it('should set role group if focus trap is not active', () => {
+  it('should set role group if focus trap is not active and an accessible name is provided', () => {
     // Arrange
     mockPopoverContext({ trapFocus: false });
+    // props includes aria-label='test', so role='group' should be applied
     const { getByTestId } = render(<PopoverSurface {...props}>Content</PopoverSurface>);
 
     // Assert
-    expect(getByTestId(testid)).not.toBeNull();
+    expect(getByTestId(testid).getAttribute('role')).toEqual('group');
+  });
+});
+
+describe('getPopoverSurfaceAriaAttributes', () => {
+  it('returns dialog attributes when focus is trapped', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: false,
+        trapFocus: true,
+      }),
+    ).toEqual({
+      role: 'dialog',
+      'aria-modal': true,
+    });
+  });
+
+  it('returns group when the surface has an accessible name', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: true,
+        trapFocus: false,
+      }),
+    ).toEqual({
+      role: 'group',
+    });
+  });
+
+  it('returns no role when the surface is unlabelled', () => {
+    expect(
+      getPopoverSurfaceAriaAttributes({
+        hasAccessibleName: false,
+        trapFocus: false,
+      }),
+    ).toEqual({});
   });
 });

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/PopoverSurface.test.tsx
@@ -1,7 +1,6 @@
 import { resetIdsForTests } from '@fluentui/react-utilities';
 import * as React from 'react';
 import { PopoverSurface } from './PopoverSurface';
-import { getPopoverSurfaceAriaAttributes } from './usePopoverSurface';
 import { render, fireEvent } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { mockPopoverContext } from '../../testing/mockUsePopoverContext';
@@ -81,39 +80,5 @@ describe('PopoverSurface', () => {
 
     // Assert
     expect(getByTestId(testid).getAttribute('role')).toEqual('group');
-  });
-});
-
-describe('getPopoverSurfaceAriaAttributes', () => {
-  it('returns dialog attributes when focus is trapped', () => {
-    expect(
-      getPopoverSurfaceAriaAttributes({
-        hasAccessibleName: false,
-        trapFocus: true,
-      }),
-    ).toEqual({
-      role: 'dialog',
-      'aria-modal': true,
-    });
-  });
-
-  it('returns group when the surface has an accessible name', () => {
-    expect(
-      getPopoverSurfaceAriaAttributes({
-        hasAccessibleName: true,
-        trapFocus: false,
-      }),
-    ).toEqual({
-      role: 'group',
-    });
-  });
-
-  it('returns no role when the surface is unlabelled', () => {
-    expect(
-      getPopoverSurfaceAriaAttributes({
-        hasAccessibleName: false,
-        trapFocus: false,
-      }),
-    ).toEqual({});
   });
 });

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -7,6 +7,35 @@ import { usePopoverContext_unstable } from '../../popoverContext';
 import type { PopoverSurfaceProps, PopoverSurfaceState } from './PopoverSurface.types';
 import { useMotionForwardedRef } from '@fluentui/react-motion';
 
+type PopoverSurfaceAriaAttributes = Pick<React.HTMLAttributes<HTMLDivElement>, 'role' | 'aria-modal'>;
+
+/**
+ * Returns the ARIA role and modal attributes for a PopoverSurface.
+ *
+ * Extracted as a pure function to allow isolated unit testing of the attribute logic.
+ * - `trapFocus=true` → `role="dialog"` + `aria-modal=true`
+ * - `trapFocus=false` + accessible name present → `role="group"`
+ * - `trapFocus=false` + no accessible name → no role (plain div avoids screen reader
+ *   announcing "contains style group" for unlabelled popovers)
+ */
+export const getPopoverSurfaceAriaAttributes = ({
+  hasAccessibleName,
+  trapFocus,
+}: {
+  hasAccessibleName: boolean;
+  trapFocus: boolean;
+}): PopoverSurfaceAriaAttributes => {
+  if (trapFocus) {
+    return { role: 'dialog', 'aria-modal': true };
+  }
+
+  if (hasAccessibleName) {
+    return { role: 'group' };
+  }
+
+  return {};
+};
+
 /**
  * Create the state required to render PopoverSurface.
  *
@@ -54,8 +83,10 @@ export const usePopoverSurface_unstable = (
         // `contentRef` is wrongly assigned to be `HTMLElement` instead of `HTMLDivElement`
         // but since it would be a breaking change to fix it, we are casting ref to it's proper type
         ref: useMergedRefs(ref, contentRef, motionForwardedRef) as React.Ref<HTMLDivElement>,
-        role: trapFocus ? 'dialog' : 'group',
-        'aria-modal': trapFocus ? true : undefined,
+        ...getPopoverSurfaceAriaAttributes({
+          hasAccessibleName: Boolean(props['aria-label'] || props['aria-labelledby']),
+          trapFocus,
+        }),
         ...modalAttributes,
         ...props,
       }),

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -57,7 +57,7 @@ export const usePopoverSurface_unstable = (
   const size = usePopoverContext_unstable(context => context.size);
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
   const appearance = usePopoverContext_unstable(context => context.appearance);
-  const trapFocus = usePopoverContext_unstable(context => context.trapFocus);
+  const trapFocus = !!usePopoverContext_unstable(context => context.trapFocus);
   const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
   const motionForwardedRef = useMotionForwardedRef();

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -12,7 +12,6 @@ type PopoverSurfaceAriaAttributes = Pick<React.HTMLAttributes<HTMLDivElement>, '
 /**
  * Returns the ARIA role and modal attributes for a PopoverSurface.
  *
- * Extracted as a pure function to allow isolated unit testing of the attribute logic.
  * - `trapFocus=true` → `role="dialog"` + `aria-modal=true`
  * - `trapFocus=false` + accessible name present → `role="group"`
  * - `trapFocus=false` + no accessible name → no role (plain div avoids screen reader

--- a/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-popover/library/src/components/PopoverSurface/usePopoverSurface.ts
@@ -56,7 +56,7 @@ export const usePopoverSurface_unstable = (
   const size = usePopoverContext_unstable(context => context.size);
   const withArrow = usePopoverContext_unstable(context => context.withArrow);
   const appearance = usePopoverContext_unstable(context => context.appearance);
-  const trapFocus = !!usePopoverContext_unstable(context => context.trapFocus);
+  const trapFocus = Boolean(usePopoverContext_unstable(context => context.trapFocus));
   const inertTrapFocus = usePopoverContext_unstable(context => context.inertTrapFocus);
   const inline = usePopoverContext_unstable(context => context.inline);
   const motionForwardedRef = useMotionForwardedRef();

--- a/packages/react-components/react-popover/stories/src/Popover/PopoverDefault.stories.tsx
+++ b/packages/react-components/react-popover/stories/src/Popover/PopoverDefault.stories.tsx
@@ -26,7 +26,7 @@ export const Default = (props: PopoverProps): JSXElement => (
       <Button>Popover trigger</Button>
     </PopoverTrigger>
 
-    <PopoverSurface tabIndex={-1}>
+    <PopoverSurface tabIndex={-1} aria-label="Popover content">
       <ExampleContent />
     </PopoverSurface>
   </Popover>


### PR DESCRIPTION
## Summary
This PR fixes the incorrect Narrator announcement for non-modal Popover when content is non-interactive.

Previously, activating this scenario could produce:
contains style group

## What Changed
PopoverSurface no longer applies role="group" unconditionally when trapFocus is false.
role="group" is now applied only when an accessible name is provided via aria-label or aria-labelledby, aligning with WAI-ARIA 1.2 requirements.
If no accessible name is provided, the surface renders as a plain div, so Narrator no longer announces contains style group.
Aria attribute logic was extracted into a pure function named getPopoverSurfaceAriaAttributes for isolated unit testing.
The default Popover story was updated to include aria-label as the recommended usage pattern.
Added a dev-only warning for non-modal popovers that open with non-interactive, non-focusable content to guide consumers toward accessible patterns.
## Previous Behavior
On activating a popover with no interactive elements, Narrator announced:
contains style group

## New Behavior
Narrator no longer announces contains style group for a non-modal popover surface without an accessible name.

## Notes
This change resolves the incorrect announcement and adds consumer guidance for the non-interactive-content edge case.

## Work Item
Fixes [#18661](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/18661)
