### PR TITLE
ci(dependabot): cap npm rollups at 11 for minor + patch

### DIFF
--- a/.agents/skills/dependabot-rollup/SKILL.md
+++ b/.agents/skills/dependabot-rollup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dependabot-rollup
 description: >-
-  Review and optionally combine open Dependabot patch and minor pull requests into a validated draft rollup PR. Use this skill to test Dependabot bundling locally or in a cloud agent without adding a scheduled GitHub Actions workflow. Always presents a dry-run plan and requires explicit approval before changing branches or GitHub pull requests.
+  Review and optionally combine at most 11 open Dependabot patch and minor pull requests into a validated draft rollup PR. Use this skill to test Dependabot bundling locally or in a cloud agent without adding a scheduled GitHub Actions workflow. Always presents a dry-run plan and requires explicit approval before changing branches or GitHub pull requests.
 disable-model-invocation: true
 argument-hint: '[--repo owner/repo] [--base branch] [--max count] [--push-remote remote]'
 allowed-tools: Bash Read Grep Glob
@@ -17,10 +17,10 @@ Build a reviewable rollup of compatible Dependabot updates without scheduled aut
 | --------------- | ---------------------------------- | --------------------------------------------- |
 | `--repo`        | `microsoft/fluentui`               | Repository containing the Dependabot PRs      |
 | `--base`        | `master`                           | Base branch for discovery and the rollup      |
-| `--max`         | `11`                               | Maximum eligible PRs in one proposed rollup   |
+| `--max`         | `11`                               | Eligible PR limit, from 1 through 11          |
 | `--push-remote` | Current branch's configured remote | Writable fork remote used only after approval |
 
-Parse overrides from `$ARGUMENTS`. Reject an invalid repository name, a non-positive integer for `--max`, an unknown Git remote, or unknown arguments instead of guessing.
+Parse overrides from `$ARGUMENTS`. Reject an invalid repository name, a `--max` value that is not an integer from 1 through 11, an unknown Git remote, or unknown arguments instead of guessing. The value 11 is an absolute ceiling, not only the default.
 
 ## Workflow
 
@@ -197,6 +197,7 @@ Report:
 - Never run on a schedule or add a GitHub Actions workflow.
 - Never request or print a GitHub token; use the user's existing `gh` authentication.
 - Never include semver-major, non-semver, downgrade, or unparseable updates.
+- Never propose, merge, or publish a rollup containing more than 11 updates.
 - Never include more than one PR for the same dependency in a proposed rollup.
 - Never mutate the user's current working tree.
 - Never auto-resolve merge conflicts or bypass failed validation.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
           - 'minor'
           - 'patch'
 
-  # npm dependencies - weekly minor and patch updates grouped by dependency type
+  # npm dependencies - weekly minor and patch updates
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -21,25 +21,6 @@ updates:
     open-pull-requests-limit: 6
     versioning-strategy: increase
     ignore:
-      # Ignore major version bumps for all npm dependencies in weekly updates
+      # Ignore major version bumps for scheduled npm version updates
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
-    groups:
-      npm-security-updates:
-        applies-to: security-updates
-        patterns:
-          - '*'
-      npm-dev-minor-patch:
-        dependency-type: 'development'
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-      npm-prod-minor-patch:
-        dependency-type: 'production'
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'

--- a/.github/instructions/dependabot-security-fixes.instructions.md
+++ b/.github/instructions/dependabot-security-fixes.instructions.md
@@ -10,24 +10,28 @@ This instruction guide explains how Dependabot automation works for security fix
 
 Dependabot is configured to automatically create pull requests for:
 
-1. **Security updates** - Advisory-driven updates grouped into consolidated npm pull requests
-2. **npm dependencies** - Weekly minor and patch updates grouped by dependency type
+1. **Security updates** - Advisory-driven npm pull requests created independently for each update
+2. **npm dependencies** - Weekly minor and patch version updates created as individual pull requests
 3. **GitHub Actions** - Weekly updates for workflow dependencies
 
 ## Configuration
 
 The Dependabot configuration is defined in `.github/dependabot.yml`:
 
-- **Production dependencies**: Weekly minor and patch version updates
-- **Development dependencies**: Weekly minor and patch version updates
+- **npm dependencies**: Weekly minor and patch version updates as individual pull requests
 - **GitHub Actions**: Weekly updates
-- **Security updates**: Grouped separately and not limited by the version update schedule
+- **Security updates**: Individual pull requests not limited by the version update schedule
+- **Rollups**: Maintainers can use `/dependabot-rollup` to combine at most 11 eligible non-major updates
+
+The repository's Advanced Security **Grouped security updates** setting must remain disabled. Dependabot does not support a maximum dependency count for automatic groups, so enabling that setting would bypass the 11-update rollup limit.
+
+The npm `open-pull-requests-limit` controls the number of scheduled version-update pull requests. It does not limit the number of dependencies in a pull request or change Dependabot's separate security-update pull request limit.
 
 ## Security Vulnerability Resolution
 
 ### Automatic Security Updates
 
