### PR TITLE
refactor: use direct headless render re-exports

### DIFF
--- a/change/@fluentui-react-headless-components-preview-78d9a769-948f-4241-add6-2555f911e203.json
+++ b/change/@fluentui-react-headless-components-preview-78d9a769-948f-4241-add6-2555f911e203.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: re-export headless render helpers",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
@@ -5,11 +5,11 @@
 ```ts
 
 import type { AvatarBaseProps } from '@fluentui/react-avatar';
-import { AvatarBaseState } from '@fluentui/react-avatar';
+import type { AvatarBaseState } from '@fluentui/react-avatar';
 import type { AvatarSlots as AvatarSlots_2 } from '@fluentui/react-avatar';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderAvatar_unstable as renderAvatar } from '@fluentui/react-avatar';
 
 // @public
 export const Avatar: ForwardRefComponent<AvatarProps>;
@@ -23,8 +23,7 @@ export type AvatarSlots = AvatarSlots_2;
 // @public
 export type AvatarState = AvatarBaseState;
 
-// @public
-export const renderAvatar: (state: AvatarBaseState) => JSXElement;
+export { renderAvatar }
 
 // @public
 export const useAvatar: (props: AvatarProps, ref: React_2.Ref<HTMLElement>) => AvatarState;

--- a/packages/react-components/react-headless-components-preview/library/etc/badge.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/badge.api.md
@@ -5,11 +5,11 @@
 ```ts
 
 import type { BadgeBaseProps } from '@fluentui/react-badge';
-import { BadgeBaseState } from '@fluentui/react-badge';
+import type { BadgeBaseState } from '@fluentui/react-badge';
 import type { BadgeSlots as BadgeSlots_2 } from '@fluentui/react-badge';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderBadge_unstable as renderBadge } from '@fluentui/react-badge';
 
 // @public
 export const Badge: ForwardRefComponent<BadgeProps>;
@@ -27,8 +27,7 @@ export type BadgeState = BadgeBaseState & {
     };
 };
 
-// @public
-export const renderBadge: (state: BadgeBaseState) => JSXElement;
+export { renderBadge }
 
 // @public
 export const useBadge: (props: BadgeProps, ref: React_2.Ref<HTMLDivElement>) => BadgeState;

--- a/packages/react-components/react-headless-components-preview/library/etc/breadcrumb.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/breadcrumb.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import type { BreadcrumbBaseProps } from '@fluentui/react-breadcrumb';
-import { BreadcrumbBaseState } from '@fluentui/react-breadcrumb';
+import type { BreadcrumbBaseState } from '@fluentui/react-breadcrumb';
 import type { BreadcrumbButtonBaseProps } from '@fluentui/react-breadcrumb';
 import type { BreadcrumbButtonBaseState } from '@fluentui/react-breadcrumb';
 import type { BreadcrumbButtonSlots as BreadcrumbButtonSlots_2 } from '@fluentui/react-breadcrumb';
@@ -20,6 +20,7 @@ import type { BreadcrumbSlots as BreadcrumbSlots_2 } from '@fluentui/react-bread
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderBreadcrumb_unstable as renderBreadcrumb } from '@fluentui/react-breadcrumb';
 
 // @public
 export const Breadcrumb: ForwardRefComponent<BreadcrumbProps>;
@@ -76,8 +77,7 @@ export type BreadcrumbSlots = BreadcrumbSlots_2;
 // @public
 export type BreadcrumbState = BreadcrumbBaseState;
 
-// @public
-export const renderBreadcrumb: (state: BreadcrumbBaseState, contextValues: BreadcrumbContextValues_2) => JSXElement;
+export { renderBreadcrumb }
 
 // @public
 export const renderBreadcrumbButton: (state: BreadcrumbButtonState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/card.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/card.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import type { CardBaseProps } from '@fluentui/react-card';
-import { CardBaseState } from '@fluentui/react-card';
+import type { CardBaseState } from '@fluentui/react-card';
 import { CardContextValue as CardContextValue_2 } from '@fluentui/react-card';
 import type { CardFooterBaseProps } from '@fluentui/react-card';
 import { CardFooterBaseState } from '@fluentui/react-card';
@@ -21,6 +21,7 @@ import type { CardSlots as CardSlots_2 } from '@fluentui/react-card';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderCard_unstable as renderCard } from '@fluentui/react-card';
 
 // @public
 export const Card: ForwardRefComponent<CardProps>;
@@ -80,8 +81,7 @@ export type CardState = CardBaseState & {
     };
 };
 
