### PR TITLE
fix(react): rebind withViewport across windows

### DIFF
--- a/change/@fluentui-react-486db03b-19ec-48a6-91b3-aa08d113d79e.json
+++ b/change/@fluentui-react-486db03b-19ec-48a6-91b3-aa08d113d79e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: rebind withViewport resize handling when its root moves to another window",
+  "packageName": "@fluentui/react",
+  "email": "2241678935@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-utilities-c4e06b96-9dff-4a21-80c7-db044591d953.json
+++ b/change/@fluentui-utilities-c4e06b96-9dff-4a21-80c7-db044591d953.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: honor an explicitly supplied window in getRect",
+  "packageName": "@fluentui/utilities",
+  "email": "2241678935@qq.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/utilities/decorators/withViewport.test.tsx
+++ b/packages/react/src/utilities/decorators/withViewport.test.tsx
@@ -5,12 +5,12 @@ import { withViewport } from './withViewport';
 import type { IViewport, IWithViewportProps } from './withViewport';
 import type { JSXElement } from '@fluentui/utilities';
 
-interface TestComponentProps extends IWithViewportProps {
+interface ITestComponentProps extends IWithViewportProps {
   renderId: number;
   viewport?: IViewport;
 }
 
-class TestComponent extends React.Component<TestComponentProps> {
+class TestComponent extends React.Component<ITestComponentProps> {
   public render(): JSXElement {
     return <div>{this.props.renderId}</div>;
   }
@@ -18,13 +18,13 @@ class TestComponent extends React.Component<TestComponentProps> {
 
 const ViewportComponent = withViewport(TestComponent);
 
-interface ResizeObserverInstanceMock {
+interface IResizeObserverInstanceMock {
   observe: jest.Mock;
   disconnect: jest.Mock;
 }
 
 function createResizeObserverMock() {
-  const instances: ResizeObserverInstanceMock[] = [];
+  const instances: IResizeObserverInstanceMock[] = [];
   const constructor = jest.fn().mockImplementation(() => {
     const instance = {
       observe: jest.fn(),

--- a/packages/react/src/utilities/decorators/withViewport.test.tsx
+++ b/packages/react/src/utilities/decorators/withViewport.test.tsx
@@ -12,7 +12,7 @@ interface ITestComponentProps extends IWithViewportProps {
 
 class TestComponent extends React.Component<ITestComponentProps> {
   public render(): JSXElement {
-    return <div>{this.props.renderId}</div>;
+    return <div data-viewport-width={this.props.viewport?.width}>{this.props.renderId}</div>;
   }
 }
 
@@ -90,12 +90,24 @@ describe('withViewport', () => {
       expect(mainResizeObserver.constructor).toHaveBeenCalledTimes(1);
       expect(mainResizeObserver.instances[0].disconnect).not.toHaveBeenCalled();
 
+      jest.spyOn(viewportRoot, 'getBoundingClientRect').mockReturnValue({
+        bottom: 100,
+        height: 100,
+        left: 0,
+        right: 712,
+        top: 0,
+        width: 712,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      });
       frameDocument.body.appendChild(viewportRoot);
       rerender(<ViewportComponent renderId={2} />);
 
       expect(mainResizeObserver.instances[0].disconnect).toHaveBeenCalledTimes(1);
       expect(frameResizeObserver.constructor).toHaveBeenCalledTimes(1);
       expect(frameResizeObserver.instances[0].observe).toHaveBeenCalledWith(viewportRoot);
+      expect(frameDocument.querySelector('[data-viewport-width]')?.getAttribute('data-viewport-width')).toBe('712');
     } finally {
       container.appendChild(viewportRoot);
       unmount();

--- a/packages/react/src/utilities/decorators/withViewport.test.tsx
+++ b/packages/react/src/utilities/decorators/withViewport.test.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { withViewport } from './withViewport';
+
+import type { IViewport, IWithViewportProps } from './withViewport';
+import type { JSXElement } from '@fluentui/utilities';
+
+interface TestComponentProps extends IWithViewportProps {
+  renderId: number;
+  viewport?: IViewport;
+}
+
+class TestComponent extends React.Component<TestComponentProps> {
+  public render(): JSXElement {
+    return <div>{this.props.renderId}</div>;
+  }
+}
+
+const ViewportComponent = withViewport(TestComponent);
+
+interface ResizeObserverInstanceMock {
+  observe: jest.Mock;
+  disconnect: jest.Mock;
+}
+
+function createResizeObserverMock() {
+  const instances: ResizeObserverInstanceMock[] = [];
+  const constructor = jest.fn().mockImplementation(() => {
+    const instance = {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+    };
+
+    instances.push(instance);
+    return instance;
+  });
+
+  return { constructor, instances };
+}
+
+function setResizeObserver(targetWindow: Window, value: jest.Mock | undefined): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(targetWindow, 'ResizeObserver');
+
+  Object.defineProperty(targetWindow, 'ResizeObserver', {
+    configurable: true,
+    writable: true,
+    value,
+  });
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(targetWindow, 'ResizeObserver', descriptor);
+    } else {
+      Reflect.deleteProperty(targetWindow, 'ResizeObserver');
+    }
+  };
+}
+
+function createIframe(): { iframe: HTMLIFrameElement; frameWindow: Window; frameDocument: Document } {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+
+  return {
+    iframe,
+    frameWindow: iframe.contentWindow!,
+    frameDocument: iframe.contentDocument!,
+  };
+}
+
+describe('withViewport', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('re-registers ResizeObserver when the root moves to another window', () => {
+    const mainResizeObserver = createResizeObserverMock();
+    const frameResizeObserver = createResizeObserverMock();
+    const restoreMainResizeObserver = setResizeObserver(window, mainResizeObserver.constructor);
+    const { iframe, frameWindow, frameDocument } = createIframe();
+    const restoreFrameResizeObserver = setResizeObserver(frameWindow, frameResizeObserver.constructor);
+    const { container, rerender, unmount } = render(<ViewportComponent renderId={0} />);
+    const viewportRoot = container.querySelector('.ms-Viewport')!;
+
+    try {
+      expect(mainResizeObserver.constructor).toHaveBeenCalledTimes(1);
+      expect(mainResizeObserver.instances[0].observe).toHaveBeenCalledWith(viewportRoot);
+
+      rerender(<ViewportComponent renderId={1} />);
+
+      expect(mainResizeObserver.constructor).toHaveBeenCalledTimes(1);
+      expect(mainResizeObserver.instances[0].disconnect).not.toHaveBeenCalled();
+
+      frameDocument.body.appendChild(viewportRoot);
+      rerender(<ViewportComponent renderId={2} />);
+
+      expect(mainResizeObserver.instances[0].disconnect).toHaveBeenCalledTimes(1);
+      expect(frameResizeObserver.constructor).toHaveBeenCalledTimes(1);
+      expect(frameResizeObserver.instances[0].observe).toHaveBeenCalledWith(viewportRoot);
+    } finally {
+      container.appendChild(viewportRoot);
+      unmount();
+      restoreFrameResizeObserver();
+      restoreMainResizeObserver();
+      iframe.remove();
+    }
+  });
+
+  it('moves the fallback resize listener to the destination window', () => {
+    const restoreMainResizeObserver = setResizeObserver(window, undefined);
+    const { iframe, frameWindow, frameDocument } = createIframe();
+    const restoreFrameResizeObserver = setResizeObserver(frameWindow, undefined);
+    const mainAddEventListener = jest.spyOn(window, 'addEventListener');
+    const mainRemoveEventListener = jest.spyOn(window, 'removeEventListener');
+    const frameAddEventListener = jest.spyOn(frameWindow, 'addEventListener');
+    const { container, rerender, unmount } = render(<ViewportComponent renderId={0} disableResizeObserver />);
+    const viewportRoot = container.querySelector('.ms-Viewport')!;
+
+    try {
+      const mainResizeRegistration = mainAddEventListener.mock.calls.find(call => call[0] === 'resize');
+      expect(mainResizeRegistration).toBeDefined();
+
+      frameDocument.body.appendChild(viewportRoot);
+      rerender(<ViewportComponent renderId={1} disableResizeObserver />);
+
+      expect(mainRemoveEventListener).toHaveBeenCalledWith(
+        'resize',
+        mainResizeRegistration![1],
+        mainResizeRegistration![2],
+      );
+      expect(frameAddEventListener.mock.calls.some(call => call[0] === 'resize')).toBe(true);
+    } finally {
+      container.appendChild(viewportRoot);
+      unmount();
+      restoreFrameResizeObserver();
+      restoreMainResizeObserver();
+      iframe.remove();
+    }
+  });
+});

--- a/packages/react/src/utilities/decorators/withViewport.tsx
+++ b/packages/react/src/utilities/decorators/withViewport.tsx
@@ -82,6 +82,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     private _root = React.createRef<HTMLDivElement>();
     private _resizeAttempts: number;
     private _viewportResizeObserver: any;
+    private _resizeWindow?: Window;
     private _async: Async;
     private _events: EventGroup;
 
@@ -101,7 +102,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     }
 
     public componentDidMount(): void {
-      const { delayFirstMeasure, disableResizeObserver, skipViewportMeasures } = this.props as IWithViewportProps;
+      const { delayFirstMeasure, skipViewportMeasures } = this.props as IWithViewportProps;
       const win = getWindow(this._root.current);
 
       this._onAsyncResize = this._async.debounce(this._onAsyncResize, RESIZE_DELAY, {
@@ -109,11 +110,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
       });
 
       if (!skipViewportMeasures) {
-        if (!disableResizeObserver && this._isResizeObserverAvailable()) {
-          this._registerResizeObserver();
-        } else {
-          this._events.on(win, 'resize', this._onAsyncResize);
-        }
+        this._registerResizeHandler(win);
 
         if (delayFirstMeasure) {
           this._async.setTimeout(() => {
@@ -127,31 +124,23 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
 
     public componentDidUpdate(previousProps: TProps) {
       const { skipViewportMeasures: previousSkipViewportMeasures } = previousProps as IWithViewportProps;
-      const { disableResizeObserver, skipViewportMeasures } = this.props as IWithViewportProps;
+      const { skipViewportMeasures } = this.props as IWithViewportProps;
       const win = getWindow(this._root.current);
+      const hasWindowChanged = win !== this._resizeWindow;
 
-      if (skipViewportMeasures !== previousSkipViewportMeasures) {
-        if (!skipViewportMeasures) {
-          if (!disableResizeObserver && this._isResizeObserverAvailable()) {
-            if (!this._viewportResizeObserver) {
-              this._registerResizeObserver();
-            }
-          } else {
-            this._events.on(win, 'resize', this._onAsyncResize);
-          }
-
-          this._updateViewport();
-        } else {
-          this._unregisterResizeObserver();
-          this._events.off(win, 'resize', this._onAsyncResize);
-        }
+      if (!skipViewportMeasures && (previousSkipViewportMeasures || hasWindowChanged)) {
+        this._unregisterResizeHandler();
+        this._registerResizeHandler(win);
+        this._updateViewport();
+      } else if (skipViewportMeasures && !previousSkipViewportMeasures) {
+        this._unregisterResizeHandler();
       }
     }
 
     public componentWillUnmount(): void {
+      this._unregisterResizeHandler();
       this._events.dispose();
       this._async.dispose();
-      this._unregisterResizeObserver();
     }
 
     public render(): JSXElement {
@@ -173,15 +162,35 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
       this._updateViewport();
     }
 
-    private _isResizeObserverAvailable(): boolean {
-      const win = getWindow(this._root.current);
+    private _registerResizeHandler = (win: Window | undefined): void => {
+      if (!win) {
+        return;
+      }
 
-      return win && (win as any).ResizeObserver;
+      const { disableResizeObserver } = this.props as IWithViewportProps;
+      this._resizeWindow = win;
+
+      if (!disableResizeObserver && this._isResizeObserverAvailable(win)) {
+        this._registerResizeObserver(win);
+      } else {
+        this._events.on(win, 'resize', this._onAsyncResize);
+      }
+    };
+
+    private _unregisterResizeHandler = (): void => {
+      this._unregisterResizeObserver();
+
+      if (this._resizeWindow) {
+        this._events.off(this._resizeWindow, 'resize', this._onAsyncResize);
+        this._resizeWindow = undefined;
+      }
+    };
+
+    private _isResizeObserverAvailable(win: Window | undefined): boolean {
+      return !!win && !!(win as any).ResizeObserver;
     }
 
-    private _registerResizeObserver = () => {
-      const win = getWindow(this._root.current);
-
+    private _registerResizeObserver = (win: Window): void => {
       this._viewportResizeObserver = new (win as any).ResizeObserver(this._onAsyncResize);
       this._viewportResizeObserver.observe(this._root.current);
     };

--- a/packages/utilities/src/dom/getRect.test.ts
+++ b/packages/utilities/src/dom/getRect.test.ts
@@ -1,0 +1,22 @@
+import { getRect } from './getRect';
+
+describe('getRect', () => {
+  it('uses the supplied window when measuring that window', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    const frameWindow = iframe.contentWindow!;
+
+    try {
+      expect(getRect(frameWindow, frameWindow)).toEqual({
+        left: 0,
+        top: 0,
+        width: frameWindow.innerWidth,
+        height: frameWindow.innerHeight,
+        right: frameWindow.innerWidth,
+        bottom: frameWindow.innerHeight,
+      });
+    } finally {
+      iframe.remove();
+    }
+  });
+});

--- a/packages/utilities/src/dom/getRect.ts
+++ b/packages/utilities/src/dom/getRect.ts
@@ -8,9 +8,10 @@ import { getWindow } from './getWindow';
  */
 export function getRect(element: HTMLElement | Window | null, win?: Window): IRectangle | undefined {
   const theWin =
-    win ?? (!element || (element && element.hasOwnProperty('devicePixelRatio')))
+    win ??
+    (!element || (element && element.hasOwnProperty('devicePixelRatio'))
       ? getWindow()
-      : getWindow(element as HTMLElement)!;
+      : getWindow(element as HTMLElement)!);
   let rect: IRectangle | undefined;
   if (element) {
     if (element === theWin) {


### PR DESCRIPTION
## Summary

- re-register `withViewport` resize handling when its root moves to a different DOM window
- clean up the old window's `ResizeObserver` or fallback resize listener before registering with the destination window
- honor an explicitly supplied window in `getRect` so popup viewport measurements use the popup rather than the global window
- add regression coverage for observer and fallback-listener handoff, viewport measurement, and cross-window `getRect`

## Root cause

`withViewport` kept its resize handling attached to the window used during mount and did not check whether the root element's owner window changed during an update.

After re-registering the observer, popup measurement was also blocked by the precedence of the nullish-coalescing and conditional expressions in `getRect`: a supplied popup window was treated as the conditional test and measurement fell back to the global window.

## Validation

- `corepack yarn jest packages/react/src/utilities/decorators/withViewport.test.tsx --config packages/react/jest.config.js --runInBand --no-cache`
- `corepack yarn jest packages/utilities/src/dom/getRect.test.ts --config packages/utilities/jest.config.js --runInBand --no-cache`
- `corepack yarn nx run react:lint --skipNxCache`
- `corepack yarn nx run utilities:lint --skipNxCache` (passes with two pre-existing warnings in unrelated files)
- `corepack yarn beachball check --branch origin/master`
- real Chromium popup verification: the viewport measured 712px after moving, then updated to 924px when the popup viewport was resized to 940px
- full utilities Jest suite passes locally
- full React Jest suite passes except for two existing `TimePicker` assertions which expect English-formatted time; this machine uses the `zh-CN` locale (`8:30:00` / `下午5:00:00`)

Fixes #35437
