### PR TITLE
chore: add Yarn Nx command plugin

### DIFF
--- a/.yarn/plugins/@fluentui/plugin-nx.cjs
+++ b/.yarn/plugins/@fluentui/plugin-nx.cjs
@@ -1,0 +1,38 @@
+module.exports = {
+  name: '@fluentui/plugin-nx',
+  factory: require => {
+    const { BaseCommand } = require('@yarnpkg/cli');
+    const { Configuration, Project, scriptUtils } = require('@yarnpkg/core');
+    const { Option } = require('clipanion');
+
+    class NxCommand extends BaseCommand {
+      static paths = [['nx']];
+
+      args = Option.Proxy();
+
+      async execute() {
+        const configuration = await Configuration.find(this.context.cwd, this.context.plugins);
+        const { project } = await Project.find(configuration, this.context.cwd);
+
+        await project.restoreInstallState();
+
+        return scriptUtils.executePackageAccessibleBinary(
+          project.topLevelWorkspace.anchoredLocator,
+          'nx',
+          this.args,
+          {
+            cwd: this.context.cwd,
+            project,
+            stdin: this.context.stdin,
+            stdout: this.context.stdout,
+            stderr: this.context.stderr,
+          },
+        );
+      }
+    }
+
+    return {
+      commands: [NxCommand],
+    };
+  },
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
 nodeLinker: node-modules
 
+plugins:
+  - path: .yarn/plugins/@fluentui/plugin-nx.cjs
+    spec: '@fluentui/plugin-nx'
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
## Summary
- register a repository-local Yarn plugin for the `nx` command
- resolve and execute the root workspace Nx binary from any workspace
- preserve stdin, stdout, stderr, cwd, and exit status when forwarding commands

## Test Plan
- [x] Run `yarn nx --version` from `packages/react-components/react-button`
- [x] Run `yarn nx show project react-button --json` from the component workspace
- [x] Run Nx format checks for the plugin and Yarn configuration