-// @public
-export const renderCard: (state: CardBaseState, cardContextValue: CardContextValue_2) => JSXElement;
+export { renderCard }
 
 // @public
 export const renderCardFooter: (state: CardFooterBaseState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/checkbox.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/checkbox.api.md
@@ -5,11 +5,11 @@
 ```ts
 
 import type { CheckboxBaseProps } from '@fluentui/react-checkbox';
-import { CheckboxBaseState } from '@fluentui/react-checkbox';
+import type { CheckboxBaseState } from '@fluentui/react-checkbox';
 import type { CheckboxSlots as CheckboxSlots_2 } from '@fluentui/react-checkbox';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderCheckbox_unstable as renderCheckbox } from '@fluentui/react-checkbox';
 
 // @public
 export const Checkbox: ForwardRefComponent<CheckboxProps>;
@@ -28,8 +28,7 @@ export type CheckboxState = CheckboxBaseState & {
     };
 };
 
-// @public
-export const renderCheckbox: (state: CheckboxBaseState) => JSXElement;
+export { renderCheckbox }
 
 // @public
 export const useCheckbox: (props: CheckboxProps, ref: React_2.Ref<HTMLInputElement>) => CheckboxState;

--- a/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
@@ -9,18 +9,21 @@ import type { BaseComboboxState } from '@fluentui/react-combobox';
 import { ComboboxContextValues } from '@fluentui/react-combobox';
 import { ComboboxSlots } from '@fluentui/react-combobox';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
-import { ListboxContextValues as ListboxContextValues_2 } from '@fluentui/react-combobox';
+import type { JSXElement } from '@fluentui/react-utilities';
+import type { ListboxContextValues as ListboxContextValues_2 } from '@fluentui/react-combobox';
 import type { ListboxProps as ListboxProps_2 } from '@fluentui/react-combobox';
 import type { ListboxSlots as ListboxSlots_2 } from '@fluentui/react-combobox';
-import { ListboxState as ListboxState_2 } from '@fluentui/react-combobox';
+import type { ListboxState as ListboxState_2 } from '@fluentui/react-combobox';
 import type { OptionGroupProps as OptionGroupProps_2 } from '@fluentui/react-combobox';
 import type { OptionGroupSlots as OptionGroupSlots_2 } from '@fluentui/react-combobox';
-import { OptionGroupState as OptionGroupState_2 } from '@fluentui/react-combobox';
+import type { OptionGroupState as OptionGroupState_2 } from '@fluentui/react-combobox';
 import type { OptionProps as OptionProps_2 } from '@fluentui/react-combobox';
 import type { OptionSlots as OptionSlots_2 } from '@fluentui/react-combobox';
-import { OptionState as OptionState_2 } from '@fluentui/react-combobox';
+import type { OptionState as OptionState_2 } from '@fluentui/react-combobox';
 import type * as React_2 from 'react';
+import { renderListbox_unstable as renderListbox } from '@fluentui/react-combobox';
+import { renderOption_unstable as renderOption } from '@fluentui/react-combobox';
+import { renderOptionGroup_unstable as renderOptionGroup } from '@fluentui/react-combobox';
 
 // @public (undocumented)
 export const Combobox: ForwardRefComponent<ComboboxProps>;
@@ -87,14 +90,11 @@ export type OptionState = OptionState_2 & {
 // @public (undocumented)
 export const renderCombobox: (state: ComboboxState, contextValues: ComboboxContextValues) => JSXElement;
 
-// @public
-export const renderListbox: (state: ListboxState_2, contextValues: ListboxContextValues_2) => JSXElement;
+export { renderListbox }
 
-// @public
-export const renderOption: (state: OptionState_2) => JSXElement;
+export { renderOption }
 
-// @public
-export const renderOptionGroup: (state: OptionGroupState_2) => JSXElement;
+export { renderOptionGroup }
 
 // @public (undocumented)
 export const useCombobox: (props: ComboboxProps, ref: React_2.Ref<HTMLInputElement>) => ComboboxState;

--- a/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
@@ -8,18 +8,21 @@ import type { DropdownBaseHookProps } from '@fluentui/react-combobox';
 import type { DropdownBaseHookState } from '@fluentui/react-combobox';
 import { DropdownContextValues } from '@fluentui/react-combobox';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
-import { ListboxContextValues as ListboxContextValues_2 } from '@fluentui/react-combobox';
+import type { JSXElement } from '@fluentui/react-utilities';
+import type { ListboxContextValues as ListboxContextValues_2 } from '@fluentui/react-combobox';
 import type { ListboxProps as ListboxProps_2 } from '@fluentui/react-combobox';
 import type { ListboxSlots as ListboxSlots_2 } from '@fluentui/react-combobox';
-import { ListboxState as ListboxState_2 } from '@fluentui/react-combobox';
+import type { ListboxState as ListboxState_2 } from '@fluentui/react-combobox';
 import type { OptionGroupProps as OptionGroupProps_2 } from '@fluentui/react-combobox';
 import type { OptionGroupSlots as OptionGroupSlots_2 } from '@fluentui/react-combobox';
-import { OptionGroupState as OptionGroupState_2 } from '@fluentui/react-combobox';
+import type { OptionGroupState as OptionGroupState_2 } from '@fluentui/react-combobox';
 import type { OptionProps as OptionProps_2 } from '@fluentui/react-combobox';
 import type { OptionSlots as OptionSlots_2 } from '@fluentui/react-combobox';
-import { OptionState as OptionState_2 } from '@fluentui/react-combobox';
+import type { OptionState as OptionState_2 } from '@fluentui/react-combobox';
 import type * as React_2 from 'react';
+import { renderListbox_unstable as renderListbox } from '@fluentui/react-combobox';
+import { renderOption_unstable as renderOption } from '@fluentui/react-combobox';
+import { renderOptionGroup_unstable as renderOptionGroup } from '@fluentui/react-combobox';
 
 // @public
 export const Dropdown: ForwardRefComponent<DropdownProps>;
@@ -84,14 +87,11 @@ export type OptionState = OptionState_2 & {
 // @public
 export const renderDropdown: (state: DropdownState, contextValues: DropdownContextValues) => JSXElement;
 
-// @public
-export const renderListbox: (state: ListboxState_2, contextValues: ListboxContextValues_2) => JSXElement;
+export { renderListbox }
 
-// @public
-export const renderOption: (state: OptionState_2) => JSXElement;
+export { renderOption }
 
-// @public
-export const renderOptionGroup: (state: OptionGroupState_2) => JSXElement;
+export { renderOptionGroup }
 
 // @public
 export const useDropdown: (props: DropdownProps, ref: React_2.Ref<HTMLButtonElement>) => DropdownState;

--- a/packages/react-components/react-headless-components-preview/library/etc/field.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/field.api.md
@@ -5,12 +5,12 @@
 ```ts
 
 import type { FieldBaseProps } from '@fluentui/react-field';
-import { FieldBaseState } from '@fluentui/react-field';
-import { FieldContextValues } from '@fluentui/react-field';
+import type { FieldBaseState } from '@fluentui/react-field';
+import type { FieldContextValues as FieldContextValues_2 } from '@fluentui/react-field';
 import type { FieldSlots as FieldSlots_2 } from '@fluentui/react-field';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderField_unstable as renderField } from '@fluentui/react-field';
 
 // @public
 export const Field: ForwardRefComponent<FieldProps>;