-GitHub triggers automatic security updates independently of the configured version update schedule. The Dependabot configuration groups eligible npm security updates into consolidated pull requests, including fixes that require major version bumps.
+GitHub triggers automatic security updates independently of the configured version update schedule. Each npm security update remains a separate pull request. Major security remediations are never included in `/dependabot-rollup`, so compatibility work stays isolated for focused review.
 
 ### Manual Resolution via Yarn Resolutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ state.root.className = mergeClasses(
 | `visual-test`       | `/visual-test Name`  | Visually verify a component via Storybook + playwright-cli |
 | `review-pr`         | `/review-pr #123`    | Review a PR with confidence scoring and category checks    |
 | `triage-issues`     | `/triage-issues`     | Walk the Needs-Triage queue and recommend labels/assignee  |
-| `dependabot-rollup` | `/dependabot-rollup` | Dry-run and optionally roll up Dependabot patch/minor PRs  |
+| `dependabot-rollup` | `/dependabot-rollup` | Roll up at most 11 Dependabot patch/minor PRs              |
 
 ## Package Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,16 +91,16 @@ state.root.className = mergeClasses(
 
 ## Skills (Slash Commands)
 
-| Skill               | Command              | Purpose                                                    |
-| ------------------- | -------------------- | ---------------------------------------------------------- |
-| `v9-component`      | `/v9-component Name` | Scaffold a new v9 component with all required files        |
-| `change`            | `/change`            | Create beachball change file from current diff             |
-| `lint-check`        | `/lint-check [pkg]`  | Run lint, parse errors, and auto-fix common issues         |
-| `token-lookup`      | `/token-lookup val`  | Find the design token for a hardcoded CSS value            |
-| `package-info`      | `/package-info pkg`  | Quick lookup: path, deps, owner, tests, structure          |
-| `visual-test`       | `/visual-test Name`  | Visually verify a component via Storybook + playwright-cli |
-| `review-pr`         | `/review-pr #123`    | Review a PR with confidence scoring and category checks    |
-| `triage-issues`     | `/triage-issues`     | Walk the Needs-Triage queue and recommend labels/assignee  |
+| Skill               | Command              | Purpose                                                              |
+| ------------------- | -------------------- | -------------------------------------------------------------------- |
+| `v9-component`      | `/v9-component Name` | Scaffold a new v9 component with all required files                  |
+| `change`            | `/change`            | Create beachball change file from current diff                       |
+| `lint-check`        | `/lint-check [pkg]`  | Run lint, parse errors, and auto-fix common issues                   |
+| `token-lookup`      | `/token-lookup val`  | Find the design token for a hardcoded CSS value                      |
+| `package-info`      | `/package-info pkg`  | Quick lookup: path, deps, owner, tests, structure                    |
+| `visual-test`       | `/visual-test Name`  | Visually verify a component via Storybook + playwright-cli           |
+| `review-pr`         | `/review-pr #123`    | Review a PR with confidence scoring and category checks              |
+| `triage-issues`     | `/triage-issues`     | Walk the Needs-Triage queue and recommend labels/assignee            |
 | `dependabot-rollup` | `/dependabot-rollup` | Dry-run and optionally roll up at most 11 Dependabot patch/minor PRs |
 
 ## Package Layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ state.root.className = mergeClasses(
 | `visual-test`       | `/visual-test Name`  | Visually verify a component via Storybook + playwright-cli |
 | `review-pr`         | `/review-pr #123`    | Review a PR with confidence scoring and category checks    |
 | `triage-issues`     | `/triage-issues`     | Walk the Needs-Triage queue and recommend labels/assignee  |
-| `dependabot-rollup` | `/dependabot-rollup` | Roll up at most 11 Dependabot patch/minor PRs              |
+| `dependabot-rollup` | `/dependabot-rollup` | Dry-run and optionally roll up at most 11 Dependabot patch/minor PRs |
 
 ## Package Layout
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Dependabot grouped npm security updates into a single pull request without restricting the update type. This allowed major version updates to be combined with minor and patch updates and could produce pull requests containing a large number of dependency updates.

## New Behavior

Dependabot creates npm updates as individual pull requests instead of automatically grouping them.

Scheduled major version updates remain ignored. Security updates that require a major version may still be created as individual pull requests, but they are excluded from `/dependabot-rollup`.

Maintainers can use `/dependabot-rollup` to combine compatible minor and patch updates. Rollups are limited to a maximum of 11 updates and never include major, downgrade, non-SemVer, or duplicate dependency updates.

## Related Issue(s)

- Fixes #36394