### PR TITLE
docs: update Yarn 4 guidance

### DIFF
--- a/.agents/skills/dependabot-rollup/SKILL.md
+++ b/.agents/skills/dependabot-rollup/SKILL.md
@@ -144,7 +144,7 @@ Never resolve dependency conflicts automatically. If no PRs merge successfully, 
 Run validation from the temporary worktree through the repository's Nx workflow:
 
 ```bash
-yarn --cwd "$ROLLUP_DIR" install --frozen-lockfile
+yarn --cwd "$ROLLUP_DIR" install --immutable
 yarn --cwd "$ROLLUP_DIR" nx affected \
   -t build test lint type-check \
   --nxBail \

--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -10,7 +10,7 @@ You are working in the Microsoft Fluent UI monorepo, a comprehensive design syst
 
 This is a large Nx monorepo with the following key characteristics:
 
-- **Package Manager**: Yarn v1 with strict dependency management
+- **Package Manager**: Yarn 4.x (exact version pinned via `packageManager` in `package.json`; `.yarnrc.yml` configures the repository binary path)
 - **Build System**: Nx workspace with custom plugins (`tools/workspace-plugin/`)
 - **Node.js Versions**: ^22.0.0
 - **Languages**: TypeScript (strict mode), React, Web Components

--- a/.github/instructions/dependabot-security-fixes.instructions.md
+++ b/.github/instructions/dependabot-security-fixes.instructions.md
@@ -57,11 +57,11 @@ The following resolutions are maintained for security purposes:
 
 ### Manual Security Fix Process
 
-1. Run `yarn audit --level ${SEVERITY}` to identify vulnerabilities (where SEVERITY can be: low, moderate, high, critical)
+1. Run `yarn npm audit --severity ${SEVERITY}` to identify vulnerabilities (where SEVERITY can be: low, moderate, high, critical)
 2. Check if Yarn resolutions are blocking updates
 3. Update resolutions to secure versions
 4. Run `yarn install` to update yarn.lock
-5. Verify fixes with `yarn audit --level ${SEVERITY}`
+5. Verify fixes with `yarn npm audit --severity ${SEVERITY}`
 6. Test that builds still work
 
 ## Testing Security Fixes
@@ -70,7 +70,7 @@ After making changes:
 
 ```bash
 # Check for remaining vulnerabilities at specified severity level
-yarn audit --level ${SEVERITY}
+yarn npm audit --severity ${SEVERITY}
 
 # Verify builds still work
 yarn nx run workspace-plugin:build