@@ -28,14 +28,13 @@ export type FieldState = FieldBaseState & {
     };
 };
 
-// @public
-export const renderField: (state: FieldBaseState, contextValues: FieldContextValues) => JSXElement;
+export { renderField }
 
 // @public
 export const useField: (props: FieldProps, ref: React_2.Ref<HTMLDivElement>) => FieldState;
 
 // @public
-export const useFieldContextValues: (state: FieldState) => FieldContextValues_2;
+export const useFieldContextValues: (state: FieldState) => FieldContextValues;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/input.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/input.api.md
@@ -6,10 +6,10 @@
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { InputBaseProps } from '@fluentui/react-input';
-import { InputBaseState } from '@fluentui/react-input';
+import type { InputBaseState } from '@fluentui/react-input';
 import type { InputSlots as InputSlots_2 } from '@fluentui/react-input';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderInput_unstable as renderInput } from '@fluentui/react-input';
 
 // @public
 export const Input: ForwardRefComponent<InputProps>;
@@ -27,8 +27,7 @@ export type InputState = InputBaseState & {
     };
 };
 
-// @public
-export const renderInput: (state: InputBaseState) => JSXElement;
+export { renderInput }
 
 // @public
 export const useInput: (props: InputProps, ref: React_2.Ref<HTMLInputElement>) => InputState;

--- a/packages/react-components/react-headless-components-preview/library/etc/link.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/link.api.md
@@ -5,11 +5,11 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type { LinkBaseProps } from '@fluentui/react-link';
-import { LinkBaseState } from '@fluentui/react-link';
+import type { LinkBaseState } from '@fluentui/react-link';
 import type { LinkSlots as LinkSlots_2 } from '@fluentui/react-link';
 import type * as React_2 from 'react';
+import { renderLink_unstable as renderLink } from '@fluentui/react-link';
 
 // @public
 export const Link: ForwardRefComponent<LinkProps>;
@@ -28,8 +28,7 @@ export type LinkState = LinkBaseState & {
     };
 };
 
-// @public
-export const renderLink: (state: LinkBaseState) => JSXElement;
+export { renderLink }
 
 // @public
 export const useLink: (props: LinkProps, ref: React_2.Ref<HTMLElement>) => LinkState;

--- a/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
@@ -6,16 +6,17 @@
 
 import { ComponentProps } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type { RadioBaseProps } from '@fluentui/react-radio';
-import { RadioBaseState } from '@fluentui/react-radio';
+import type { RadioBaseState } from '@fluentui/react-radio';
 import type { RadioGroupBaseProps } from '@fluentui/react-radio';
-import { RadioGroupBaseState } from '@fluentui/react-radio';
-import { RadioGroupContextValues } from '@fluentui/react-radio';
+import type { RadioGroupBaseState } from '@fluentui/react-radio';
+import type { RadioGroupContextValues as RadioGroupContextValues_2 } from '@fluentui/react-radio';
 import type { RadioGroupSlots as RadioGroupSlots_2 } from '@fluentui/react-radio';
 import { RadioOnChangeData } from '@fluentui/react-radio';
 import { RadioSlots as RadioSlots_2 } from '@fluentui/react-radio';
 import * as React_2 from 'react';
