### PR TITLE
feat(react-motion-components-preview): migrate Rotate to directed parameters

### DIFF
--- a/change/@fluentui-react-motion-components-preview-rotate-presence.json
+++ b/change/@fluentui-react-motion-components-preview-rotate-presence.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Migrate Rotate from outAngle/inAngle to graph-level fromAngle/restAngle/toAngle parameters, and make rotateAtom a neutral directed fromAngle/toAngle atom",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-rotate-presence.json
+++ b/change/@fluentui-react-nav-rotate-presence.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: migrate NavCategoryItem to the graph-level Rotate angle parameters",
+  "packageName": "@fluentui/react-nav",
+  "email": "robertpenner@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
+++ b/packages/react-components/react-motion-components-preview/library/etc/react-motion-components-preview.api.md
@@ -72,13 +72,14 @@ export const FadeSnappy: PresenceComponent<FadeParams>;
 export const Rotate: PresenceComponent<RotateParams>;
 
 // @public
-export const rotateAtom: ({ direction, duration, easing, delay, axis, outAngle, inAngle, }: RotateAtomParams) => AtomMotion;
+export const rotateAtom: ({ duration, easing, delay, axis, fromAngle, toAngle, }: RotateAtomParams) => AtomMotion;
 
 // @public (undocumented)
 export type RotateParams = BasePresenceParams & AnimateOpacity & {
     axis?: Axis3D;
-    outAngle?: number;
-    inAngle?: number;
+    fromAngle?: number;
+    restAngle?: number;
+    toAngle?: number;
 };
 
 // @public

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.test.ts
@@ -2,152 +2,57 @@ import { motionTokens } from '@fluentui/react-motion';
 import { rotateAtom } from './rotate-atom';
 
 describe('rotateAtom', () => {
-  it('creates enter keyframes with rotation from angle to 0', () => {
+  it('creates directed keyframes from one angle to another', () => {
     const atom = rotateAtom({
-      direction: 'enter',
       duration: 300,
       easing: motionTokens.curveEasyEase,
-      outAngle: -90,
+      fromAngle: -90,
+      toAngle: 45,
     });
 
     expect(atom).toMatchObject({
       duration: 300,
       easing: motionTokens.curveEasyEase,
-      keyframes: [{ rotate: 'z -90deg' }, { rotate: 'z 0deg' }],
+      keyframes: [{ rotate: 'z -90deg' }, { rotate: 'z 45deg' }],
     });
   });
 
-  it('creates exit keyframes with rotation from 0 to inAngle', () => {
-    const atom = rotateAtom({
-      direction: 'exit',
-      duration: 250,
-      easing: motionTokens.curveAccelerateMin,
-      outAngle: -90,
-      inAngle: 90,
-    });
-
-    expect(atom).toMatchObject({
-      duration: 250,
-      easing: motionTokens.curveAccelerateMin,
-      keyframes: [{ rotate: 'z 90deg' }, { rotate: 'z -90deg' }],
-    });
-  });
-
-  it('uses default angle when not provided', () => {
-    const atom = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-    });
+  it('uses default angle endpoints when not provided', () => {
+    const atom = rotateAtom({ duration: 300 });
 
     expect(atom.keyframes).toEqual([{ rotate: 'z -90deg' }, { rotate: 'z 0deg' }]);
   });
 
   it('uses default easing when not provided', () => {
-    const atom = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: 45,
-    });
+    const atom = rotateAtom({ duration: 300, fromAngle: 45 });
 
     expect(atom.easing).toBe(motionTokens.curveLinear);
   });
 
-  it('uses default axis when not provided', () => {
-    const atom = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: 180,
-    });
-
-    expect(atom.keyframes[0]).toEqual({ rotate: 'z 180deg' });
-    expect(atom.keyframes[1]).toEqual({ rotate: 'z 0deg' });
-  });
-
-  it('applies custom outAngle and inAngle values', () => {
-    const atom = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: 180,
-      inAngle: 45,
-    });
-
-    expect(atom.keyframes).toEqual([{ rotate: 'z 180deg' }, { rotate: 'z 45deg' }]);
-  });
-
   it('handles different rotation axes', () => {
-    const atomX = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      axis: 'x',
-      outAngle: 45,
-    });
+    const atomX = rotateAtom({ duration: 300, axis: 'x', fromAngle: 45, toAngle: 0 });
+    const atomY = rotateAtom({ duration: 300, axis: 'y', fromAngle: 45, toAngle: 0 });
+    const atomZ = rotateAtom({ duration: 300, axis: 'z', fromAngle: 45, toAngle: 0 });
 
