### PR TITLE
feat(react-motion-components-preview): migrate Blur to directed parameters

### DIFF
--- a/change/@fluentui-react-motion-components-preview-8d6b55d7-ef0b-45b6-a8e3-45b53e8bdd54.json
+++ b/change/@fluentui-react-motion-components-preview-8d6b55d7-ef0b-45b6-a8e3-45b53e8bdd54.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Migrate Blur from outRadius/inRadius to graph-level fromRadius/restRadius/toRadius parameters, and make blurAtom a neutral directed fromRadius/toRadius atom",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "githubcopilot@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-menu/stories/src/Menu/MenuMotionCustom.stories.tsx
+++ b/packages/react-components/react-menu/stories/src/Menu/MenuMotionCustom.stories.tsx
@@ -16,7 +16,7 @@ const FadeInBlurOut = createPresenceComponent({
   enter: fadeAtom({ direction: 'enter', duration: 500 }),
   exit: [
     fadeAtom({ direction: 'exit', duration: 500 }),
-    blurAtom({ direction: 'exit', duration: 500, easing: motionTokens.curveEasyEase }),
+    blurAtom({ duration: 500, easing: motionTokens.curveEasyEase, fromRadius: '0px', toRadius: '10px' }),
   ],
 });
 

--- a/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
+++ b/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
@@ -14,12 +14,13 @@ import * as React_2 from 'react';
 export const Blur: PresenceComponent<BlurParams>;
 
 // @public
