### PR TITLE
fix(web-components): minify tagged templates in the ESM build

### DIFF
--- a/change/@fluentui-web-components-7c2f9b1e-4a83-4e6d-9f5a-36298abc1001.json
+++ b/change/@fluentui-web-components-7c2f9b1e-4a83-4e6d-9f5a-36298abc1001.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: minify html/css tagged templates in the ESM build so template whitespace no longer renders under non-normal CSS white-space, matching the rollup bundles",
+  "packageName": "@fluentui/web-components",
+  "email": "akshitnassa412@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -99,6 +99,7 @@
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "0.10.10",
+    "@jridgewell/remapping": "^2.3.5",
     "@tensile-perf/web-components": "~0.2.2",
     "@storybook/html": "9.1.17",
     "@storybook/html-vite": "9.1.17",
@@ -106,6 +107,7 @@
     "@wc-toolkit/cem-inheritance": "1.2.2",
     "@wc-toolkit/module-path-resolver": "1.0.0",
     "@wc-toolkit/type-parser": "1.0.3",
+    "acorn": "^8.17.0",
     "chromedriver": "^125.0.0",
     "dedent": "^1.2.0",
     "rollup-plugin-fast-tagged-templates": "^1.0.2"

--- a/packages/web-components/scripts/compile.js
+++ b/packages/web-components/scripts/compile.js
@@ -6,6 +6,8 @@ import { dirname, join } from 'node:path';
 
 import chalk from 'chalk';
 
+import { minifyTaggedTemplates } from './minify-tagged-templates.js';
+
 const SRC = 'src';
 const OUT = 'dist/esm';
 