-    const atomY = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      axis: 'y',
-      outAngle: 45,
-    });
-
-    const atomZ = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      axis: 'z',
-      outAngle: 45,
-    });
-
-    expect(atomX.keyframes[0]).toEqual({ rotate: 'x 45deg' });
-    expect(atomY.keyframes[0]).toEqual({ rotate: 'y 45deg' });
-    expect(atomZ.keyframes[0]).toEqual({ rotate: 'z 45deg' });
-  });
-
-  it('uses inAngle when direction is exit', () => {
-    const atom = rotateAtom({
-      direction: 'exit',
-      duration: 300,
-      outAngle: -90,
-      inAngle: 45,
-    });
-
-    expect(atom.keyframes).toEqual([{ rotate: 'z 45deg' }, { rotate: 'z -90deg' }]);
-  });
-
-  it('uses default inAngle when not provided', () => {
-    const atom = rotateAtom({
-      direction: 'exit',
-      duration: 300,
-      outAngle: -90,
-    });
-
-    expect(atom.keyframes).toEqual([{ rotate: 'z 0deg' }, { rotate: 'z -90deg' }]);
+    expect(atomX.keyframes).toEqual([{ rotate: 'x 45deg' }, { rotate: 'x 0deg' }]);
+    expect(atomY.keyframes).toEqual([{ rotate: 'y 45deg' }, { rotate: 'y 0deg' }]);
+    expect(atomZ.keyframes).toEqual([{ rotate: 'z 45deg' }, { rotate: 'z 0deg' }]);
   });
 
   it('handles positive and negative angle values', () => {
-    const atomPositive = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: 90,
-    });
+    const atom = rotateAtom({ duration: 300, fromAngle: 90, toAngle: -45 });
 
-    const atomNegative = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: -45,
-    });
-
-    expect(atomPositive.keyframes[0]).toEqual({ rotate: 'z 90deg' });
-    expect(atomNegative.keyframes[0]).toEqual({ rotate: 'z -45deg' });
+    expect(atom.keyframes).toEqual([{ rotate: 'z 90deg' }, { rotate: 'z -45deg' }]);
   });
 