+import { renderRadio_unstable as renderRadio } from '@fluentui/react-radio';
+import { renderRadioGroup_unstable as renderRadioGroup } from '@fluentui/react-radio';
 
 // @public
 export const Radio: React_2.ForwardRefExoticComponent<Omit<ComponentProps<Partial<RadioSlots_2>, "input">, "onChange" | "size"> & {
@@ -50,11 +51,9 @@ export type RadioState = RadioBaseState & {
     };
 };
 
-// @public
-export const renderRadio: (state: RadioBaseState) => JSXElement;
+export { renderRadio }
 
-// @public
-export const renderRadioGroup: (state: RadioGroupBaseState, contextValues: RadioGroupContextValues) => JSXElement;
+export { renderRadioGroup }
 
 // @public
 export const useRadio: (props: RadioProps, ref: React_2.Ref<HTMLInputElement>) => RadioState;
@@ -63,7 +62,7 @@ export const useRadio: (props: RadioProps, ref: React_2.Ref<HTMLInputElement>) =
 export const useRadioGroup: (props: RadioGroupProps, ref: React_2.Ref<HTMLDivElement>) => RadioGroupState;
 
 // @public (undocumented)
-export const useRadioGroupContextValues: (state: RadioGroupState) => RadioGroupContextValues_2;
+export const useRadioGroupContextValues: (state: RadioGroupState) => RadioGroupContextValues;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/rating-display.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/rating-display.api.md
@@ -5,12 +5,12 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type { RatingDisplayBaseProps } from '@fluentui/react-rating';
-import { RatingDisplayBaseState } from '@fluentui/react-rating';
-import { RatingDisplayContextValues } from '@fluentui/react-rating';
+import type { RatingDisplayBaseState } from '@fluentui/react-rating';
+import type { RatingDisplayContextValues as RatingDisplayContextValues_2 } from '@fluentui/react-rating';
 import type { RatingDisplaySlots as RatingDisplaySlots_2 } from '@fluentui/react-rating';
 import * as React_2 from 'react';
+import { renderRatingDisplay_unstable as renderRatingDisplay } from '@fluentui/react-rating';
 
 // @public
 export const RatingDisplay: ForwardRefComponent<RatingDisplayProps>;
@@ -24,14 +24,13 @@ export type RatingDisplaySlots = RatingDisplaySlots_2;
 // @public
 export type RatingDisplayState = RatingDisplayBaseState;
 
-// @public
-export const renderRatingDisplay: (state: RatingDisplayBaseState, contextValues: RatingDisplayContextValues) => JSXElement;
+export { renderRatingDisplay }
 
 // @public
 export const useRatingDisplay: (props: RatingDisplayProps, ref: React_2.Ref<HTMLDivElement>) => RatingDisplayState;
 
 // @public (undocumented)
-export const useRatingDisplayContextValues: (state: RatingDisplayState) => RatingDisplayContextValues_2;
+export const useRatingDisplayContextValues: (state: RatingDisplayState) => RatingDisplayContextValues;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/rating.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/rating.api.md
@@ -5,15 +5,16 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type { RatingBaseProps } from '@fluentui/react-rating';
-import { RatingBaseState } from '@fluentui/react-rating';
-import { RatingContextValues } from '@fluentui/react-rating';
+import type { RatingBaseState } from '@fluentui/react-rating';
+import type { RatingContextValues as RatingContextValues_2 } from '@fluentui/react-rating';
 import type { RatingItemBaseProps } from '@fluentui/react-rating';
-import { RatingItemBaseState } from '@fluentui/react-rating';
+import type { RatingItemBaseState } from '@fluentui/react-rating';
 import { RatingItemSlots as RatingItemSlots_2 } from '@fluentui/react-rating';
 import type { RatingSlots as RatingSlots_2 } from '@fluentui/react-rating';
 import * as React_2 from 'react';
+import { renderRating_unstable as renderRating } from '@fluentui/react-rating';
+import { renderRatingItem_unstable as renderRatingItem } from '@fluentui/react-rating';
 
 // @public
 export const Rating: ForwardRefComponent<RatingProps>;
@@ -49,17 +50,15 @@ export type RatingSlots = RatingSlots_2;
 // @public
 export type RatingState = RatingBaseState;
 
-// @public
-export const renderRating: (state: RatingBaseState, contextValues: RatingContextValues) => JSXElement;
+export { renderRating }
 
-// @public
-export const renderRatingItem: (state: RatingItemBaseState) => JSXElement;
+export { renderRatingItem }
 
 // @public
 export const useRating: (props: RatingProps, ref: React_2.Ref<HTMLDivElement>) => RatingState;
 
 // @public (undocumented)