@@ -34,6 +36,10 @@ async function compile() {
 
   console.log(chalk.blueBright(`compile: running tsc`));
   execSync(`tsc -p tsconfig.lib.json --rootDir ./src --baseUrl .`, { stdio: 'inherit' });
+
+  console.log(chalk.blueBright(`compile: minifying tagged templates`));
+  const minified = await minifyTaggedTemplates(OUT);
+  console.log(chalk.dim(`compile: minified tagged templates in ${minified} file${minified === 1 ? '' : 's'}`));
 
   console.log(chalk.blueBright(`compile: copying SSR assets`));
   await copySsrAssets();

--- a/packages/web-components/scripts/minify-tagged-templates.js
+++ b/packages/web-components/scripts/minify-tagged-templates.js
@@ -1,0 +1,60 @@
+// @ts-check
+
+import { glob, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import remapping from '@jridgewell/remapping';
+import { parse } from 'acorn';
+import fastTaggedTemplates from 'rollup-plugin-fast-tagged-templates';
+
+/**
+ * Minifies `html` and `css` tagged template literals in the compiled ESM output, reusing the
+ * exact transform the rollup bundles get from rollup.config.js. Whitespace-only text nodes in
+ * templates become visible when a consumer sets a non-`normal` CSS `white-space` on an ancestor,
+ * so the shipped ESM must not contain them — and running the same transform as the bundles keeps
+ * both builds behaviorally identical.
+ * @see https://github.com/microsoft/fluentui/issues/36298
+ * @param {string} esmDir - path to the compiled ESM output directory
+ * @returns {Promise<number>} the number of files rewritten
+ */
+export async function minifyTaggedTemplates(esmDir) {
+  const plugin = fastTaggedTemplates();
+  const pluginContext = { parse: code => parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) };
+
+  let count = 0;
+
+  for await (const file of glob('**/*.js', { cwd: esmDir })) {
+    const filePath = join(esmDir, file);
+    const code = await readFile(filePath, 'utf-8');
+
+    try {
+      const result = await plugin.transform.call(pluginContext, code, filePath);
+
+      if (!result || result.code === code) {
+        continue;
+      }
+
+      await writeFile(filePath, result.code);
+      await mergeSourceMap(filePath, result.map);
+      count++;
+    } catch (cause) {
+      throw new Error(`minify-tagged-templates: failed to transform ${filePath}`, { cause });
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Composes the minification sourcemap with the map tsc emitted, so the shipped map still traces
+ * the transformed JS back to the TypeScript sources.
+ * @param {string} filePath - path to the rewritten .js file
+ * @param {import('magic-string').SourceMap} transformMap - map produced by the template transform
+ */
+async function mergeSourceMap(filePath, transformMap) {
+  const mapPath = `${filePath}.map`;
+  const tscMap = JSON.parse(await readFile(mapPath, 'utf-8'));
+  const merged = remapping([JSON.parse(transformMap.toString()), tscMap], () => null);
+  merged.file = tscMap.file;
+  await writeFile(mapPath, merged.toString());
+}

--- a/packages/web-components/scripts/verify-packaging.js
+++ b/packages/web-components/scripts/verify-packaging.js
@@ -6,13 +6,16 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { glob, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { parse } from 'acorn';
 import micromatch from 'micromatch';
+import fastTaggedTemplates from 'rollup-plugin-fast-tagged-templates';
 
-main();
+await main();
 
-function main() {
+async function main() {
   /**
    * @see https://docs.npmjs.com/cli/v10/commands/npm-publish#files-included-in-package
    */
@@ -29,6 +32,36 @@ function main() {
   const nonProdAssets = ['assets/', 'docs/*', 'temp/*', 'bundle-size/*', '.storybook/*', 'stories/*'];
 
   verifyPackaging({ alwaysPublishedFiles, nonProdAssets, rootConfigFiles });
+  await verifyTaggedTemplatesAreMinified();
+}
+
+/**
+ * The shipped ESM build must not contain readable whitespace inside `html` and `css` tagged
+ * template literals: whitespace-only text nodes in templates become visible when a consumer
+ * sets a non-`normal` CSS `white-space`, and the rollup bundles already ship these templates
+ * minified via rollup-plugin-fast-tagged-templates. Asserting that the same transform is a
+ * no-op over `dist/esm` guarantees the ESM and bundle builds stay behaviorally identical.
+ * @see https://github.com/microsoft/fluentui/issues/36298
+ */
+async function verifyTaggedTemplatesAreMinified() {
+  const esmRoot = path.join(import.meta.dirname, '../dist/esm');
+  const plugin = fastTaggedTemplates();
+  const pluginContext = { parse: code => parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) };
+
+  const unminified = [];
+  for await (const file of glob('**/*.js', { cwd: esmRoot })) {
+    const code = await readFile(path.join(esmRoot, file), 'utf-8');
+    const result = await plugin.transform.call(pluginContext, code, file);
+    if (result && result.code !== code) {
+      unminified.push(file);
+    }
+  }
+
+  assert.deepEqual(
+    unminified,
+    [],
+    'ships esm with minified tagged templates (dist/esm files listed above still contain template whitespace)',
+  );
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,7 +5760,7 @@ acorn-walk@^8.0.0, acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.12.1, acorn@^8.14.1, acorn@^8.15.0, acorn@^8.16.0, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.12.1, acorn@^8.14.1, acorn@^8.15.0, acorn@^8.16.0, acorn@^8.17.0, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
   integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==


### PR DESCRIPTION
## Previous Behavior

The ESM build (`dist/esm`, plain `tsc` output) ships `html`/`css` tagged templates with the literal newlines and indentation used in the source for readability. Those whitespace-only text nodes land in every component's shadow DOM, and when an app sets a CSS `white-space` value other than `normal` on an ancestor, they suddenly render — components like Label, Listbox and TextInput grow stray gaps and look broken.

The rollup bundles (`dist/web-components*.js`) never had this problem, because `rollup.config.js` runs `rollup-plugin-fast-tagged-templates`, which minifies the templates. So the two builds of the same package behaved differently.

## New Behavior

The compile step now runs that **exact same plugin transform** over the tsc output (new `scripts/minify-tagged-templates.js`, called from `scripts/compile.js`). Both builds now ship byte-identical template content — verified quasi-by-quasi across the affected components. Sourcemaps are re-mapped (`@jridgewell/remapping`) so `dist/esm` still traces back to the TypeScript sources.

To keep the bug from coming back, `scripts/verify-packaging.js` (already wired into CI with `dependsOn: build`) now asserts that re-running the transform over every shipped `dist/esm/**/*.js` file is a no-op. Before this fix that check failed with 85 files; now the whole tree is a fixed point.

Verified locally:
- All template strings in the ESM output are byte-identical to the rollup bundle versions.
- In-browser check: a `required` Label under `white-space: pre` has **zero** whitespace-only text nodes and identical dimensions to `white-space: normal`, while the pre-fix template shows 3 stray text nodes and +19px height.
- `label`/`text-input`/`listbox` Playwright specs pass in both CSR and SSR modes (170 tests), plus lint, type-check, and a clean uncached build.

Notes for reviewers:
- Single spaces adjacent to inline elements (e.g. between the two fallback `<svg>`s in Option's checked indicator) are deliberately preserved by html-minifier-terser — identical to what the bundles ship today.
- Source `*.template.ts` files are untouched; authoring stays readable. The dev harness (vite/storybook, served from `src`) is also unaffected.
- Known adjacent gap, intentionally out of scope: the generated SSR `*.template.html` files still contain prettier-formatted whitespace, so declarative-shadow-DOM output is still whitespace-sensitive. Happy to file a follow-up issue for that render path if wanted.
- @radium-v this reuses your `rollup-plugin-fast-tagged-templates` as-is for parity — and since the issue is assigned to you, apologies if this crosses work you already had in flight; glad to adjust or hand off.

## Related Issue(s)

- Fixes #36298
