### PR TITLE
fix(web-components): display selections in multiple comboboxes

### DIFF
--- a/change/@fluentui-web-components-ddd88572-9ab5-4fe0-9f1c-39daf2aed06d.json
+++ b/change/@fluentui-web-components-ddd88572-9ab5-4fe0-9f1c-39daf2aed06d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(web-components): display selected values in multiple comboboxes",
+  "packageName": "@fluentui/web-components",
+  "email": "2241678935@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/dropdown/dropdown.base.ts
+++ b/packages/web-components/src/dropdown/dropdown.base.ts
@@ -142,7 +142,7 @@ export class BaseDropdown extends FASTElement {
    */
   @volatile
   public get displayValue(): string {
-    if (!this.$fastController.isConnected || !this.control || (this.isCombobox && this.multiple)) {
+    if (!this.$fastController.isConnected || !this.control) {
       toggleState(this.elementInternals, 'placeholder-shown', false);
       return '';
     }

--- a/packages/web-components/src/dropdown/dropdown.spec.ts
+++ b/packages/web-components/src/dropdown/dropdown.spec.ts
@@ -455,6 +455,22 @@ test.describe('Dropdown', () => {
       await expect(input).toHaveValue('Kiwi');
     });
 
+    test('should display all selected options when configured as a multiple combobox', async ({ fastPage }) => {
+      const { element } = fastPage;
+      const input = element.locator('input');
+      const appleOption = element.locator(`${OptionTagName}[value=apple]`);
+      const bananaOption = element.locator(`${OptionTagName}[value=banana]`);
+
+      await fastPage.setTemplate({ attributes: { type: 'combobox', multiple: true } });
+
+      await input.click();
+      await appleOption.click();
+      await bananaOption.click();
+
+      await expect(input).toHaveValue(/Apple/);
+      await expect(input).toHaveValue(/Banana/);
+    });
+
     test('should emit a `change` event when the value changes and the control loses focus via blur', async ({
       fastPage,
       page,


### PR DESCRIPTION
## Previous Behavior

A `fluent-dropdown` configured with `type="combobox"` and `multiple`
cleared its input after selecting options because `displayValue` returned
early for this configuration.

## New Behavior

Multiple-selection comboboxes now use the existing selected-options
formatter and display all selected option labels in the input.

A browser regression test selects Apple and Banana and verifies that both
labels remain visible.

## Testing

- Chromium CSR focused regression test
- Chromium SSR focused regression test
- Firefox CSR focused regression test
- Firefox SSR focused regression test
- WebKit CSR focused regression test
- WebKit SSR focused regression test
- Complete Dropdown Chromium CSR spec: 28 passed
- `yarn nx run web-components:lint` — 0 errors, 93 existing warnings
- `yarn nx run web-components:type-check`
- `git diff origin/master...HEAD --check`

Local browser timing note: Firefox CSR was flaky with the harness's default
5-second fixture timeout but passed without retries with a 15-second timeout.
WebKit CSR passed with 15 seconds, while WebKit SSR required 30 seconds.
The shorter-timeout failures occurred during fixture navigation or option
availability, before the display-value assertions.

## Related Issue(s)

- Fixes #36306