-export const useRatingContextValues: (state: RatingState) => RatingContextValues_2;
+export const useRatingContextValues: (state: RatingState) => RatingContextValues;
 
 // @public
 export const useRatingItem: (props: RatingItemProps, ref: React_2.Ref<HTMLSpanElement>) => RatingItemState;

--- a/packages/react-components/react-headless-components-preview/library/etc/search-box.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/search-box.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSearchBox_unstable as renderSearchBox } from '@fluentui/react-search';
 import type { SearchBoxBaseProps } from '@fluentui/react-search';
-import { SearchBoxBaseState } from '@fluentui/react-search';
+import type { SearchBoxBaseState } from '@fluentui/react-search';
 import type { SearchBoxSlots as SearchBoxSlots_2 } from '@fluentui/react-search';
 
-// @public
-export const renderSearchBox: (state: SearchBoxBaseState) => JSXElement;
+export { renderSearchBox }
 
 // @public
 export const SearchBox: ForwardRefComponent<SearchBoxProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/select.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/select.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSelect_unstable as renderSelect } from '@fluentui/react-select';
 import type { SelectBaseProps } from '@fluentui/react-select';
-import { SelectBaseState } from '@fluentui/react-select';
+import type { SelectBaseState } from '@fluentui/react-select';
 import type { SelectSlots as SelectSlots_2 } from '@fluentui/react-select';
 
-// @public
-export const renderSelect: (state: SelectBaseState) => JSXElement;
+export { renderSelect }
 
 // @public
 export const Select: ForwardRefComponent<SelectProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/skeleton.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/skeleton.api.md