-export const blurAtom: ({ direction, duration, easing, delay, outRadius, inRadius, }: BlurAtomParams) => AtomMotion;
+export const blurAtom: ({ duration, easing, delay, fromRadius, toRadius, }: BlurAtomParams) => AtomMotion;
 
 // @public (undocumented)
 export type BlurParams = BasePresenceParams & AnimateOpacity & {
-    outRadius?: string;
-    inRadius?: string;
+    fromRadius?: string;
+    restRadius?: string;
+    toRadius?: string;
 };
 
 // @public

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.test.ts
@@ -2,50 +2,23 @@ import { motionTokens } from '@fluentui/react-motion';
 import { blurAtom } from './blur-atom';
 
 describe('blurAtom', () => {
-  it('creates enter keyframes with blur from radius to 0', () => {
+  it('creates directed keyframes from one radius to another', () => {
     const atom = blurAtom({
-      direction: 'enter',
       duration: 300,
       easing: motionTokens.curveEasyEase,
-      outRadius: '20px',
+      fromRadius: '20px',
+      toRadius: '5px',
     });
 
     expect(atom).toMatchObject({
       duration: 300,
       easing: motionTokens.curveEasyEase,
-      keyframes: [{ filter: 'blur(20px)' }, { filter: 'blur(0px)' }],
+      keyframes: [{ filter: 'blur(20px)' }, { filter: 'blur(5px)' }],
     });
   });
 
-  it('creates exit keyframes with blur from 0 to radius', () => {
+  it('uses default radius endpoints when not provided', () => {
     const atom = blurAtom({
-      direction: 'exit',
-      duration: 250,
-      easing: motionTokens.curveAccelerateMin,
-      outRadius: '15px',
-    });
-
-    expect(atom).toMatchObject({
-      duration: 250,
-      easing: motionTokens.curveAccelerateMin,
-      keyframes: [{ filter: 'blur(0px)' }, { filter: 'blur(15px)' }],
-    });
-  });
-
-  it('applies custom inRadius values', () => {
-    const atom = blurAtom({
-      direction: 'enter',
-      duration: 300,
-      outRadius: '20px',
-      inRadius: '5px',
-    });
-
-    expect(atom.keyframes).toEqual([{ filter: 'blur(20px)' }, { filter: 'blur(5px)' }]);
-  });
-
-  it('uses default outRadius when not provided', () => {
-    const atom = blurAtom({
-      direction: 'enter',
       duration: 300,
     });
 
@@ -54,27 +27,24 @@ describe('blurAtom', () => {
 
   it('uses default easing when not provided', () => {
     const atom = blurAtom({
-      direction: 'enter',
       duration: 300,
-      outRadius: '5px',
+      fromRadius: '5px',
     });
 
     expect(atom.easing).toBe(motionTokens.curveLinear);
   });
 
-  it('handles different CSS units for outRadius and inRadius', () => {
+  it('handles different CSS units for graph endpoints', () => {
     const atomPx = blurAtom({
-      direction: 'enter',
       duration: 300,
-      outRadius: '8px',
-      inRadius: '2px',
+      fromRadius: '8px',
+      toRadius: '2px',
     });
 
     const atomRem = blurAtom({
-      direction: 'enter',
       duration: 300,
-      outRadius: '1rem',
-      inRadius: '0.5rem',
+      fromRadius: '1rem',
+      toRadius: '0.5rem',
     });
 
     expect(atomPx.keyframes[0]).toEqual({ filter: 'blur(8px)' });

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/blur-atom.ts
@@ -2,39 +2,31 @@ import type { AtomMotion } from '@fluentui/react-motion';
 import { motionTokens } from '@fluentui/react-motion';
 import type { BaseAtomParams } from '../types';
 
-interface BlurAtomParams extends BaseAtomParams {
-  /** Blur radius for the out state (exited). Defaults to '10px'. */
-  outRadius?: string;
-  /** Blur radius for the in state (entered). Defaults to '0px'. */
-  inRadius?: string;
+interface BlurAtomParams extends Omit<BaseAtomParams, 'direction'> {
+  /** Blur radius at the start of the motion. Defaults to '10px'. */
+  fromRadius?: string;
+  /** Blur radius at the end of the motion. Defaults to '0px'. */
+  toRadius?: string;
 }
 
 /**
- * Generates a motion atom object for a blur-in or blur-out.
- * @param direction - The functional direction of the motion: 'enter' or 'exit'.
+ * Generates a directed blur motion atom.
  * @param duration - The duration of the motion in milliseconds.
  * @param easing - The easing curve for the motion. Defaults to `motionTokens.curveLinear`.
- * @param outRadius - Blur radius for the out state (exited) with units (e.g., '20px', '1rem'). Defaults to '10px'.
- * @param inRadius - Blur radius for the in state (entered) with units (e.g., '0px', '5px'). Defaults to '0px'.
+ * @param fromRadius - Initial blur radius with units (e.g., '20px', '1rem'). Defaults to '10px'.
+ * @param toRadius - Final blur radius with units. Defaults to '0px'.
  * @param delay - Time (ms) to delay the animation. Defaults to 0.
  * @returns A motion atom object with filter blur keyframes and the supplied duration and easing.
  */
 export const blurAtom = ({
-  direction,
   duration,
   easing = motionTokens.curveLinear,
   delay = 0,
-  outRadius = '10px',
-  inRadius = '0px',
-}: BlurAtomParams): AtomMotion => {
-  const keyframes = [{ filter: `blur(${outRadius})` }, { filter: `blur(${inRadius})` }];
-  if (direction === 'exit') {
-    keyframes.reverse();
-  }
-  return {
-    keyframes,
-    duration,
-    easing,
-    delay,
-  };
-};
+  fromRadius = '10px',
+  toRadius = '0px',
+}: BlurAtomParams): AtomMotion => ({
+  keyframes: [{ filter: `blur(${fromRadius})` }, { filter: `blur(${toRadius})` }],
+  duration,
+  easing,
+  delay,
+});

--- a/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.test.ts
@@ -1,5 +1,32 @@
+import type { AtomMotion } from '@fluentui/react-motion';
+import { motionTokens } from '@fluentui/react-motion';
 import { expectPresenceMotionFunction, expectPresenceMotionArray } from '../../testing/testUtils';
+import type { BlurParams } from './blur-types';
 import { Blur } from './Blur';
+
+function getMotionFunction(component: object, symbolName: string): Function {
+  const symbol = Object.getOwnPropertySymbols(component).find(
+    candidate => candidate.toString() === `Symbol(${symbolName})`,
+  );
+
+  expect(symbol).toBeDefined();
+  return (component as Record<symbol, Function>)[symbol!];
+}
+
+const element = document.createElement('div');
+
+type BlurMotion = { enter: AtomMotion[]; exit: AtomMotion[] };
+type BlurMotionParams = BlurParams & { element: HTMLElement };
+
+const getBlurPresenceFn = (): ((params: BlurMotionParams) => BlurMotion) => {
+  const presenceFn = getMotionFunction(Blur, 'PRESENCE_MOTION_DEFINITION');
+  return params => presenceFn(params) as BlurMotion;
+};
+
+const getBlurMotionFn = (component: object): ((params: BlurMotionParams) => AtomMotion[]) => {
+  const motionFn = getMotionFunction(component, 'MOTION_DEFINITION');
+  return params => motionFn(params) as AtomMotion[];
+};
 
 describe('Blur', () => {
   it('stores its motion definition as a static function', () => {
@@ -8,5 +35,73 @@ describe('Blur', () => {
 
   it('generates a motion definition from the static function', () => {
     expectPresenceMotionArray(Blur);
+  });
+
+  it('projects from to rest on enter and rest to to on exit', () => {
+    const presenceFn = getBlurPresenceFn();
+    const motion = presenceFn({
+      element,
+      fromRadius: '12px',
+      restRadius: '2px',
+      toRadius: '20px',
+      animateOpacity: false,
+    });
+
+    expect(motion.enter[0].keyframes).toEqual([{ filter: 'blur(12px)' }, { filter: 'blur(2px)' }]);
+    expect(motion.exit[0].keyframes).toEqual([{ filter: 'blur(2px)' }, { filter: 'blur(20px)' }]);
+  });
+
+  it('defaults the exit destination to the entry origin', () => {
+    const presenceFn = getBlurPresenceFn();
+    const motion = presenceFn({ element, fromRadius: '7px', restRadius: '1px', animateOpacity: false });
+
+    expect(motion.exit[0].keyframes).toEqual([{ filter: 'blur(1px)' }, { filter: 'blur(7px)' }]);
+  });
+
+  it('keeps factory-generated In and Out projections on the same parameter record', () => {
+    const inFn = getBlurMotionFn(Blur.In);
+    const outFn = getBlurMotionFn(Blur.Out);
+    const params = { element, fromRadius: '9px', restRadius: '3px', toRadius: '15px', animateOpacity: false };
+
+    expect(inFn(params)[0].keyframes).toEqual([{ filter: 'blur(9px)' }, { filter: 'blur(3px)' }]);
+    expect(outFn(params)[0].keyframes).toEqual([{ filter: 'blur(3px)' }, { filter: 'blur(15px)' }]);
+  });
+
+  it('preserves timing defaults and explicit exit timing', () => {
+    const presenceFn = getBlurPresenceFn();
+    const defaults = presenceFn({ element, duration: 450, delay: 30, animateOpacity: false });
+    const explicit = presenceFn({
+      element,
+      duration: 450,
+      delay: 30,
+      exitDuration: 175,
+      exitDelay: 15,
+      exitEasing: motionTokens.curveEasyEase,
+      animateOpacity: false,
+    });
+
+    expect(defaults.exit[0]).toMatchObject({
+      duration: 450,
+      delay: 30,
+      easing: motionTokens.curveAccelerateMin,
+    });
+    expect(explicit.exit[0]).toMatchObject({
+      duration: 175,
+      delay: 15,
+      easing: motionTokens.curveEasyEase,
+    });
+  });
+
+  it('preserves optional opacity composition for both edges', () => {
+    const presenceFn = getBlurPresenceFn();
+    const withOpacity = presenceFn({ element });
+    const withoutOpacity = presenceFn({ element, animateOpacity: false });
+
+    expect(withOpacity.enter).toHaveLength(2);
+    expect(withOpacity.exit).toHaveLength(2);
+    expect(withOpacity.enter[1].keyframes).toEqual([{ opacity: 0 }, { opacity: 1 }]);
+    expect(withOpacity.exit[1].keyframes).toEqual([{ opacity: 1 }, { opacity: 0 }]);
+    expect(withoutOpacity.enter).toHaveLength(1);
+    expect(withoutOpacity.exit).toHaveLength(1);
   });
 });

--- a/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Blur/Blur.ts
@@ -13,8 +13,9 @@ import type { BlurParams } from './blur-types';
  * @param exitDuration - Time (ms) for the exit transition (blur-out). Defaults to the `duration` param for symmetry.
  * @param exitEasing - Easing curve for the exit transition (blur-out). Defaults to the `curveAccelerateMin` value.
  * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
- * @param outRadius - Blur radius for the out state (exited). Defaults to `'10px'`.
- * @param inRadius - Blur radius for the in state (entered). Defaults to `'0px'`.
+ * @param fromRadius - Blur radius before entry. Defaults to `'10px'`.
+ * @param restRadius - Blur radius while visible. Defaults to `'0px'`.
+ * @param toRadius - Blur radius after exit. Defaults to `fromRadius`.
  * @param animateOpacity - Whether to animate the opacity. Defaults to `true`.
  */
 const blurPresenceFn: PresenceMotionFn<BlurParams> = ({
@@ -24,19 +25,19 @@ const blurPresenceFn: PresenceMotionFn<BlurParams> = ({
   exitDuration = duration,
   exitEasing = motionTokens.curveAccelerateMin,
   exitDelay = delay,
-  outRadius = '10px',
-  inRadius = '0px',
+  fromRadius = '10px',
+  restRadius = '0px',
+  toRadius = fromRadius,
   animateOpacity = true,
 }) => {
-  const enterAtoms = [blurAtom({ direction: 'enter', duration, easing, delay, outRadius, inRadius })];
+  const enterAtoms = [blurAtom({ duration, easing, delay, fromRadius, toRadius: restRadius })];
   const exitAtoms = [
     blurAtom({
-      direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
       delay: exitDelay,
-      outRadius,
-      inRadius,
+      fromRadius: restRadius,
+      toRadius,
     }),
   ];
 

--- a/packages/react-components/react-motion-components-preview/library/src/components/Blur/blur-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Blur/blur-types.ts
@@ -2,9 +2,12 @@ import type { BasePresenceParams, AnimateOpacity } from '../../types';
 
 export type BlurParams = BasePresenceParams &
   AnimateOpacity & {
-    /** Blur radius for the out state (exited). Defaults to '10px'. */
-    outRadius?: string;
+    /** Blur radius before entry. Used by Blur and Blur.In. Defaults to '10px'. */
+    fromRadius?: string;
 
-    /** Blur radius for the in state (entered). Defaults to '0px'. */
-    inRadius?: string;
+    /** Blur radius while visible. Used by Blur, Blur.In, and Blur.Out. Defaults to '0px'. */
+    restRadius?: string;
+
+    /** Blur radius after exit. Used by Blur and Blur.Out. Defaults to `fromRadius`. */
+    toRadius?: string;
   };

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
@@ -25,7 +25,7 @@ const createAtomMotion = (type: AtomType) => {
         rotateAtom({ direction: 'enter', duration: demoDuration, easing, axis: 'z', outAngle: -90 }),
       );
     case 'blur':
-      return createMotionComponent(blurAtom({ direction: 'enter', duration: demoDuration, easing, outRadius: '10px' }));
+      return createMotionComponent(blurAtom({ duration: demoDuration, easing, fromRadius: '10px', toRadius: '0px' }));
     default: {
       const _exhaustive: never = type;
       throw new Error(`Unhandled atom type: ${_exhaustive}`);
@@ -68,10 +68,9 @@ const atomCodeSnippets: Record<AtomType, string> = {
   inAngle: 0,
 })`,
   blur: `blurAtom({
-  direction: 'enter',
   duration: 600,
-  outRadius: '10px',
-  inRadius: '0px',
+  fromRadius: '10px',
+  toRadius: '0px',
 })`,
 };
 

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
@@ -16,7 +16,7 @@ const easing = motionTokens.curveDecelerateMid;
 const SpinBlur = createPresenceComponent({
   enter: [
     rotateAtom({ direction: 'enter', duration, easing, axis: 'z', outAngle: -20, inAngle: 0 }),
-    blurAtom({ direction: 'enter', duration, easing, outRadius: '8px', inRadius: '0px' }),
+    blurAtom({ duration, easing, fromRadius: '8px', toRadius: '0px' }),
     scaleAtom({ direction: 'enter', duration, easing, outScale: 2 }),
   ],
   exit: [
@@ -29,11 +29,10 @@ const SpinBlur = createPresenceComponent({
       inAngle: 0,
     }),
     blurAtom({
-      direction: 'exit',
       duration: exitDuration,
       easing: motionTokens.curveLinear,
-      outRadius: '8px',
-      inRadius: '0px',
+      fromRadius: '0px',
+      toRadius: '8px',
     }),
     scaleAtom({ direction: 'exit', duration: exitDuration, easing: motionTokens.curveLinear, outScale: 0 }),
   ],
@@ -42,12 +41,12 @@ const SpinBlur = createPresenceComponent({
 const codeSnippet = `const SpinBlur = createPresenceComponent({
   enter: [
     rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
-    blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
+    blurAtom({ duration: 800, fromRadius: '8px', toRadius: '0px' }),
     scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
   ],
   exit: [
     rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
-    blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
+    blurAtom({ duration: 600, fromRadius: '0px', toRadius: '8px' }),
     scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
   ],
 });
@@ -84,12 +83,12 @@ const useClasses = makeStyles({
 const SpinBlur = createPresenceComponent({
   enter: [
     rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
-    blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
+    blurAtom({ duration: 800, fromRadius: '8px', toRadius: '0px' }),
     scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
   ],
   exit: [
     rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
-    blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
+    blurAtom({ duration: 600, fromRadius: '0px', toRadius: '8px' }),
     scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
   ],
 });

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
@@ -104,7 +104,7 @@ const fadeIn = fadeAtom({
 | `scaleAtom`  | Size scaling         | `transform: scale()`     | `outScale`, `inScale`         |
 | `slideAtom`  | Position translation | `transform: translate()` | `outX`, `outY`, `inX`, `inY`  |
 | `rotateAtom` | 3D rotation          | `transform: rotate3d()`  | `axis`, `outAngle`, `inAngle` |
-| `blurAtom`   | Blur filter          | `filter: blur()`         | `outRadius`, `inRadius`       |
+| `blurAtom`   | Blur filter          | `filter: blur()`         | `fromRadius`, `toRadius`      |
 
 <AtomsDemo />
 
@@ -141,7 +141,7 @@ slideAtom({ direction: 'enter', duration: 500, outX: '0px', outY: '20px', inX: '
 rotateAtom({ direction: 'enter', duration: 600, axis: 'z', outAngle: -90, inAngle: 0 });
 
 // blurAtom — blur filter
-blurAtom({ direction: 'enter', duration: 500, outRadius: '10px', inRadius: '0px' });
+blurAtom({ duration: 500, fromRadius: '10px', toRadius: '0px' });
 ```
 
 ## Creating Custom Presence Components

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDemo.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurDemo.stories.tsx
@@ -103,12 +103,12 @@ export const LayeredBlurDemo = (): JSXElement => {
           {images.map((image, index) => (
             <div key={image.id} className={classes.imageCard} onClick={() => toggleImage(index)}>
               {/* Background with blur effect - starts blurred, becomes clear when revealed */}
-              <Blur visible={revealedImages[index]} outRadius="5px" animateOpacity={false}>
+              <Blur visible={revealedImages[index]} fromRadius="5px" animateOpacity={false}>
                 <div className={classes.imageBackground} style={{ backgroundImage: image.gradient }} />
               </Blur>
 
               {/* "Click to reveal" button - starts clear, blurs/fades out when clicked */}
-              <Blur visible={!revealedImages[index]} outRadius="10px" animateOpacity={true}>
+              <Blur visible={!revealedImages[index]} fromRadius="10px" animateOpacity={true}>
                 <div className={classes.overlay}>
                   <div className={classes.overlayButton}>Click to reveal</div>
                 </div>

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.md
@@ -1,6 +1,7 @@
-The `Blur` component accepts two radius props:
+The `Blur` component accepts three graph-level radius props:
 
-- **`outRadius`** — blur amount when the element is hidden
-- **`inRadius`** — blur amount when the element is visible (defaults to `0px`)
+- **`fromRadius`** — blur amount before the element enters (defaults to `10px`)
+- **`restRadius`** — blur amount while the element is visible (defaults to `0px`)
+- **`toRadius`** — blur amount after the element exits (defaults to `fromRadius`)
 
-Each card shows a different combination. The active radius value is **bolded** in the header. `animateOpacity` is disabled to isolate the blur effect.
+Each card shows a different transition graph, including asymmetric exits. `animateOpacity` is disabled to isolate the blur effect.

--- a/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Blur/BlurRadius.stories.tsx
@@ -45,12 +45,10 @@ const useClasses = makeStyles({
 });
 
 const blurRadiusCombinations = [
-  // Top row: outRadius 5px, inRadius 0px (default)
-  { outRadius: '5px', inRadius: '0px' },
-  { outRadius: '10px', inRadius: '0px' },
-  // Bottom row: outRadius 20px, with inRadius values
-  { outRadius: '10px', inRadius: '1px' },
-  { outRadius: '10px', inRadius: '2px' },
+  { fromRadius: '5px', restRadius: '0px', toRadius: '5px' },
+  { fromRadius: '10px', restRadius: '0px', toRadius: '10px' },
+  { fromRadius: '10px', restRadius: '1px', toRadius: '20px' },
+  { fromRadius: '10px', restRadius: '2px', toRadius: '5px' },
 ];
 
 export const Radius = (): JSXElement => {
@@ -75,22 +73,24 @@ export const Radius = (): JSXElement => {
               <Table size="small" noNativeElements aria-label="Blur radius values">
                 <TableHeader>
                   <TableRow>
-                    <TableHeaderCell>outRadius</TableHeaderCell>
-                    <TableHeaderCell>inRadius</TableHeaderCell>
+                    <TableHeaderCell>fromRadius</TableHeaderCell>
+                    <TableHeaderCell>restRadius</TableHeaderCell>
+                    <TableHeaderCell>toRadius</TableHeaderCell>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   <TableRow>
-                    <TableCell className={isVisible ? classes.cellNormal : classes.cellBold}>
-                      {option.outRadius}
-                    </TableCell>
+                    <TableCell>{option.fromRadius}</TableCell>
                     <TableCell className={isVisible ? classes.cellBold : classes.cellNormal}>
-                      {option.inRadius}
+                      {option.restRadius}
+                    </TableCell>
+                    <TableCell className={isVisible ? classes.cellNormal : classes.cellBold}>
+                      {option.toRadius}
                     </TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
-              <Blur visible={isVisible} outRadius={option.outRadius} inRadius={option.inRadius} animateOpacity={false}>
+              <Blur visible={isVisible} {...option} animateOpacity={false}>
                 <div>Lorem ipsum dolor sit amet</div>
               </Blur>
               <CardFooter>

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
@@ -263,15 +263,15 @@ function List({ items, visible }) {
 
 ### Component Reference
 
-| Component  | Variants                                               | Key Parameters                                      |
-| ---------- | ------------------------------------------------------ | --------------------------------------------------- |
-| `Fade`     | `FadeSnappy`, `FadeRelaxed`                            | `outOpacity`, `inOpacity`, `duration`, `easing`     |
-| `Scale`    | `ScaleSnappy`, `ScaleRelaxed`                          | `outScale`, `inScale`, `duration`, `easing`         |
-| `Collapse` | `CollapseSnappy`, `CollapseRelaxed`, `CollapseDelayed` | `orientation`, `outSize`, `duration`, `easing`      |
-| `Slide`    | `SlideSnappy`, `SlideRelaxed`                          | `outX`, `outY`, `inX`, `inY`, `duration`, `easing`  |
-| `Blur`     | —                                                      | `outRadius`, `inRadius`, `duration`, `easing`       |
-| `Rotate`   | —                                                      | `axis`, `outAngle`, `inAngle`, `duration`, `easing` |
-| `Stagger`  | —                                                      | `itemDelay`, `itemDuration`, `reversed`, `hideMode` |
+| Component  | Variants                                               | Key Parameters                                               |
+| ---------- | ------------------------------------------------------ | ------------------------------------------------------------ |
+| `Fade`     | `FadeSnappy`, `FadeRelaxed`                            | `outOpacity`, `inOpacity`, `duration`, `easing`              |
+| `Scale`    | `ScaleSnappy`, `ScaleRelaxed`                          | `outScale`, `inScale`, `duration`, `easing`                  |
+| `Collapse` | `CollapseSnappy`, `CollapseRelaxed`, `CollapseDelayed` | `orientation`, `outSize`, `duration`, `easing`               |
+| `Slide`    | `SlideSnappy`, `SlideRelaxed`                          | `outX`, `outY`, `inX`, `inY`, `duration`, `easing`           |
+| `Blur`     | —                                                      | `fromRadius`, `restRadius`, `toRadius`, `duration`, `easing` |
+| `Rotate`   | —                                                      | `axis`, `outAngle`, `inAngle`, `duration`, `easing`          |
+| `Stagger`  | —                                                      | `itemDelay`, `itemDuration`, `reversed`, `hideMode`          |
 
 </div>
 

--- a/packages/react-components/react-popover/stories/src/Popover/PopoverMotionCustom.stories.tsx
+++ b/packages/react-components/react-popover/stories/src/Popover/PopoverMotionCustom.stories.tsx
@@ -5,7 +5,10 @@ import { fadeAtom, blurAtom } from '@fluentui/react-motion-components-preview';
 
 const FadeInBlurOut = createPresenceComponent({
   enter: fadeAtom({ duration: 500, direction: 'enter' }),
-  exit: [fadeAtom({ duration: 500, direction: 'exit' }), blurAtom({ duration: 500, direction: 'exit' })],
+  exit: [
+    fadeAtom({ duration: 500, direction: 'exit' }),
+    blurAtom({ duration: 500, fromRadius: '0px', toRadius: '10px' }),
+  ],
 });
 
 export const MotionCustom = (): JSXElement => (


### PR DESCRIPTION
## Summary

- migrate `Blur` from `outRadius`/`inRadius` to the graph-level `fromRadius`/`restRadius`/`toRadius` parameter record
- preserve the stable factory-generated `Blur.In` and `Blur.Out` projections
- make `blurAtom` a neutral directed `fromRadius` → `toRadius` atom
- update component and atom call sites, stories, tests, API report, and change file

## Validation

- `yarn nx test react-motion-components-preview --runInBand` — 171 tests passed
- `yarn nx run react-motion-components-preview:type-check --excludeTaskDependencies`
- `yarn nx run react-motion-components-preview:lint --excludeTaskDependencies`
- `yarn nx run react-motion-components-preview:generate-api --excludeTaskDependencies --skipNxCache`
- `git diff --check`