### PR TITLE
fix(web-components): remove default MessageBar max-width

### DIFF
--- a/change/@fluentui-web-components-0ef14c7c-01fd-46bd-b192-f97bf0702842.json
+++ b/change/@fluentui-web-components-0ef14c7c-01fd-46bd-b192-f97bf0702842.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove the default 520px max-width on MessageBar content (matching React v9) and add the `--message-bar-content-max-width` CSS custom property to optionally re-introduce a cap",
+  "packageName": "@fluentui/web-components",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/message-bar/message-bar.spec.ts
+++ b/packages/web-components/src/message-bar/message-bar.spec.ts
@@ -95,4 +95,28 @@ test.describe('Message Bar', () => {
 
     await expect(didDismiss).resolves.toBe(true);
   });
+
+  test('should not cap the content width by default', async ({ fastPage }) => {
+    const { element } = fastPage;
+    const content = element.locator('.content');
+
+    await fastPage.setTemplate();
+
+    await expect(content).toHaveCSS('max-width', 'none');
+  });
+
+  test('should cap the content width when the `--message-bar-content-max-width` custom property is set', async ({
+    fastPage,
+  }) => {
+    const { element } = fastPage;
+    const content = element.locator('.content');
+
+    await fastPage.setTemplate();
+
+    await element.evaluate((node: MessageBar) => {
+      node.style.setProperty('--message-bar-content-max-width', '300px');
+    });
+
+    await expect(content).toHaveCSS('max-width', '300px');
+  });
 });

--- a/packages/web-components/src/message-bar/message-bar.styles.css
+++ b/packages/web-components/src/message-bar/message-bar.styles.css
@@ -6,6 +6,7 @@
   line-height: var(--lineHeightBase200);
   width: 100%;
   background: var(--colorNeutralBackground3);
+  color: var(--colorNeutralForeground3);
   border: 1px solid var(--colorNeutralStroke1);
   padding-inline: var(--spacingHorizontalM);
   border-radius: var(--borderRadiusMedium);
@@ -46,7 +47,7 @@
 
 .content {
   grid-area: body;
-  max-width: 520px;
+  max-width: var(--message-bar-content-max-width, none);
   padding-block: var(--spacingVerticalMNudge);
   padding-inline: 0;
 }

--- a/packages/web-components/src/message-bar/message-bar.styles.ts
+++ b/packages/web-components/src/message-bar/message-bar.styles.ts
@@ -75,7 +75,7 @@ export const styles: ElementStyles = css`
 
   .content {
     grid-area: body;
-    max-width: 520px;
+    max-width: var(--message-bar-content-max-width, none);
     padding-block: ${spacingVerticalMNudge};
     padding-inline: 0;
   }

--- a/packages/web-components/src/message-bar/message-bar.ts
+++ b/packages/web-components/src/message-bar/message-bar.ts
@@ -11,6 +11,7 @@ import { MessageBarIntent, MessageBarLayout, MessageBarShape } from './message-b
  * @slot icon - Content that can be provided for the leading icon
  * @slot - The default slot for the content
  * @fires { CustomEvent } dismiss - Fired when the message bar is dismissed.
+ * @cssproperty --message-bar-content-max-width - Sets a max-width on the message content. Defaults to `none` (no cap); set a length to constrain it (e.g., 520px).
  * @public
  */
 export class MessageBar extends FASTElement {


### PR DESCRIPTION
## Previous Behavior

`<fluent-message-bar>` capped its content at a hardcoded `max-width: 520px`. Per current Fabric design guidance that cap is no longer desired, and it doesn't match Fluent UI React v9 (whose `MessageBarBody` has no `max-width`).

## New Behavior

The MessageBar content is no longer capped by default — it fills its container, matching React v9. Consumers who still want a cap can opt in with a new CSS custom property:

```css
fluent-message-bar {
  --message-bar-content-max-width: 520px; /* or any length */
}
```

### Why a custom property (rather than removing the cap outright)

The issue offered three options — remove entirely, a CSS custom property, or a CSS part. I went with the **custom property** because it delivers the requested default (no cap) while leaving a supported, on-convention escape hatch for anyone who relied on the 520px cap — no shadow-DOM piercing required. It mirrors the existing `--drawer-width` / `--menu-max-height` idiom and keeps the new public surface minimal (a single documented property), which felt appropriate for an issue still marked **Needs: Discussion**.

Happy to switch to a plain removal, or additionally expose `part="content"`, if the team prefers — @chrisdholt.

## What changed

- `message-bar.styles.ts` — `max-width: 520px` → `max-width: var(--message-bar-content-max-width, none)`
- `message-bar.styles.css` — regenerated via `yarn generate:ssr` (the committed SSR mirror)
- `message-bar.ts` — documented the new property with `@cssproperty`
- `message-bar.spec.ts` — two tests: no cap by default, and it caps when the property is set (both run across CSR **and** SSR)
- beachball change file (`minor` — introduces a new public CSS custom property)

## How to verify

```bash
cd packages/web-components
yarn e2e src/message-bar/message-bar.spec.ts
```

48 pass (8 tests × chromium/firefox/webkit × CSR/SSR). Visually, in Storybook, a long single-line message no longer clamps at 520px; setting `--message-bar-content-max-width` re-introduces the cap.

## Notes for the reviewer

- Regenerating the SSR stylesheet also re-synced a small **pre-existing drift**: the committed `message-bar.styles.css` was missing `color: var(--colorNeutralForeground3)` on `:host` that the source (`.styles.ts`) already declares — so SSR text color differed from CSR. I kept the corrected output so `check:ssr` stays green for this component. This is the only incidental line beyond the `max-width` change.
- `apps/vr-tests-web-components` has no MessageBar story, so this visual change has no VRT snapshot guard today — flagging as a possible follow-up.

## Related Issue(s)

- Fixes #36365