--- a/change/@fluentui-babel-preset-global-context-11690495-98b7-460d-815c-b6f7b9d5527d.json
+++ b/change/@fluentui-babel-preset-global-context-11690495-98b7-460d-815c-b6f7b9d5527d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update readme to reference correct yarn page link",
+  "packageName": "@fluentui/babel-preset-global-context",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/docs/react-v9/contributing/dev-env.md
+++ b/docs/react-v9/contributing/dev-env.md
@@ -11,10 +11,9 @@ Note that the core team does not support native Windows as a development platfor
   - Microsoft employees: please [link your GitHub account](https://repos.opensource.microsoft.com) (new or existing) to your MS account
 
 - Windows users should install **[WSL](https://learn.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-wsl)**
-- Install **[Node.js LTS](https://nodejs.org/en/)** (20 as of writing)
+- Install **[Node.js LTS](https://nodejs.org/en/)** (^22 or ^24)
   - Optional: If you're developing across multiple repos with varying Node version requirements, you may want to use `nvm` to install and manage Node versions.
-- Install **[Yarn v1](https://classic.yarnpkg.com/) (we do not use Yarn >=v2)**
-  - easiest way: run `npm install -g yarn@1`
+- Install **[Yarn 4](https://yarnpkg.com/getting-started/install)**. The repo pins a specific Yarn 4.x release via the `packageManager` field in `package.json` (the exact version source of truth); `.yarnrc.yml` configures the repository binary path.
 - Install **[Git](https://git-scm.com/)**
 - Install **[Visual Studio Code](https://code.visualstudio.com/)** or any other editor of your preference
 - Install **[Nx Console extension for Visual Studio](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console)**
@@ -28,8 +27,8 @@ Note that the core team does not support native Windows as a development platfor
 
 Open a command line and run:
 
-- `node -v`: Should be `^22.x.x`.
-- `yarn -v`: Should be >= 1.15.0 but **less than 2**. If not, run `npm install -g yarn@1`.
+- `node -v`: Should be `^22.x.x` or `^24.x.x`.
+- `yarn -v`: Should report `4.x`; the exact version is pinned by `packageManager` in `package.json`.
 - `git --version` to ensure you have Git installed.
 - If using VS Code, go to a folder and run `code .` to open the folder in VS Code. If it doesn't work, open VS Code and press `F1` or `ctrl+shift+P` (`cmd+shift+P`), type `path`, and select the `Install 'code' command in PATH` option.
 

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/dependency-versions.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/dependency-versions.md
@@ -62,7 +62,7 @@ resolved "https://..."
 integrity sha512-...
 ```
 
-There are workaround that customers can use in this case ([`yarn resolutions`](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/), [webpack aliases](https://webpack.js.org/configuration/resolve/#resolvealias)) to use a proper version. But we should not create an additional walls for customers to properly consumer the library.
+There are workaround that customers can use in this case ([`yarn resolutions`](https://yarnpkg.com/configuration/manifest#resolutions), [webpack aliases](https://webpack.js.org/configuration/resolve/#resolvealias)) to use a proper version. But we should not create an additional walls for customers to properly consumer the library.
 
 There is a Webpack plugin (similar to [duplicate-package-checker-webpack-plugin](https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin)) that prevents imports of duplicate versions on Teams side.
 

--- a/docs/react-v9/contributing/using-local-unpublished-version-of-the-lib-with-a-local-React-app.md
+++ b/docs/react-v9/contributing/using-local-unpublished-version-of-the-lib-with-a-local-React-app.md
@@ -1,4 +1,4 @@
-In addition to the standard [development practice](https://github.com/microsoft/fluentui/wiki/Development-Workflow), it is sometimes useful to run a local app against the introduced changes within the library, for instance, when trying to repro a bug locally, etc. In this case, `yarn link` tool comes in real handy, and this short guide will take you through the full setup to get you up and running.
+In addition to the standard [development practice](https://github.com/microsoft/fluentui/wiki/Development-Workflow), it is sometimes useful to run a local app against the introduced changes within the library, for instance, when trying to repro a bug locally, etc. This guide walks through the setup using Yarn 4's path-based linking.
 
 ## The scenario
 
@@ -29,81 +29,43 @@ import { PrimaryButton } from '@fluentui/react';
 render(<PrimaryButton />, document.getElementById('content'));
 ```
 
-Normally, you'd add `@fluentui/react` to your project using `yarn add <package>`. However, since we want to test our local changes to the `fluentui` package, this will not be sufficient. This is where `yarn link` saves the day. `yarn link` creates a symlink to your local package inside the `node_modules` directory, however, at the same time, it doesn't add the dependency to the `package.json` file. Having said that, you can still import the linked package as you'd normally do when adding a package from the npm registry. So no difference there. The trick is with the actual linking. We discuss this next.
+Normally, you'd add `@fluentui/react` to your project using `yarn add <package>`. However, since we want to test our local changes to the `fluentui` package, this will not be sufficient. This is where `yarn link` saves the day.
 
 ## The solution
 
-We want to link `@fluentui/react` as a dependency of the `app` package. To do this, we first of all need to add our local copy of `@fluentui/react` into `yarn`'s link registry. This can be done by navigating to the `fluentui` project and then into the appropriate package source directory, in this case, `react`, and invoking `yarn link`:
+Yarn 4 supports path-based linking directly, without a global link registry. From the `app` directory, point Yarn at the local package source:
 
-```
-$ cd fluentui/packages/react
-$ yarn link
-yarn link v1.22.10
-success Registered "@fluentui/react".
-info You can now run `yarn link "@fluentui/react"` in the projects where you want to use this package and it will be used instead.
-✨  Done in 0.04s.
-```
-
-OK, so we're halfway there. Now, from within the `app`'s root directory, we execute the hint given to us by `yarn link`, that is:
-
-```
+```bash
 $ cd app
-$ yarn link @fluentui/react
-yarn link v1.22.10
-success Using linked package for "@fluentui/react".
-✨  Done in 0.04s.
+$ yarn link ../fluentui/packages/react
 ```
 
-After this is done, if you navigate into your `app`'s `node_modules` dir, you'll see that `@fluentui/react` is a symlink:
+This records the local path for `@fluentui/react` in `app/package.json` under `resolutions` using Yarn's
+[`portal:` protocol](https://yarnpkg.com/protocol/portal) and installs the link. The package is now resolved from your
+local `fluentui/packages/react` directory — no separate registration step needed in the library.
 
-```
-$ cd app/node_modules/@fluentui
-$ ls -la react
-lrwxr-xr-x  1 username  group  45 Jan 11 13:03 node_modules/@fluentui/react -> ../../../../.config/yarn/link/@fluentui/react
-```
-
-This symlink points to `yarn`'s local link-registry, which in turn dereferences to the `fluentui/packages/react` directory:
-
-```
-$ ls -la ~/.config/yarn/link/@fluentui/react
-lrwxr-xr-x  1 username  group  39 Jan 11 11:56 ~/.config/yarn/link/@fluentui/react -> ../../../../common_root/fluentui/packages/react
-```
-
-In effect, you can think of it as:
-
-```
-common_root
- \
-  | -- fluentui
-  |     \
-  |      | -- packages/react <---------|
-  |                                    |
-  | -- app                             |
-        \                              |
-         | -- node_modules/@fluentui/react
-```
-
-If you try running your app however, you will get greeted by a nasty looking [React error scolding you for violating the "Rules of Hooks"](https://reactjs.org/warnings/invalid-hook-call-warning.html). The good news is, we've not violated anything. The bad news is, the app will refuse to launch. It turns out, in addition to violating the "Rules of Hooks", this problem also surfaces when the two projects you want to link locally via symlink both add `react` and `react-dom` as dependencies. In such case, as prescribed by React, it is necessary to manually link in the same version of `react` and `react-dom` between the linked packages using `npm link <path>`, and is best done in the lib's `node_modules`:
-
-```
-$ cd fluentui
-$ rm -rf fluentui/node_modules/react # please, be extremely careful when invoking rm with -rf flags!
-$ rm -rf fluentui/node_modules/react-dom
-$ npm link ../app/node_modules/react
-$ npm link ../app/node_modules/react-dom
-```
+> **Warning:** If you encounter a [React "Rules of Hooks" error](https://reactjs.org/warnings/invalid-hook-call-warning.html), both projects are loading separate copies of `react`. Yarn 4 path linking preserves the consuming app's peer dependency resolution, so the linked package should resolve `react` through the app's own `node_modules`. If the error still occurs, verify that the app and the linked package declare compatible `react` peer versions. Do not add self-referential `link:./node_modules/react` resolutions — they are circular and unreliable.
 
 With this done, you should be able to successfully run the app:
 
-```
+```bash
 $ yarn start
+```
+
+## Unlinking
+
+To restore the original published version, remove the entry `yarn link` added for `@fluentui/react` from the `resolutions` field in `app/package.json`, then reinstall:
+
+```bash
+$ cd app
+$ yarn install
 ```
 
 ## Development workflow
 
 Now, whenever you make tweaks to the `fluentui` lib, you simply need to rebuild it via:
 
-```
+```bash
 $ cd fluentui
 $ yarn nx run react:build
 ```

--- a/packages/react-components/babel-preset-global-context/README.md
+++ b/packages/react-components/babel-preset-global-context/README.md
@@ -55,7 +55,7 @@ function Consumer() {
 ```
 
 > ⚠️ The recommended solution to the above problem is to make sure that the affected dependency
-> only exists once in node_modules. You can do this by upgrading your dependencies or using [resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).
+> only exists once in node_modules. You can do this by upgrading your dependencies or using [resolutions](https://yarnpkg.com/configuration/manifest#resolutions).
 
 This library should only be used as a workaround in the cases where it might not be feasible to deduplicate `node_modules`.
 


### PR DESCRIPTION
## Summary

- update maintained contributor and agent documentation for Yarn 4
- replace Yarn v1 commands, links, audit, and local linking guidance
- document that `yarn link` creates a `portal:` resolution

## Validation

- `yarn install --immutable`
- `yarn nx format:check`