### PR TITLE
Remove non-existent @maifnramev from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -248,7 +248,7 @@ packages/react-components/react-switch/library @microsoft/cxe-prg @ValentinaKozl
 packages/react-components/react-switch/stories @microsoft/cxe-prg @ValentinaKozlova
 packages/react-components/react-tabs/library @microsoft/cxe-prg @dmytrokirpa
 packages/react-components/react-tabs/stories @microsoft/cxe-prg @dmytrokirpa
-packages/react-components/react-text/library @microsoft/cxe-prg @maifnramev
+packages/react-components/react-text/library @microsoft/cxe-prg
 packages/react-components/react-text/stories @microsoft/cxe-prg @mainframev
 packages/react-components/react-textarea/library @microsoft/cxe-prg @mainframev
 packages/react-components/react-textarea/stories @microsoft/cxe-prg @mainframev


### PR DESCRIPTION
Hi, and thank you for Fluent UI.

`.github/CODEOWNERS` (line 251) references `@maifnramev`, but that GitHub account no longer exists (`gh api users/maifnramev` → 404), so review routing to it silently drops. This removes the dead handle and keeps the `@microsoft/cxe-prg` team owner on the line.

For transparency: I used AI assistance to spot and draft this; I verified the 404 myself.