@@ -4,21 +4,20 @@
 
 ```ts
 
-import { JSXElement } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
+import { renderSkeleton_unstable as renderSkeleton } from '@fluentui/react-skeleton';
+import { renderSkeletonItem_unstable as renderSkeletonItem } from '@fluentui/react-skeleton';
 import { SkeletonBaseProps } from '@fluentui/react-skeleton';
-import { SkeletonBaseState } from '@fluentui/react-skeleton';
-import { SkeletonContextValues } from '@fluentui/react-skeleton';
+import type { SkeletonBaseState } from '@fluentui/react-skeleton';
+import type { SkeletonContextValues as SkeletonContextValues_2 } from '@fluentui/react-skeleton';
 import { SkeletonItemBaseProps } from '@fluentui/react-skeleton';
-import { SkeletonItemBaseState } from '@fluentui/react-skeleton';
+import type { SkeletonItemBaseState } from '@fluentui/react-skeleton';
 import type { SkeletonItemSlots as SkeletonItemSlots_2 } from '@fluentui/react-skeleton';
 import type { SkeletonSlots as SkeletonSlots_2 } from '@fluentui/react-skeleton';
 
-// @public
-export const renderSkeleton: (state: SkeletonBaseState, contextValues: SkeletonContextValues) => JSXElement;
+export { renderSkeleton }
 
-// @public
-export const renderSkeletonItem: (state: SkeletonItemBaseState) => JSXElement;
+export { renderSkeletonItem }
 
 // @public
 export const Skeleton: React_2.ForwardRefExoticComponent<SkeletonBaseProps & React_2.RefAttributes<HTMLDivElement>>;
@@ -48,7 +47,7 @@ export type SkeletonState = SkeletonBaseState;
 export const useSkeleton: (props: SkeletonProps, ref: React_2.Ref<HTMLDivElement>) => SkeletonState;
 
 // @public
-export const useSkeletonContextValues: (state: SkeletonState) => SkeletonContextValues_2;
+export const useSkeletonContextValues: (state: SkeletonState) => SkeletonContextValues;
 
 // @public
 export const useSkeletonItem: (props: SkeletonItemProps, ref: React_2.Ref<HTMLDivElement>) => SkeletonItemState;

--- a/packages/react-components/react-headless-components-preview/library/etc/slider.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/slider.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSlider_unstable as renderSlider } from '@fluentui/react-slider';
 import type { SliderBaseProps } from '@fluentui/react-slider';
-import { SliderBaseState } from '@fluentui/react-slider';
+import type { SliderBaseState } from '@fluentui/react-slider';
 import type { SliderSlots as SliderSlots_2 } from '@fluentui/react-slider';
 
-// @public
-export const renderSlider: (state: SliderBaseState) => JSXElement;
+export { renderSlider }
 
 // @public
 export const Slider: ForwardRefComponent<SliderProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/spin-button.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/spin-button.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSpinButton_unstable as renderSpinButton } from '@fluentui/react-spinbutton';
 import type { SpinButtonBaseProps } from '@fluentui/react-spinbutton';
-import { SpinButtonBaseState } from '@fluentui/react-spinbutton';
+import type { SpinButtonBaseState } from '@fluentui/react-spinbutton';
 import type { SpinButtonSlots as SpinButtonSlots_2 } from '@fluentui/react-spinbutton';
 
-// @public
-export const renderSpinButton: (state: SpinButtonBaseState) => JSXElement;
+export { renderSpinButton }
 
 // @public
 export const SpinButton: ForwardRefComponent<SpinButtonProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/spinner.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/spinner.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSpinner_unstable as renderSpinner } from '@fluentui/react-spinner';
 import type { SpinnerBaseProps } from '@fluentui/react-spinner';
-import { SpinnerBaseState } from '@fluentui/react-spinner';
+import type { SpinnerBaseState } from '@fluentui/react-spinner';
 import type { SpinnerSlots as SpinnerSlots_2 } from '@fluentui/react-spinner';
 
-// @public
-export const renderSpinner: (state: SpinnerBaseState) => JSXElement;
+export { renderSpinner }
 
 // @public
 export const Spinner: ForwardRefComponent<SpinnerProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/switch.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/switch.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderSwitch_unstable as renderSwitch } from '@fluentui/react-switch';
 import type { SwitchBaseProps } from '@fluentui/react-switch';
-import { SwitchBaseState } from '@fluentui/react-switch';
+import type { SwitchBaseState } from '@fluentui/react-switch';
 import type { SwitchSlots as SwitchSlots_2 } from '@fluentui/react-switch';
 
-// @public
-export const renderSwitch: (state: SwitchBaseState) => JSXElement;
+export { renderSwitch }
 
 // @public
 export const Switch: ForwardRefComponent<SwitchProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
@@ -5,22 +5,21 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderTab_unstable as renderTab } from '@fluentui/react-tabs';
+import { renderTabList_unstable as renderTabList } from '@fluentui/react-tabs';
 import type { TabBaseProps } from '@fluentui/react-tabs';
-import { TabBaseState } from '@fluentui/react-tabs';
+import type { TabBaseState } from '@fluentui/react-tabs';
 import type { TabListBaseProps } from '@fluentui/react-tabs';
-import { TabListBaseState } from '@fluentui/react-tabs';
-import { TabListContextValues } from '@fluentui/react-tabs';
+import type { TabListBaseState } from '@fluentui/react-tabs';
+import type { TabListContextValues as TabListContextValues_2 } from '@fluentui/react-tabs';
 import type { TabListSlots as TabListSlots_2 } from '@fluentui/react-tabs';
 import { TabSlots } from '@fluentui/react-tabs';
 import { TabValue } from '@fluentui/react-tabs';
 
-// @public
-export const renderTab: (state: TabBaseState) => JSXElement;
+export { renderTab }
 
-// @public
-export const renderTabList: (state: TabListBaseState, contextValues: TabListContextValues) => JSXElement;
+export { renderTabList }
 
 // @public
 export const Tab: ForwardRefComponent<TabProps>;
@@ -65,7 +64,7 @@ export const useTab: (props: TabProps, ref: React_2.Ref<HTMLElement>) => TabStat
 export const useTabList: (props: TabListProps, ref: React_2.Ref<HTMLElement>) => TabListState;
 
 // @public (undocumented)
-export const useTabListContextValues: (state: TabListState) => TabListContextValues_2;
+export const useTabListContextValues: (state: TabListState) => TabListContextValues;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/textarea.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/textarea.api.md
@@ -5,14 +5,13 @@
 ```ts
 
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
+import { renderTextarea_unstable as renderTextarea } from '@fluentui/react-textarea';
 import type { TextareaBaseProps } from '@fluentui/react-textarea';
-import { TextareaBaseState } from '@fluentui/react-textarea';
+import type { TextareaBaseState } from '@fluentui/react-textarea';
 import type { TextareaSlots as TextareaSlots_2 } from '@fluentui/react-textarea';
 
-// @public
-export const renderTextarea: (state: TextareaBaseState) => JSXElement;
+export { renderTextarea }
 
 // @public
 export const Textarea: ForwardRefComponent<TextareaProps>;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/renderAvatar.tsx