-  it('includes all expected properties in the returned atom', () => {
+  it('includes timing properties in the returned atom', () => {
     const atom = rotateAtom({
-      direction: 'enter',
       duration: 400,
       delay: 50,
       easing: 'ease-in-out',
       axis: 'x',
-      outAngle: 180,
-      inAngle: 45,
+      fromAngle: 180,
+      toAngle: 45,
     });
 
     expect(atom).toMatchObject({
@@ -156,24 +61,5 @@ describe('rotateAtom', () => {
       easing: 'ease-in-out',
       delay: 50,
     });
-  });
-
-  it('creates proper keyframes for enter and exit directions', () => {
-    const enterAtom = rotateAtom({
-      direction: 'enter',
-      duration: 300,
-      outAngle: -90,
-      inAngle: 0,
-    });
-
-    const exitAtom = rotateAtom({
-      direction: 'exit',
-      duration: 300,
-      outAngle: -90,
-      inAngle: 0,
-    });
-
-    expect(enterAtom.keyframes).toEqual([{ rotate: 'z -90deg' }, { rotate: 'z 0deg' }]);
-    expect(exitAtom.keyframes).toEqual([{ rotate: 'z 0deg' }, { rotate: 'z -90deg' }]);
   });
 });

--- a/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/atoms/rotate-atom.ts
@@ -5,12 +5,12 @@ import type { BaseAtomParams } from '../types';
 
 type Axis3D = NonNullable<RotateParams['axis']>;
 
-interface RotateAtomParams extends BaseAtomParams {
+interface RotateAtomParams extends Omit<BaseAtomParams, 'direction'> {
   axis?: Axis3D;
-  /** Rotation angle for the out state (exited) in degrees. Defaults to -90. */
-  outAngle?: number;
-  /** Rotation angle for the in state (entered) in degrees. Defaults to 0. */
-  inAngle?: number;
+  /** Rotation angle at the start of the directed motion in degrees. Defaults to -90. */
+  fromAngle?: number;
+  /** Rotation angle at the end of the directed motion in degrees. Defaults to 0. */
+  toAngle?: number;
 }
 
 const createRotateValue = (axis: Axis3D, angle: number): string => {
@@ -19,33 +19,24 @@ const createRotateValue = (axis: Axis3D, angle: number): string => {
 
 /**
  * Generates a motion atom object for a rotation around a single axis.
- * @param direction - The functional direction of the motion: 'enter' or 'exit'.
  * @param duration - The duration of the motion in milliseconds.
  * @param easing - The easing curve for the motion. Defaults to `motionTokens.curveLinear`.
  * @param axis - The axis of rotation: 'x', 'y', or 'z'. Defaults to 'y'.
- * @param outAngle - Rotation angle for the out state (exited) in degrees. Defaults to -90.
- * @param inAngle - Rotation angle for the in state (entered) in degrees. Defaults to 0.
+ * @param fromAngle - Rotation angle at the start of the directed motion in degrees. Defaults to -90.
+ * @param toAngle - Rotation angle at the end of the directed motion in degrees. Defaults to 0.
  * @param delay - Time (ms) to delay the animation. Defaults to 0.
  * @returns A motion atom object with rotate keyframes and the supplied duration and easing.
  */
 export const rotateAtom = ({
-  direction,
   duration,
   easing = motionTokens.curveLinear,
   delay = 0,
   axis = 'z',
-  outAngle = -90,
-  inAngle = 0,
-}: RotateAtomParams): AtomMotion => {
-  const keyframes = [{ rotate: createRotateValue(axis, outAngle) }, { rotate: createRotateValue(axis, inAngle) }];
-  if (direction === 'exit') {
-    keyframes.reverse();
-  }
-
-  return {
-    keyframes,
-    duration,
-    easing,
-    delay,
-  };
-};
+  fromAngle = -90,
+  toAngle = 0,
+}: RotateAtomParams): AtomMotion => ({
+  keyframes: [{ rotate: createRotateValue(axis, fromAngle) }, { rotate: createRotateValue(axis, toAngle) }],
+  duration,
+  easing,
+  delay,
+});

--- a/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.test.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.test.ts
@@ -1,5 +1,31 @@
+import type { AtomMotion, AtomMotionFn, PresenceMotion, PresenceMotionFn } from '@fluentui/react-motion';
+import { motionTokens } from '@fluentui/react-motion';
 import { expectPresenceMotionFunction, expectPresenceMotionArray } from '../../testing/testUtils';
+import type { RotateParams } from './rotate-types';
 import { Rotate } from './Rotate';
+
+const element = document.createElement('div');
+
+function getDefinition<T>(component: object, description: string): T {
+  const symbol = Object.getOwnPropertySymbols(component).find(candidate => candidate.description === description);
+
+  if (!symbol) {
+    throw new Error(`Expected ${description} on component`);
+  }
+
+  return (component as Record<symbol, T>)[symbol];
+}
+
+function getPresence(params: RotateParams = {}): PresenceMotion {
+  const definition = getDefinition<PresenceMotionFn<RotateParams>>(Rotate, 'PRESENCE_MOTION_DEFINITION');
+  return definition({ element, ...params });
+}
+
+function getProjection(component: object, params: RotateParams = {}): AtomMotion[] {
+  const definition = getDefinition<AtomMotionFn<RotateParams>>(component, 'MOTION_DEFINITION');
+  const motion = definition({ element, ...params });
+  return Array.isArray(motion) ? motion : [motion];
+}
 
 describe('Rotate', () => {
   it('stores its motion definition as a static function', () => {
@@ -8,5 +34,69 @@ describe('Rotate', () => {
 
   it('generates a motion definition from the static function', () => {
     expectPresenceMotionArray(Rotate);
+  });
+
+  it('projects from to rest on enter and rest to to on exit', () => {
+    const presence = getPresence({ fromAngle: -45, restAngle: 15, toAngle: 120, animateOpacity: false });
+
+    expect((presence.enter as AtomMotion[])[0].keyframes).toEqual([{ rotate: 'z -45deg' }, { rotate: 'z 15deg' }]);
+    expect((presence.exit as AtomMotion[])[0].keyframes).toEqual([{ rotate: 'z 15deg' }, { rotate: 'z 120deg' }]);
+  });
+
+  it('defaults the exit destination to the entry origin', () => {
+    const presence = getPresence({ fromAngle: 35, restAngle: 5, animateOpacity: false });
+
+    expect((presence.exit as AtomMotion[])[0].keyframes).toEqual([{ rotate: 'z 5deg' }, { rotate: 'z 35deg' }]);
+    expect(getProjection(Rotate.Out, { fromAngle: 35, restAngle: 5, animateOpacity: false })[0].keyframes).toEqual([
+      { rotate: 'z 5deg' },
+      { rotate: 'z 35deg' },
+    ]);
+  });
+
+  it('keeps factory-generated In and Out projections on the shared RotateParams record', () => {
+    const params: RotateParams = {
+      fromAngle: -30,
+      restAngle: 10,
+      toAngle: 80,
+      axis: 'x',
+      animateOpacity: false,
+    };
+
+    expect(getProjection(Rotate.In, params)[0].keyframes).toEqual([{ rotate: 'x -30deg' }, { rotate: 'x 10deg' }]);
+    expect(getProjection(Rotate.Out, params)[0].keyframes).toEqual([{ rotate: 'x 10deg' }, { rotate: 'x 80deg' }]);
+  });
+
+  it('applies entry and exit timing to the corresponding projections', () => {
+    const params: RotateParams = {
+      duration: 150,
+      easing: motionTokens.curveEasyEase,
+      delay: 25,
+      exitDuration: 275,
+      exitEasing: motionTokens.curveAccelerateMid,
+      exitDelay: 40,
+      animateOpacity: false,
+    };
+
+    expect(getProjection(Rotate.In, params)[0]).toMatchObject({ duration: 150, easing: params.easing, delay: 25 });
+    expect(getProjection(Rotate.Out, params)[0]).toMatchObject({
+      duration: 275,
+      easing: params.exitEasing,
+      delay: 40,
+    });
+  });
+
+  it('uses entry duration and delay as exit timing fallbacks', () => {
+    expect(getProjection(Rotate.Out, { duration: 180, delay: 30, animateOpacity: false })[0]).toMatchObject({
+      duration: 180,
+      easing: motionTokens.curveAccelerateMax,
+      delay: 30,
+    });
+  });
+
+  it('preserves opacity composition and supports disabling it', () => {
+    expect(getProjection(Rotate.In)[1].keyframes).toEqual([{ opacity: 0 }, { opacity: 1 }]);
+    expect(getProjection(Rotate.Out)[1].keyframes).toEqual([{ opacity: 1 }, { opacity: 0 }]);
+    expect(getProjection(Rotate.In, { animateOpacity: false })).toHaveLength(1);
+    expect(getProjection(Rotate.Out, { animateOpacity: false })).toHaveLength(1);
   });
 });

--- a/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Rotate/Rotate.ts
@@ -14,8 +14,9 @@ import type { RotateParams } from './rotate-types';
  * @param exitEasing - Easing curve for the exit transition (rotate-out). Defaults to the `curveAccelerateMax` value.
  * @param exitDelay - Time (ms) to delay the exit transition. Defaults to the `delay` param for symmetry.
  * @param axis - The axis of rotation: 'x', 'y', or 'z'. Defaults to 'z'.
- * @param outAngle - Rotation angle for the out state (exited) in degrees. Defaults to -90.
- * @param inAngle - Rotation angle for the in state (entered) in degrees. Defaults to 0.
+ * @param fromAngle - Rotation angle before entry in degrees. Defaults to -90.
+ * @param restAngle - Rotation angle at rest in degrees. Defaults to 0.
+ * @param toAngle - Rotation angle after exit in degrees. Defaults to `fromAngle`.
  * @param animateOpacity - Whether to animate the opacity during the rotation. Defaults to `true`.
  */
 const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
@@ -26,31 +27,30 @@ const rotatePresenceFn: PresenceMotionFn<RotateParams> = ({
   exitEasing = motionTokens.curveAccelerateMax,
   exitDelay = delay,
   axis = 'z',
-  outAngle = -90,
-  inAngle = 0,
+  fromAngle = -90,
+  restAngle = 0,
+  toAngle = fromAngle,
   animateOpacity = true,
 }: RotateParams) => {
   const enterAtoms: AtomMotion[] = [
     rotateAtom({
-      direction: 'enter',
       duration,
       easing,
       delay,
       axis,
-      outAngle,
-      inAngle,
+      fromAngle,
+      toAngle: restAngle,
     }),
   ];
 
   const exitAtoms: AtomMotion[] = [
     rotateAtom({
-      direction: 'exit',
       duration: exitDuration,
       easing: exitEasing,
       delay: exitDelay,
       axis,
-      outAngle,
-      inAngle,
+      fromAngle: restAngle,
+      toAngle,
     }),
   ];
 

--- a/packages/react-components/react-motion-components-preview/library/src/components/Rotate/rotate-types.ts
+++ b/packages/react-components/react-motion-components-preview/library/src/components/Rotate/rotate-types.ts
@@ -11,14 +11,20 @@ export type RotateParams = BasePresenceParams &
     axis?: Axis3D;
 
     /**
-     * Rotation angle for the out state (exited) in degrees.
-     * Defaults to -90.
+     * Rotation angle before entry in degrees. Used by Rotate and Rotate.In.
+     * Also supplies the default for `toAngle`. Defaults to -90.
      */
-    outAngle?: number;
+    fromAngle?: number;
 
     /**
-     * Rotation angle for the in state (entered) in degrees.
+     * Rotation angle at rest in degrees. Used as the entry destination and exit origin.
      * Defaults to 0.
      */
-    inAngle?: number;
+    restAngle?: number;
+
+    /**
+     * Rotation angle after exit in degrees. Used by Rotate and Rotate.Out.
+     * Defaults to `fromAngle`.
+     */
+    toAngle?: number;
   };

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/AtomsDemo.tsx
@@ -22,7 +22,7 @@ const createAtomMotion = (type: AtomType) => {
       return createMotionComponent(slideAtom({ direction: 'enter', duration: demoDuration, easing, outY: '30px' }));
     case 'rotate':
       return createMotionComponent(
-        rotateAtom({ direction: 'enter', duration: demoDuration, easing, axis: 'z', outAngle: -90 }),
+        rotateAtom({ duration: demoDuration, easing, axis: 'z', fromAngle: -90, toAngle: 0 }),
       );
     case 'blur':
       return createMotionComponent(blurAtom({ direction: 'enter', duration: demoDuration, easing, outRadius: '10px' }));
@@ -61,11 +61,10 @@ const atomCodeSnippets: Record<AtomType, string> = {
   inY: '0px',
 })`,
   rotate: `rotateAtom({
-  direction: 'enter',
   duration: 600,
   axis: 'z',
-  outAngle: -90,
-  inAngle: 0,
+  fromAngle: -90,
+  toAngle: 0,
 })`,
   blur: `blurAtom({
   direction: 'enter',

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/ComposingAtomsDemo.tsx
@@ -15,18 +15,17 @@ const easing = motionTokens.curveDecelerateMid;
 // Custom "SpinBlur" — combines rotate + blur + scale
 const SpinBlur = createPresenceComponent({
   enter: [
-    rotateAtom({ direction: 'enter', duration, easing, axis: 'z', outAngle: -20, inAngle: 0 }),
+    rotateAtom({ duration, easing, axis: 'z', fromAngle: -20, toAngle: 0 }),
     blurAtom({ direction: 'enter', duration, easing, outRadius: '8px', inRadius: '0px' }),
     scaleAtom({ direction: 'enter', duration, easing, outScale: 2 }),
   ],
   exit: [
     rotateAtom({
-      direction: 'exit',
       duration: exitDuration,
       easing: motionTokens.curveAccelerateMid,
       axis: 'z',
-      outAngle: 90,
-      inAngle: 0,
+      fromAngle: 0,
+      toAngle: 90,
     }),
     blurAtom({
       direction: 'exit',
@@ -41,12 +40,12 @@ const SpinBlur = createPresenceComponent({
 
 const codeSnippet = `const SpinBlur = createPresenceComponent({
   enter: [
-    rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
+    rotateAtom({ duration: 800, axis: 'z', fromAngle: -20, toAngle: 0 }),
     blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
     scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
   ],
   exit: [
-    rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
+    rotateAtom({ duration: 600, axis: 'z', fromAngle: 0, toAngle: -20 }),
     blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
     scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
   ],
@@ -83,12 +82,12 @@ const useClasses = makeStyles({
 
 const SpinBlur = createPresenceComponent({
   enter: [
-    rotateAtom({ direction: 'enter', duration: 800, axis: 'z', outAngle: -20 }),
+    rotateAtom({ duration: 800, axis: 'z', fromAngle: -20, toAngle: 0 }),
     blurAtom({ direction: 'enter', duration: 800, outRadius: '8px' }),
     scaleAtom({ direction: 'enter', duration: 800, outScale: 0.8 }),
   ],
   exit: [
-    rotateAtom({ direction: 'exit', duration: 600, axis: 'z', outAngle: -20 }),
+    rotateAtom({ duration: 600, axis: 'z', fromAngle: 0, toAngle: -20 }),
     blurAtom({ direction: 'exit', duration: 600, outRadius: '8px' }),
     scaleAtom({ direction: 'exit', duration: 600, outScale: 0.8 }),
   ],

--- a/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Atoms/index.mdx
@@ -98,13 +98,13 @@ const fadeIn = fadeAtom({
 
 ## Available Atoms
 
-| Atom         | Effect               | CSS Property             | Key Parameters                |
-| ------------ | -------------------- | ------------------------ | ----------------------------- |
-| `fadeAtom`   | Opacity transition   | `opacity`                | `outOpacity`, `inOpacity`     |
-| `scaleAtom`  | Size scaling         | `transform: scale()`     | `outScale`, `inScale`         |
-| `slideAtom`  | Position translation | `transform: translate()` | `outX`, `outY`, `inX`, `inY`  |
-| `rotateAtom` | 3D rotation          | `transform: rotate3d()`  | `axis`, `outAngle`, `inAngle` |
-| `blurAtom`   | Blur filter          | `filter: blur()`         | `outRadius`, `inRadius`       |
+| Atom         | Effect               | CSS Property             | Key Parameters                 |
+| ------------ | -------------------- | ------------------------ | ------------------------------ |
+| `fadeAtom`   | Opacity transition   | `opacity`                | `outOpacity`, `inOpacity`      |
+| `scaleAtom`  | Size scaling         | `transform: scale()`     | `outScale`, `inScale`          |
+| `slideAtom`  | Position translation | `transform: translate()` | `outX`, `outY`, `inX`, `inY`   |
+| `rotateAtom` | 3D rotation          | `transform: rotate3d()`  | `axis`, `fromAngle`, `toAngle` |
+| `blurAtom`   | Blur filter          | `filter: blur()`         | `outRadius`, `inRadius`        |
 
 <AtomsDemo />
 
@@ -138,7 +138,7 @@ scaleAtom({ direction: 'enter', duration: 500, outScale: 0.9, inScale: 1 });
 slideAtom({ direction: 'enter', duration: 500, outX: '0px', outY: '20px', inX: '0px', inY: '0px' });
 
 // rotateAtom — rotation (axis: 'x' | 'y' | 'z')
-rotateAtom({ direction: 'enter', duration: 600, axis: 'z', outAngle: -90, inAngle: 0 });
+rotateAtom({ duration: 600, axis: 'z', fromAngle: -90, toAngle: 0 });
 
 // blurAtom — blur filter
 blurAtom({ direction: 'enter', duration: 500, outRadius: '10px', inRadius: '0px' });

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/ComponentsGrid.tsx
@@ -80,7 +80,7 @@ export const ComponentsGrid: React.FC = () => {
 
       <ComponentCard name="Rotate">
         {visible => (
-          <Rotate visible={visible} outAngle={-90} inAngle={0} axis="z">
+          <Rotate visible={visible} fromAngle={-90} restAngle={0} axis="z">
             <div className={classes.demoBox}>Rotate</div>
           </Rotate>
         )}

--- a/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Introduction/index.mdx
@@ -263,15 +263,15 @@ function List({ items, visible }) {
 
 ### Component Reference
 
-| Component  | Variants                                               | Key Parameters                                      |
-| ---------- | ------------------------------------------------------ | --------------------------------------------------- |
-| `Fade`     | `FadeSnappy`, `FadeRelaxed`                            | `outOpacity`, `inOpacity`, `duration`, `easing`     |
-| `Scale`    | `ScaleSnappy`, `ScaleRelaxed`                          | `outScale`, `inScale`, `duration`, `easing`         |
-| `Collapse` | `CollapseSnappy`, `CollapseRelaxed`, `CollapseDelayed` | `orientation`, `outSize`, `duration`, `easing`      |
-| `Slide`    | `SlideSnappy`, `SlideRelaxed`                          | `outX`, `outY`, `inX`, `inY`, `duration`, `easing`  |
-| `Blur`     | —                                                      | `outRadius`, `inRadius`, `duration`, `easing`       |
-| `Rotate`   | —                                                      | `axis`, `outAngle`, `inAngle`, `duration`, `easing` |
-| `Stagger`  | —                                                      | `itemDelay`, `itemDuration`, `reversed`, `hideMode` |
+| Component  | Variants                                               | Key Parameters                                                    |
+| ---------- | ------------------------------------------------------ | ----------------------------------------------------------------- |
+| `Fade`     | `FadeSnappy`, `FadeRelaxed`                            | `outOpacity`, `inOpacity`, `duration`, `easing`                   |
+| `Scale`    | `ScaleSnappy`, `ScaleRelaxed`                          | `outScale`, `inScale`, `duration`, `easing`                       |
+| `Collapse` | `CollapseSnappy`, `CollapseRelaxed`, `CollapseDelayed` | `orientation`, `outSize`, `duration`, `easing`                    |
+| `Slide`    | `SlideSnappy`, `SlideRelaxed`                          | `outX`, `outY`, `inX`, `inY`, `duration`, `easing`                |
+| `Blur`     | —                                                      | `outRadius`, `inRadius`, `duration`, `easing`                     |
+| `Rotate`   | —                                                      | `axis`, `fromAngle`, `restAngle`, `toAngle`, `duration`, `easing` |
+| `Stagger`  | —                                                      | `itemDelay`, `itemDuration`, `reversed`, `hideMode`               |
 
 </div>
 

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateCardFlip.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateCardFlip.stories.tsx
@@ -60,7 +60,7 @@ const curveSpringRelaxed = `linear(0.0000 0.00%, 0.9935 36.00%, 1.042 38.00%, 1.
 const curveAnticipation = `linear(0, -0.01210 6%, -0.07124 19%, -0.08333 25%, -0.07200 30%, -0.04316 34%, 0.007701 38%, 0.06276 41%, 0.1342 44%, 0.2238 47%, 0.4463 53%, 0.5760 57%, 0.6836 61%, 0.7713 65%, 0.8411 69%, 0.9063 74%, 0.9506 79%, 0.9820 85%, 0.9982 93%, 1)`;
 
 type RequiredRotateParams = Required<
-  Pick<RotateParams, 'axis' | 'outAngle' | 'duration' | 'easing' | 'exitEasing' | 'exitDuration'>
+  Pick<RotateParams, 'axis' | 'fromAngle' | 'duration' | 'easing' | 'exitEasing' | 'exitDuration'>
 >;
 
 type RotatePattern = {
@@ -79,7 +79,7 @@ const patterns: RotatePattern[] = [
     icon: '↔️',
     color: tokens.colorPaletteBlueForeground2,
     axis: 'y',
-    outAngle: 180,
+    fromAngle: 180,
     easing: curveSpringRelaxed,
     exitEasing: curveAnticipation,
     duration: motionTokens.durationUltraSlow * 4, // 2000ms = 500ms * 4
@@ -92,7 +92,7 @@ const patterns: RotatePattern[] = [
     icon: '↕️',
     color: tokens.colorPaletteGreenForeground2,
     axis: 'x',
-    outAngle: 180,
+    fromAngle: 180,
     easing: curveSpringRelaxed,
     exitEasing: curveAnticipation,
     duration: motionTokens.durationUltraSlow * 4, // 2000ms = 500ms * 4
@@ -105,7 +105,7 @@ const patterns: RotatePattern[] = [
     icon: '🔄',
     color: tokens.colorPaletteRedForeground2,
     axis: 'z',
-    outAngle: 180,
+    fromAngle: 180,
     easing: curveSpringRelaxed,
     exitEasing: curveAnticipation,
     duration: motionTokens.durationUltraSlow * 4, // 2000ms = 500ms * 4
@@ -157,7 +157,7 @@ export const CardFlip = (): JSXElement => {
             <Rotate
               visible={activePatterns.has(pattern.id)}
               axis={pattern.axis}
-              outAngle={pattern.outAngle}
+              fromAngle={pattern.fromAngle}
               duration={pattern.duration}
               easing={pattern.easing}
               exitEasing={pattern.exitEasing}

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDefault.stories.tsx
@@ -109,11 +109,15 @@ export const Default = (props: React.ComponentProps<typeof Rotate>): JSXElement 
   const [perspective, setPerspective] = React.useState<string>('1000px');
   const [duration, setDuration] = React.useState<number>(motionTokens.durationUltraSlow); // 500ms
   const [axis, setAxis] = React.useState<Axis3D>('z');
-  const [outAngle, setOutAngle] = React.useState<number>(-90);
+  const [fromAngle, setFromAngle] = React.useState<number>(-90);
+  const [restAngle, setRestAngle] = React.useState<number>(0);
+  const [toAngle, setToAngle] = React.useState<number>(-90);
 
   const perspectiveSliderId = useId();
   const durationSliderId = useId();
-  const outAngleSliderId = useId();
+  const fromAngleSliderId = useId();
+  const restAngleSliderId = useId();
+  const toAngleSliderId = useId();
 
   const perspectiveMin = 200;
   const perspectiveMax = 2000;
@@ -146,18 +150,54 @@ export const Default = (props: React.ComponentProps<typeof Rotate>): JSXElement 
 
           <Field className={classes.sliderField}>
             <div className={classes.sliderHeader}>
-              <Label htmlFor={outAngleSliderId} className={classes.sliderLabel}>
-                Out Angle
+              <Label htmlFor={fromAngleSliderId} className={classes.sliderLabel}>
+                From Angle
               </Label>
-              <span className={classes.valueDisplay}>{outAngle}°</span>
+              <span className={classes.valueDisplay}>{fromAngle}°</span>
             </div>
             <Slider
               min={angleMin}
               max={angleMax}
-              defaultValue={outAngle}
-              id={outAngleSliderId}
+              defaultValue={fromAngle}
+              id={fromAngleSliderId}
               onChange={(_, data) => {
-                setOutAngle(data.value);
+                setFromAngle(data.value);
+              }}
+            />
+          </Field>
+
+          <Field className={classes.sliderField}>
+            <div className={classes.sliderHeader}>
+              <Label htmlFor={restAngleSliderId} className={classes.sliderLabel}>
+                Rest Angle
+              </Label>
+              <span className={classes.valueDisplay}>{restAngle}°</span>
+            </div>
+            <Slider
+              min={angleMin}
+              max={angleMax}
+              defaultValue={restAngle}
+              id={restAngleSliderId}
+              onChange={(_, data) => {
+                setRestAngle(data.value);
+              }}
+            />
+          </Field>
+
+          <Field className={classes.sliderField}>
+            <div className={classes.sliderHeader}>
+              <Label htmlFor={toAngleSliderId} className={classes.sliderLabel}>
+                To Angle
+              </Label>
+              <span className={classes.valueDisplay}>{toAngle}°</span>
+            </div>
+            <Slider
+              min={angleMin}
+              max={angleMax}
+              defaultValue={toAngle}
+              id={toAngleSliderId}
+              onChange={(_, data) => {
+                setToAngle(data.value);
               }}
             />
           </Field>
@@ -203,7 +243,14 @@ export const Default = (props: React.ComponentProps<typeof Rotate>): JSXElement 
         </div>
       </div>
 
-      <Rotate visible={visible} axis={axis} outAngle={outAngle} duration={duration}>
+      <Rotate
+        visible={visible}
+        axis={axis}
+        fromAngle={fromAngle}
+        restAngle={restAngle}
+        toAngle={toAngle}
+        duration={duration}
+      >
         <Card className={classes.card}>
           <CardHeader
             header={

--- a/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDescription.md
+++ b/packages/react-components/react-motion-components-preview/stories/src/Rotate/RotateDescription.md
@@ -7,7 +7,7 @@ import { Rotate } from '@fluentui/react-motion-components-preview';
 
 function Component({ visible }) {
   return (
-    <Rotate visible={visible} axis="x" angle={45}>
+    <Rotate visible={visible} axis="x" fromAngle={45} restAngle={0} toAngle={-45}>
       <div>Content</div>
     </Rotate>
   );

--- a/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
+++ b/packages/react-components/react-nav/library/src/components/NavCategoryItem/useNavCategoryItem.tsx
@@ -19,8 +19,8 @@ const ExpandIconMotion = createPresenceComponentVariant(Rotate, {
   duration: motionTokens.durationFast,
   easing: motionTokens.curveEasyEase,
   animateOpacity: false, // Don't fade out the icon
-  outAngle: 0,
-  inAngle: 180,
+  fromAngle: 0,
+  restAngle: 180,
 });
 
 /**


### PR DESCRIPTION
## Summary

- migrate `Rotate` from `outAngle`/`inAngle` to the graph-level `fromAngle`/`restAngle`/`toAngle` parameter record
- preserve the stable factory-generated `Rotate.In` and `Rotate.Out` projections
- make `rotateAtom` a neutral directed `fromAngle` → `toAngle` atom
- migrate stories and the `NavCategoryItem` consumer while preserving its `0 → 180 → 0` behavior
- update tests, API report, documentation, and package change files

## Validation

- `yarn nx test react-motion-components-preview --runInBand` — 168 tests passed
- motion preview type-check, lint, and API generation passed
- `yarn nx test react-nav --runInBand` — 284 tests passed
- react-nav type-check and lint passed
- `git diff --check`