### PR TITLE
fix(react-charts): prevent Vega prototype pollution

### DIFF
--- a/change/@fluentui-react-charts-ef77c3a0-c336-4aa7-9d69-a025dce9b65a.json
+++ b/change/@fluentui-react-charts-ef77c3a0-c336-4aa7-9d69-a025dce9b65a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Safely handle schema-derived keys when transforming Vega chart data.",
+  "packageName": "@fluentui/react-charts",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
@@ -49,6 +49,7 @@ import type {
 import { CartesianChart, Legends, getColorFromToken } from '../../index';
 import { tokens } from '@fluentui/react-theme';
 import { useImageExport } from '../../utilities/hooks';
+import { createSafeRecord } from '../../utilities/createSafeRecord';
 import { isInvalidValue } from '@fluentui/chart-utilities';
 
 type NumericScale = ScaleLinear<number, number>;
@@ -95,7 +96,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   let _xAxisOuterPadding: number = 0;
   let _barLegends: string[] = [];
   let _lineLegends: string[] = [];
-  let _legendColorMap: Record<string, [string, string]> = {};
+  let _legendColorMap = createSafeRecord<[string, string]>();
   const { cartesianChartRef, legendsRef: _legendsRef } = useImageExport(props.componentRef, props.hideLegend);
   const Y_ORIGIN: number = 0;
   const _rectRef = React.useRef<SVGRectElement>(null);
@@ -141,7 +142,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const datasetForBars: any = [];
 
-    const linePointsByX: Record<string, YValueHover[]> = {};
+    const linePointsByX = createSafeRecord<YValueHover[]>();
     const visitedX = new Set<string>();
     lineData.forEach(series => {
       series.data.forEach(point => {
@@ -160,8 +161,8 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
 
     barData.forEach((point: GroupedVerticalBarChartData, index: number) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const singleDatasetPointForBars: any = {};
-      const legendToBarPoint: Record<string, GVBarChartSeriesPoint> = {};
+      const singleDatasetPointForBars: any = createSafeRecord<unknown>();
+      const legendToBarPoint = createSafeRecord<GVBarChartSeriesPoint>();
 
       point.series.forEach((seriesPoint: GVBarChartSeriesPoint) => {
         if (!singleDatasetPointForBars[seriesPoint.legend]) {
@@ -265,7 +266,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _processDataV2 = (dataV2: (BarSeries<string, number> | LineSeries<string, number>)[]) => {
-    const barPointsByX: Record<string, GroupedVerticalBarChartData> = {};
+    const barPointsByX = createSafeRecord<GroupedVerticalBarChartData>();
     const lineData: GVBCLineSeries[] = [];
 
     dataV2.forEach(series => {
@@ -303,7 +304,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
       ({ barData, lineData } = _processDataV2(props.dataV2));
     }
 
-    _legendColorMap = {};
+    _legendColorMap = createSafeRecord<[string, string]>();
     let colorIndex = 0;
 
     return {
@@ -360,7 +361,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _mapCategoryToValues = (barData: GroupedVerticalBarChartData[], lineData: GVBCLineSeries[]) => {
-    const categoryToValues: Record<string, number[]> = {};
+    const categoryToValues = createSafeRecord<number[]>();
     barData.forEach(point => {
       if (!categoryToValues[point.name]) {
         categoryToValues[point.name] = [];

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
@@ -1246,6 +1246,43 @@ describe('VegaDeclarativeChart - More Heatmap Charts', () => {
 });
 
 describe('VegaDeclarativeChart - Security', () => {
+  it('renders grouped chart data with special keys without prototype pollution', () => {
+    const prototype = Object.prototype as Record<string, unknown>;
+    const probeKey = '__fluentuiPrototypePollutionProbe';
+    delete prototype[probeKey];
+
+    const maliciousSpec: VegaLiteSpec = {
+      mark: 'bar',
+      data: {
+        values: [
+          { category: '__proto__', value: 1, series: probeKey },
+          { category: 'constructor', value: 2, series: '__proto__' },
+          { category: 'prototype', value: 3, series: 'constructor' },
+        ],
+      },
+      encoding: {
+        x: { field: 'category', type: 'nominal' },
+        y: { field: 'value', type: 'quantitative' },
+        color: { field: 'series', type: 'nominal' },
+        xOffset: { field: 'series' },
+      },
+    };
+
+    try {
+      const { getAllByRole } = render(<VegaDeclarativeChart chartSchema={{ vegaLiteSpec: maliciousSpec }} />);
+
+      expect(Object.prototype.hasOwnProperty.call(prototype, probeKey)).toBe(false);
+      for (const legend of [probeKey, '__proto__', 'constructor']) {
+        const legendButton = getAllByRole('option').find(button => button.textContent === legend);
+        const colorSwatch = legendButton?.querySelector<HTMLElement>('[style*="background-color"]');
+
+        expect(colorSwatch?.style.backgroundColor).toBeTruthy();
+      }
+    } finally {
+      delete prototype[probeKey];
+    }
+  });
+
   it('blocks malicious calculate expression (MSRC PoC: globalThis assignment)', () => {
     // Exact payload from the MSRC vulnerability report
     const maliciousSpec: VegaLiteSpec = {

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
@@ -41,6 +41,7 @@ import type {
   ScatterPolarSeries,
   LineChartLineOptions,
 } from '../../types/index';
+import { createSafeRecord } from '../../utilities/createSafeRecord';
 import type { ColorFillBarsProps } from '../LineChart/index';
 import type { Legend, LegendsProps } from '../Legends/index';
 import type { TitleStyles } from '../../utilities/Common.styles';
@@ -2396,7 +2397,7 @@ export function transformVegaLiteToVerticalStackedBarChartProps(
   const { colorScheme, colorRange } = extractColorConfig(encoding);
 
   // Group data by x value, then by color (stack)
-  const mapXToDataPoints: { [key: string]: VerticalStackedChartProps } = {};
+  const mapXToDataPoints = createSafeRecord<VerticalStackedChartProps>();
   const colorIndex = new Map<string, number>();
   let currentColorIndex = 0;
 
@@ -2757,7 +2758,7 @@ export function transformVegaLiteToGroupedVerticalBarChartProps(
   const { colorScheme, colorRange } = extractColorConfig(encoding);
 
   // Group data by x value (name), then by color (series)
-  const groupedData: { [key: string]: { [legend: string]: number } } = {};
+  const groupedData = createSafeRecord<Record<string, number>>();
   const colorIndex = new Map<string, number>();
   let currentColorIndex = 0;
 
@@ -2774,7 +2775,7 @@ export function transformVegaLiteToGroupedVerticalBarChartProps(
     const legend = String(groupValue);
 
     if (!groupedData[xKey]) {
-      groupedData[xKey] = {};
+      groupedData[xKey] = createSafeRecord<number>();
     }
 
     groupedData[xKey][legend] = yValue;
@@ -3105,7 +3106,7 @@ export function transformVegaLiteToScatterChartProps(
   }
 
   // Group data by series (color encoding)
-  const groupedData: Record<string, Array<Record<string, unknown>>> = {};
+  const groupedData = createSafeRecord<Array<Record<string, unknown>>>();
 
   dataValues.forEach(row => {
     const seriesName = colorField && row[colorField] !== undefined ? String(row[colorField]) : 'default';

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
@@ -3,6 +3,9 @@ import {
   transformVegaLiteToVerticalBarChartProps,
   transformVegaLiteToHistogramProps,
   transformVegaLiteToPolarChartProps,
+  transformVegaLiteToGroupedVerticalBarChartProps,
+  transformVegaLiteToVerticalStackedBarChartProps,
+  transformVegaLiteToScatterChartProps,
   getVegaLiteLegendsProps,
   getVegaLiteTitles,
 } from './VegaLiteSchemaAdapter';
@@ -1456,6 +1459,119 @@ describe('VegaLiteSchemaAdapter', () => {
 
       expect(pointA?.y).toBe(20); // (10 + 20 + 30) / 3
       expect(pointB?.y).toBe(20); // (15 + 25) / 2
+    });
+  });
+
+  describe('Special Key Security', () => {
+    test('does not mutate Object.prototype for special category keys', () => {
+      const prototype = Object.prototype as Record<string, unknown>;
+      const probeKey = '__fluentuiPrototypePollutionProbe';
+      delete prototype[probeKey];
+
+      const spec: VegaLiteSpec = {
+        mark: 'bar',
+        data: {
+          values: [
+            { category: '__proto__', value: 1, series: probeKey },
+            { category: 'constructor', value: 2, series: '__proto__' },
+            { category: 'prototype', value: 3, series: 'constructor' },
+          ],
+        },
+        encoding: {
+          x: { field: 'category', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+          color: { field: 'series', type: 'nominal' },
+          xOffset: { field: 'series' },
+        },
+      };
+
+      try {
+        const props = transformVegaLiteToGroupedVerticalBarChartProps(spec, { current: colorMap }, false);
+
+        expect(Object.prototype.hasOwnProperty.call(prototype, probeKey)).toBe(false);
+        expect(props.data).toEqual([
+          {
+            name: '__proto__',
+            series: [
+              expect.objectContaining({
+                key: probeKey,
+                legend: probeKey,
+                data: 1,
+              }),
+            ],
+          },
+          {
+            name: 'constructor',
+            series: [
+              expect.objectContaining({
+                key: '__proto__',
+                legend: '__proto__',
+                data: 2,
+              }),
+            ],
+          },
+          {
+            name: 'prototype',
+            series: [
+              expect.objectContaining({
+                key: 'constructor',
+                legend: 'constructor',
+                data: 3,
+              }),
+            ],
+          },
+        ]);
+      } finally {
+        delete prototype[probeKey];
+      }
+    });
+
+    test('handles special category keys in stacked bar data', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'bar',
+        data: {
+          values: [
+            { category: '__proto__', value: 1, series: 'A' },
+            { category: 'constructor', value: 2, series: 'B' },
+          ],
+        },
+        encoding: {
+          x: { field: 'category', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+          color: { field: 'series', type: 'nominal' },
+        },
+      };
+
+      const props = transformVegaLiteToVerticalStackedBarChartProps(spec, { current: colorMap }, false);
+
+      expect(props.data).toEqual([
+        expect.objectContaining({ xAxisPoint: '__proto__' }),
+        expect.objectContaining({ xAxisPoint: 'constructor' }),
+      ]);
+    });
+
+    test('handles special series keys in scatter data', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'point',
+        data: {
+          values: [
+            { x: 1, y: 2, series: '__proto__' },
+            { x: 3, y: 4, series: 'constructor' },
+          ],
+        },
+        encoding: {
+          x: { field: 'x', type: 'quantitative' },
+          y: { field: 'y', type: 'quantitative' },
+          color: { field: 'series', type: 'nominal' },
+        },
+      };
+
+      const props = transformVegaLiteToScatterChartProps(spec, { current: colorMap }, false);
+
+      expect(props.data.scatterChartData).toEqual([
+        expect.objectContaining({ legend: '__proto__' }),
+        expect.objectContaining({ legend: 'constructor' }),
+      ]);
     });
   });
 });

--- a/packages/charts/react-charts/library/src/utilities/createSafeRecord.ts
+++ b/packages/charts/react-charts/library/src/utilities/createSafeRecord.ts
@@ -1,0 +1,1 @@
+export const createSafeRecord = <T>(): Record<string, T> => Object.create(null) as Record<string, T>;


### PR DESCRIPTION
## Summary

- prevent schema-derived grouped Vega keys from writing through inherited object properties
- use null-prototype records for downstream category and legend lookups so special labels render safely
- add adapter and public-component regression coverage for `__proto__`, `constructor`, and `prototype` values