@@ -1,6 +1,1 @@
-import { renderAvatar_unstable } from '@fluentui/react-avatar';
-
-/**
- * Renders the final JSX of the Avatar component, given the state.
- */
-export const renderAvatar = renderAvatar_unstable;
+export { renderAvatar_unstable as renderAvatar } from '@fluentui/react-avatar';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Badge/renderBadge.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Badge/renderBadge.tsx
@@ -1,6 +1,1 @@
-import { renderBadge_unstable } from '@fluentui/react-badge';
-
-/**
- * Renders the final JSX of the Badge component, given the state.
- */
-export const renderBadge = renderBadge_unstable;
+export { renderBadge_unstable as renderBadge } from '@fluentui/react-badge';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Breadcrumb/renderBreadcrumb.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Breadcrumb/renderBreadcrumb.tsx
@@ -1,6 +1,1 @@
-import { renderBreadcrumb_unstable } from '@fluentui/react-breadcrumb';
-
-/**
- * Renders the final JSX of the Breadcrumb component, given the state and context values.
- */
-export const renderBreadcrumb = renderBreadcrumb_unstable;
+export { renderBreadcrumb_unstable as renderBreadcrumb } from '@fluentui/react-breadcrumb';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Card/renderCard.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Card/renderCard.tsx
@@ -1,6 +1,1 @@
-import { renderCard_unstable } from '@fluentui/react-card';
-
-/**
- * Renders the final JSX of the Card component, given the state and context value.
- */
-export const renderCard = renderCard_unstable;
+export { renderCard_unstable as renderCard } from '@fluentui/react-card';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/renderCheckbox.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/renderCheckbox.tsx
@@ -1,6 +1,1 @@
-import { renderCheckbox_unstable } from '@fluentui/react-checkbox';
-
-/**
- * Render the final JSX of Checkbox
- */
-export const renderCheckbox = renderCheckbox_unstable;
+export { renderCheckbox_unstable as renderCheckbox } from '@fluentui/react-checkbox';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/renderListbox.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/renderListbox.tsx
@@ -1,6 +1,1 @@
-import { renderListbox_unstable } from '@fluentui/react-combobox';
-
-/**
- * Renders the final JSX of the Listbox component, given the state and context values.
- */
-export const renderListbox = renderListbox_unstable;
+export { renderListbox_unstable as renderListbox } from '@fluentui/react-combobox';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/renderOption.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/renderOption.tsx
@@ -1,6 +1,1 @@
-import { renderOption_unstable } from '@fluentui/react-combobox';
-
-/**
- * Renders the final JSX of the Option component, given the state.
- */
-export const renderOption = renderOption_unstable;
+export { renderOption_unstable as renderOption } from '@fluentui/react-combobox';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/OptionGroup/renderOptionGroup.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/OptionGroup/renderOptionGroup.tsx
@@ -1,6 +1,1 @@
-import { renderOptionGroup_unstable } from '@fluentui/react-combobox';
-
-/**
- * Renders the final JSX of the OptionGroup component, given the state.
- */
-export const renderOptionGroup = renderOptionGroup_unstable;
+export { renderOptionGroup_unstable as renderOptionGroup } from '@fluentui/react-combobox';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Field/renderField.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Field/renderField.tsx
@@ -1,6 +1,1 @@
-import { renderField_unstable } from '@fluentui/react-field';
-
-/**
- * Renders the final JSX of the Field component, given the state.
- */
-export const renderField = renderField_unstable;
+export { renderField_unstable as renderField } from '@fluentui/react-field';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Input/renderInput.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Input/renderInput.tsx
@@ -1,6 +1,1 @@
-import { renderInput_unstable } from '@fluentui/react-input';
-
-/**
- * Renders the final JSX of the Input component, given the state.
- */
-export const renderInput = renderInput_unstable;
+export { renderInput_unstable as renderInput } from '@fluentui/react-input';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Link/renderLink.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Link/renderLink.tsx
@@ -1,6 +1,1 @@
-import { renderLink_unstable } from '@fluentui/react-link';
-
-/**
- * Renders the final JSX of the Link component, given the state.
- */
-export const renderLink = renderLink_unstable;
+export { renderLink_unstable as renderLink } from '@fluentui/react-link';

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/renderRadio.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/renderRadio.tsx
@@ -1,6 +1,1 @@
-import { renderRadio_unstable } from '@fluentui/react-radio';
-
-/**
- * Renders the final JSX of the Radio component, given the state.
- */
-export const renderRadio = renderRadio_unstable;
+export { renderRadio_unstable as renderRadio } from '@fluentui/react-radio';

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/renderRadioGroup.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/renderRadioGroup.tsx
@@ -1,6 +1,1 @@
-import { renderRadioGroup_unstable } from '@fluentui/react-radio';
-
-/**
- * Renders the final JSX of the RadioGroup component, given the state.
- */
-export const renderRadioGroup = renderRadioGroup_unstable;
+export { renderRadioGroup_unstable as renderRadioGroup } from '@fluentui/react-radio';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Rating/RatingItem/renderRatingItem.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Rating/RatingItem/renderRatingItem.tsx
@@ -1,6 +1,1 @@
-import { renderRatingItem_unstable } from '@fluentui/react-rating';
-
-/**
- * Renders the final JSX of the RatingItem component, given the state.
- */
-export const renderRatingItem = renderRatingItem_unstable;
+export { renderRatingItem_unstable as renderRatingItem } from '@fluentui/react-rating';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Rating/renderRating.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Rating/renderRating.tsx
@@ -1,6 +1,1 @@
-import { renderRating_unstable } from '@fluentui/react-rating';
-
-/**
- * Renders the final JSX of the Rating component, given the state.
- */
-export const renderRating = renderRating_unstable;
+export { renderRating_unstable as renderRating } from '@fluentui/react-rating';

--- a/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/renderRatingDisplay.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RatingDisplay/renderRatingDisplay.tsx
@@ -1,6 +1,1 @@
-import { renderRatingDisplay_unstable } from '@fluentui/react-rating';
-
-/**
- * Renders the final JSX of the RatingDisplay component, given the state.
- */
-export const renderRatingDisplay = renderRatingDisplay_unstable;
+export { renderRatingDisplay_unstable as renderRatingDisplay } from '@fluentui/react-rating';

--- a/packages/react-components/react-headless-components-preview/library/src/components/SearchBox/renderSearchBox.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SearchBox/renderSearchBox.tsx
@@ -1,6 +1,1 @@
-import { renderSearchBox_unstable } from '@fluentui/react-search';
-
-/**
- * Renders the final JSX of the SearchBox component, given the state.
- */
-export const renderSearchBox = renderSearchBox_unstable;
+export { renderSearchBox_unstable as renderSearchBox } from '@fluentui/react-search';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Select/renderSelect.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Select/renderSelect.tsx
@@ -1,6 +1,1 @@
-import { renderSelect_unstable } from '@fluentui/react-select';
-
-/**
- * Render the final JSX of Select
- */
-export const renderSelect = renderSelect_unstable;
+export { renderSelect_unstable as renderSelect } from '@fluentui/react-select';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Skeleton/SkeletonItem/renderSkeletonItem.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Skeleton/SkeletonItem/renderSkeletonItem.tsx
@@ -1,6 +1,1 @@
-import { renderSkeletonItem_unstable } from '@fluentui/react-skeleton';
-
-/**
- * Renders the final JSX of the SkeletonItem component, given the state.
- */
-export const renderSkeletonItem = renderSkeletonItem_unstable;
+export { renderSkeletonItem_unstable as renderSkeletonItem } from '@fluentui/react-skeleton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Skeleton/renderSkeleton.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Skeleton/renderSkeleton.tsx
@@ -1,6 +1,1 @@
-import { renderSkeleton_unstable } from '@fluentui/react-skeleton';
-
-/**
- * Renders the final JSX of the Skeleton component, given the state.
- */
-export const renderSkeleton = renderSkeleton_unstable;
+export { renderSkeleton_unstable as renderSkeleton } from '@fluentui/react-skeleton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Slider/renderSlider.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Slider/renderSlider.tsx
@@ -1,6 +1,1 @@
-import { renderSlider_unstable } from '@fluentui/react-slider';
-
-/**
- * Renders the final JSX of the Slider component, given the state.
- */
-export const renderSlider = renderSlider_unstable;
+export { renderSlider_unstable as renderSlider } from '@fluentui/react-slider';

--- a/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/renderSpinButton.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/renderSpinButton.tsx
@@ -1,6 +1,1 @@
-import { renderSpinButton_unstable } from '@fluentui/react-spinbutton';
-
-/**
- * Renders the final JSX of the SpinButton component, given the state.
- */
-export const renderSpinButton = renderSpinButton_unstable;
+export { renderSpinButton_unstable as renderSpinButton } from '@fluentui/react-spinbutton';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Spinner/renderSpinner.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Spinner/renderSpinner.tsx
@@ -1,6 +1,1 @@
-import { renderSpinner_unstable } from '@fluentui/react-spinner';
-
-/**
- * Renders the final JSX of the Spinner component, given the state.
- */
-export const renderSpinner = renderSpinner_unstable;
+export { renderSpinner_unstable as renderSpinner } from '@fluentui/react-spinner';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Switch/renderSwitch.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Switch/renderSwitch.tsx
@@ -1,6 +1,1 @@
-import { renderSwitch_unstable } from '@fluentui/react-switch';
-
-/**
- * Renders the final JSX of the Switch component, given the state.
- */
-export const renderSwitch = renderSwitch_unstable;
+export { renderSwitch_unstable as renderSwitch } from '@fluentui/react-switch';

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/renderTab.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/renderTab.tsx
@@ -1,6 +1,1 @@
-import { renderTab_unstable } from '@fluentui/react-tabs';
-
-/**
- * Renders the final JSX of the Tab component, given the state.
- */
-export const renderTab = renderTab_unstable;
+export { renderTab_unstable as renderTab } from '@fluentui/react-tabs';

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/renderTabList.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/renderTabList.tsx
@@ -1,6 +1,1 @@
-import { renderTabList_unstable } from '@fluentui/react-tabs';
-
-/**
- * Renders the final JSX of the TabList component, given the state.
- */
-export const renderTabList = renderTabList_unstable;
+export { renderTabList_unstable as renderTabList } from '@fluentui/react-tabs';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Textarea/renderTextarea.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Textarea/renderTextarea.tsx
@@ -1,6 +1,1 @@
-import { renderTextarea_unstable } from '@fluentui/react-textarea';
-
-/**
- * Renders the final JSX of the Textarea component, given the state.
- */
-export const renderTextarea = renderTextarea_unstable;
+export { renderTextarea_unstable as renderTextarea } from '@fluentui/react-textarea';


### PR DESCRIPTION
refactor render function imports in headless components to make it consistent with the rest components