### PR TITLE
make native disabled state support SSR better

### DIFF
--- a/change/@fluentui-web-components-a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c.json
+++ b/change/@fluentui-web-components-a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make native disabled state support SSR better",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/button/button.styles.css
+++ b/packages/web-components/src/button/button.styles.css
@@ -213,33 +213,60 @@
   border-color: transparent;
 }
 
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover:active) {
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      )
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover:active
+  ) {
   background-color: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
   color: var(--colorNeutralForegroundDisabled);
   cursor: not-allowed;
 }
 
-:host([appearance='primary']:is(:disabled, [disabled-focusable])),
-:host([appearance='primary']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
 }
 
-:host([appearance='outline']:is(:disabled, [disabled-focusable])),
-:host([appearance='outline']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
 }
 
-:host([appearance='subtle']:is(:disabled, [disabled-focusable])),
-:host([appearance='subtle']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
   border-color: transparent;
 }
 
-:host([appearance='transparent']:is(:disabled, [disabled-focusable])),
-:host([appearance='transparent']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
   background-color: var(--colorTransparentBackground);
 }
@@ -260,7 +287,16 @@
     forced-color-adjust: none;
   }
 
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+  :host(
+      :is(
+          :disabled,
+          [disabled],
+          [disabled-focusable],
+          [appearance]:disabled,
+          [appearance][disabled],
+          [appearance][disabled-focusable]
+        )
+    ) {
     background-color: ButtonFace;
     color: GrayText;
     border-color: ButtonText;

--- a/packages/web-components/src/button/button.styles.ts
+++ b/packages/web-components/src/button/button.styles.ts
@@ -280,33 +280,33 @@ export const baseButtonStyles = css`
 export const styles = css`
   ${baseButtonStyles}
 
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])),
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover),
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover:active) {
+  :host(:is(:disabled, [disabled], [disabled-focusable], [appearance]:disabled, [appearance][disabled], [appearance][disabled-focusable])),
+  :host(:is(:disabled, [disabled], [disabled-focusable], [appearance]:disabled, [appearance][disabled], [appearance][disabled-focusable]):hover),
+  :host(:is(:disabled, [disabled], [disabled-focusable], [appearance]:disabled, [appearance][disabled], [appearance][disabled-focusable]):hover:active) {
     background-color: ${colorNeutralBackgroundDisabled};
     border-color: ${colorNeutralStrokeDisabled};
     color: ${colorNeutralForegroundDisabled};
     cursor: not-allowed;
   }
 
-  :host([appearance='primary']:is(:disabled, [disabled-focusable])),
-  :host([appearance='primary']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+  :host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable])),
+  :host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
     border-color: transparent;
   }
 
-  :host([appearance='outline']:is(:disabled, [disabled-focusable])),
-  :host([appearance='outline']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+  :host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable])),
+  :host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
     background-color: ${colorTransparentBackground};
   }
 
-  :host([appearance='subtle']:is(:disabled, [disabled-focusable])),
-  :host([appearance='subtle']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+  :host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable])),
+  :host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
     background-color: ${colorTransparentBackground};
     border-color: transparent;
   }
 
-  :host([appearance='transparent']:is(:disabled, [disabled-focusable])),
-  :host([appearance='transparent']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+  :host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable])),
+  :host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
     border-color: transparent;
     background-color: ${colorTransparentBackground};
   }
@@ -327,7 +327,16 @@ export const styles = css`
       forced-color-adjust: none;
     }
 
-    :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+    :host(
+        :is(
+            :disabled,
+            [disabled],
+            [disabled-focusable],
+            [appearance]:disabled,
+            [appearance][disabled],
+            [appearance][disabled-focusable]
+          )
+      ) {
       background-color: ButtonFace;
       color: GrayText;
       border-color: ButtonText;

--- a/packages/web-components/src/checkbox/checkbox.styles.css
+++ b/packages/web-components/src/checkbox/checkbox.styles.css
@@ -109,21 +109,21 @@
   border-radius: var(--borderRadiusCircular);
 }
 
-:host([disabled]),
-:host([disabled]:state(checked)) {
+:host(:is([disabled], :disabled)),
+:host(:is([disabled], :disabled):state(checked)) {
   background-color: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
 }
 
-:host([disabled]) {
+:host(:is([disabled], :disabled)) {
   cursor: unset;
 }
 
-:host([disabled]:state(indeterminate)) .indeterminate-indicator {
+:host(:is([disabled], :disabled):state(indeterminate)) .indeterminate-indicator {
   background-color: var(--colorNeutralStrokeDisabled);
 }
 
-:host([disabled]:state(checked)) .checked-indicator {
+:host(:is([disabled], :disabled):state(checked)) .checked-indicator {
   color: var(--colorNeutralStrokeDisabled);
 }
 
@@ -136,8 +136,8 @@
     border-color: Canvas;
   }
 
-  :host(:not([disabled]):hover),
-  :host(:state(checked):not([disabled]):hover),
+  :host(:not(:is([disabled], :disabled)):hover),
+  :host(:state(checked):not(:is([disabled], :disabled)):hover),
   :host(:not([slot='input']):focus-visible)::after {
     border-color: Highlight;
   }
@@ -152,21 +152,21 @@
     background-color: FieldText;
   }
 
-  :host(:state(checked):not([disabled]):hover),
-  :host(:state(indeterminate):not([disabled]):hover) .indeterminate-indicator {
+  :host(:state(checked):not(:is([disabled], :disabled)):hover),
+  :host(:state(indeterminate):not(:is([disabled], :disabled)):hover) .indeterminate-indicator {
     background-color: Highlight;
   }
 
-  :host([disabled]) {
+  :host(:is([disabled], :disabled)) {
     border-color: GrayText;
   }
 
-  :host([disabled]:state(indeterminate)) .indeterminate-indicator {
+  :host(:is([disabled], :disabled):state(indeterminate)) .indeterminate-indicator {
     background-color: GrayText;
   }
 
-  :host([disabled]),
-  :host([disabled]:state(checked)) .checked-indicator {
+  :host(:is([disabled], :disabled)),
+  :host(:is([disabled], :disabled):state(checked)) .checked-indicator {
     color: GrayText;
   }
 }

--- a/packages/web-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/src/checkbox/checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { checkedState, indeterminateState } from '../styles/states/index.js';
+import { checkedState, indeterminateState, nativeDisabledState } from '../styles/states/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,
@@ -135,21 +135,21 @@ export const styles = css`
     border-radius: ${borderRadiusCircular};
   }
 
-  :host([disabled]),
-  :host([disabled]${checkedState}) {
+  :host(${nativeDisabledState}),
+  :host(${nativeDisabledState}${checkedState}) {
     background-color: ${colorNeutralBackgroundDisabled};
     border-color: ${colorNeutralStrokeDisabled};
   }
 
-  :host([disabled]) {
+  :host(${nativeDisabledState}) {
     cursor: unset;
   }
 
-  :host([disabled]${indeterminateState}) .indeterminate-indicator {
+  :host(${nativeDisabledState}${indeterminateState}) .indeterminate-indicator {
     background-color: ${colorNeutralStrokeDisabled};
   }
 
-  :host([disabled]${checkedState}) .checked-indicator {
+  :host(${nativeDisabledState}${checkedState}) .checked-indicator {
     color: ${colorNeutralStrokeDisabled};
   }
 
@@ -162,8 +162,8 @@ export const styles = css`
       border-color: Canvas;
     }
 
-    :host(:not([disabled]):hover),
-    :host(${checkedState}:not([disabled]):hover),
+    :host(:not(${nativeDisabledState}):hover),
+    :host(${checkedState}:not(${nativeDisabledState}):hover),
     :host(:not([slot='input']):focus-visible)::after {
       border-color: Highlight;
     }
@@ -178,21 +178,21 @@ export const styles = css`
       background-color: FieldText;
     }
 
-    :host(${checkedState}:not([disabled]):hover),
-    :host(${indeterminateState}:not([disabled]):hover) .indeterminate-indicator {
+    :host(${checkedState}:not(${nativeDisabledState}):hover),
+    :host(${indeterminateState}:not(${nativeDisabledState}):hover) .indeterminate-indicator {
       background-color: Highlight;
     }
 
-    :host([disabled]) {
+    :host(${nativeDisabledState}) {
       border-color: GrayText;
     }
 
-    :host([disabled]${indeterminateState}) .indeterminate-indicator {
+    :host(${nativeDisabledState}${indeterminateState}) .indeterminate-indicator {
       background-color: GrayText;
     }
 
-    :host([disabled]),
-    :host([disabled]${checkedState}) .checked-indicator {
+    :host(${nativeDisabledState}),
+    :host(${nativeDisabledState}${checkedState}) .checked-indicator {
       color: GrayText;
     }
   }

--- a/packages/web-components/src/compound-button/compound-button.styles.css
+++ b/packages/web-components/src/compound-button/compound-button.styles.css
@@ -213,33 +213,60 @@
   border-color: transparent;
 }
 
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover:active) {
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      )
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover:active
+  ) {
   background-color: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
   color: var(--colorNeutralForegroundDisabled);
   cursor: not-allowed;
 }
 
-:host([appearance='primary']:is(:disabled, [disabled-focusable])),
-:host([appearance='primary']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
 }
 
-:host([appearance='outline']:is(:disabled, [disabled-focusable])),
-:host([appearance='outline']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
 }
 
-:host([appearance='subtle']:is(:disabled, [disabled-focusable])),
-:host([appearance='subtle']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
   border-color: transparent;
 }
 
-:host([appearance='transparent']:is(:disabled, [disabled-focusable])),
-:host([appearance='transparent']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
   background-color: var(--colorTransparentBackground);
 }
@@ -260,7 +287,16 @@
     forced-color-adjust: none;
   }
 
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+  :host(
+      :is(
+          :disabled,
+          [disabled],
+          [disabled-focusable],
+          [appearance]:disabled,
+          [appearance][disabled],
+          [appearance][disabled-focusable]
+        )
+    ) {
     background-color: ButtonFace;
     color: GrayText;
     border-color: ButtonText;
@@ -323,7 +359,16 @@
   color: var(--colorNeutralForeground2BrandPressed);
 }
 
-:host(:is(:disabled, :disabled[appearance], [disabled-focusable], [disabled-focusable][appearance]))
+:host(
+    :is(
+        :disabled,
+        :disabled[appearance],
+        [disabled],
+        [disabled][appearance],
+        [disabled-focusable],
+        [disabled-focusable][appearance]
+      )
+  )
   ::slotted([slot='description']) {
   color: var(--colorNeutralForegroundDisabled);
 }
@@ -363,7 +408,7 @@
 }
 
 @media (forced-colors: active) {
-  :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled-focusable]))
+  :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled], [disabled-focusable]))
     ::slotted([slot='description']) {
     color: HighlightText;
   }

--- a/packages/web-components/src/compound-button/compound-button.styles.ts
+++ b/packages/web-components/src/compound-button/compound-button.styles.ts
@@ -79,7 +79,16 @@ export const styles = css`
     color: ${colorNeutralForeground2BrandPressed};
   }
 
-  :host(:is(:disabled, :disabled[appearance], [disabled-focusable], [disabled-focusable][appearance]))
+  :host(
+      :is(
+          :disabled,
+          :disabled[appearance],
+          [disabled],
+          [disabled][appearance],
+          [disabled-focusable],
+          [disabled-focusable][appearance]
+        )
+    )
     ::slotted([slot='description']) {
     color: ${colorNeutralForegroundDisabled};
   }
@@ -119,7 +128,7 @@ export const styles = css`
   }
 
   @media (forced-colors: active) {
-    :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled-focusable]))
+    :host([appearance='primary']:not(:hover, :focus-visible, :disabled, [disabled], [disabled-focusable]))
       ::slotted([slot='description']) {
       color: HighlightText;
     }

--- a/packages/web-components/src/dropdown/dropdown.styles.css
+++ b/packages/web-components/src/dropdown/dropdown.styles.css
@@ -175,18 +175,18 @@
   --control-border-color: var(--colorTransparentStroke);
 }
 
-:host(:disabled),
-:host(:disabled) ::slotted(:where(button, input)) {
+:host(:is([disabled], :disabled)),
+:host(:is([disabled], :disabled)) ::slotted(:where(button, input)) {
   cursor: not-allowed;
 }
 
-:host(:disabled) .control::before,
-:host(:disabled) .control::after {
+:host(:is([disabled], :disabled)) .control::before,
+:host(:is([disabled], :disabled)) .control::after {
   content: none;
 }
 
-:host(:disabled) .control:is(*, :active, :hover),
-:host(:disabled) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
+:host(:is([disabled], :disabled)) .control:is(*, :active, :hover),
+:host(:is([disabled], :disabled)) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
   --control-border-color: var(--colorNeutralStrokeDisabled);
   background-color: var(--colorNeutralBackgroundDisabled);
   color: var(--colorNeutralForegroundDisabled);
@@ -213,10 +213,10 @@
 }
 
 @media (forced-colors: active) {
-  :host(:disabled) .control {
+  :host(:is([disabled], :disabled)) .control {
     border-color: GrayText;
   }
-  :host(:disabled) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
+  :host(:is([disabled], :disabled)) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
     color: GrayText;
   }
 }

--- a/packages/web-components/src/dropdown/dropdown.styles.ts
+++ b/packages/web-components/src/dropdown/dropdown.styles.ts
@@ -4,7 +4,7 @@ import {
   typographyBody2Styles,
   typographyCaption1Styles,
 } from '../styles/partials/typography.partials.js';
-import { openState, placeholderShownState } from '../styles/states/index.js';
+import { nativeDisabledState, openState, placeholderShownState } from '../styles/states/index.js';
 import {
   borderRadiusMedium,
   borderRadiusNone,
@@ -216,18 +216,18 @@ export const styles = css`
     --control-border-color: ${colorTransparentStroke};
   }
 
-  :host(:disabled),
-  :host(:disabled) ::slotted(:where(button, input)) {
+  :host(${nativeDisabledState}),
+  :host(${nativeDisabledState}) ::slotted(:where(button, input)) {
     cursor: not-allowed;
   }
 
-  :host(:disabled) .control::before,
-  :host(:disabled) .control::after {
+  :host(${nativeDisabledState}) .control::before,
+  :host(${nativeDisabledState}) .control::after {
     content: none;
   }
 
-  :host(:disabled) .control:is(*, :active, :hover),
-  :host(:disabled) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
+  :host(${nativeDisabledState}) .control:is(*, :active, :hover),
+  :host(${nativeDisabledState}) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
     --control-border-color: ${colorNeutralStrokeDisabled};
     background-color: ${colorNeutralBackgroundDisabled};
     color: ${colorNeutralForegroundDisabled};
@@ -254,10 +254,10 @@ export const styles = css`
   }
 
   @media (forced-colors: active) {
-    :host(:disabled) .control {
+    :host(${nativeDisabledState}) .control {
       border-color: GrayText;
     }
-    :host(:disabled) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
+    :host(${nativeDisabledState}) :where(slot[name='indicator'] > *, ::slotted([slot='indicator'])) {
       color: GrayText;
     }
   }

--- a/packages/web-components/src/menu-button/menu-button.styles.css
+++ b/packages/web-components/src/menu-button/menu-button.styles.css
@@ -213,33 +213,60 @@
   border-color: transparent;
 }
 
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover:active) {
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      )
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover:active
+  ) {
   background-color: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
   color: var(--colorNeutralForegroundDisabled);
   cursor: not-allowed;
 }
 
-:host([appearance='primary']:is(:disabled, [disabled-focusable])),
-:host([appearance='primary']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
 }
 
-:host([appearance='outline']:is(:disabled, [disabled-focusable])),
-:host([appearance='outline']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
 }
 
-:host([appearance='subtle']:is(:disabled, [disabled-focusable])),
-:host([appearance='subtle']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
   border-color: transparent;
 }
 
-:host([appearance='transparent']:is(:disabled, [disabled-focusable])),
-:host([appearance='transparent']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
   background-color: var(--colorTransparentBackground);
 }
@@ -260,7 +287,16 @@
     forced-color-adjust: none;
   }
 
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+  :host(
+      :is(
+          :disabled,
+          [disabled],
+          [disabled-focusable],
+          [appearance]:disabled,
+          [appearance][disabled],
+          [appearance][disabled-focusable]
+        )
+    ) {
     background-color: ButtonFace;
     color: GrayText;
     border-color: ButtonText;

--- a/packages/web-components/src/option/option.styles.css
+++ b/packages/web-components/src/option/option.styles.css
@@ -46,7 +46,7 @@
   color: var(--colorNeutralForeground2Pressed);
 }
 
-:host(:disabled) {
+:host(:is([disabled], :disabled)) {
   background-color: var(--colorNeutralBackground1);
   color: var(--colorNeutralForegroundDisabled);
   cursor: default;
@@ -92,11 +92,11 @@ slot[name='checked-indicator'] > *,
   fill: var(--colorNeutralForegroundInverted);
 }
 
-:host(:disabled:state(multiple)) .checkmark-12-regular {
+:host(:is([disabled], :disabled):state(multiple)) .checkmark-12-regular {
   border-color: var(--colorNeutralStrokeDisabled);
 }
 
-:host(:disabled:state(multiple):state(selected)) .checkmark-12-regular {
+:host(:is([disabled], :disabled):state(multiple):state(selected)) .checkmark-12-regular {
   background-color: var(--colorNeutralBackgroundDisabled);
 }
 
@@ -128,7 +128,7 @@ slot[name='checked-indicator'] > *,
 }
 
 @media (forced-colors: active) {
-  :host(:disabled) {
+  :host(:is([disabled], :disabled)) {
     color: GrayText;
   }
 }

--- a/packages/web-components/src/option/option.styles.ts
+++ b/packages/web-components/src/option/option.styles.ts
@@ -1,6 +1,12 @@
 import { css } from '@microsoft/fast-element';
 import { typographyBody1Styles, typographyCaption1Styles } from '../styles/partials/typography.partials.js';
-import { activeState, descriptionState, multipleState, selectedState } from '../styles/states/index.js';
+import {
+  activeState,
+  descriptionState,
+  multipleState,
+  nativeDisabledState,
+  selectedState,
+} from '../styles/states/index.js';
 import {
   borderRadiusMedium,
   borderRadiusSmall,
@@ -71,7 +77,7 @@ export const styles = css`
     color: ${colorNeutralForeground2Pressed};
   }
 
-  :host(:disabled) {
+  :host(${nativeDisabledState}) {
     background-color: ${colorNeutralBackground1};
     color: ${colorNeutralForegroundDisabled};
     cursor: default;
@@ -117,11 +123,11 @@ export const styles = css`
     fill: ${colorNeutralForegroundInverted};
   }
 
-  :host(:disabled${multipleState}) .checkmark-12-regular {
+  :host(${nativeDisabledState}${multipleState}) .checkmark-12-regular {
     border-color: ${colorNeutralStrokeDisabled};
   }
 
-  :host(:disabled${multipleState}${selectedState}) .checkmark-12-regular {
+  :host(${nativeDisabledState}${multipleState}${selectedState}) .checkmark-12-regular {
     background-color: ${colorNeutralBackgroundDisabled};
   }
 
@@ -149,7 +155,7 @@ export const styles = css`
   }
 
   @media (forced-colors: active) {
-    :host(:disabled) {
+    :host(${nativeDisabledState}) {
       color: GrayText;
     }
   }

--- a/packages/web-components/src/slider/slider.styles.css
+++ b/packages/web-components/src/slider/slider.styles.css
@@ -37,12 +37,12 @@
   --rail-color: var(--colorCompoundBrandBackgroundPressed);
 }
 
-:host(:disabled) {
+:host(:is([disabled], :disabled)) {
   --rail-color: var(--colorNeutralForegroundDisabled);
   --track-color: var(--colorNeutralBackgroundDisabled);
 }
 
-:host(:not(:disabled)) {
+:host(:not(:is([disabled], :disabled))) {
   cursor: pointer;
 }
 

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@microsoft/fast-element';
 import { display } from '../utils/display.js';
+import { nativeDisabledState } from '../styles/states/index.js';
 import {
   borderRadiusCircular,
   borderRadiusMedium,
@@ -54,12 +55,12 @@ export const styles = css`
     --rail-color: ${colorCompoundBrandBackgroundPressed};
   }
 
-  :host(:disabled) {
+  :host(${nativeDisabledState}) {
     --rail-color: ${colorNeutralForegroundDisabled};
     --track-color: ${colorNeutralBackgroundDisabled};
   }
 
-  :host(:not(:disabled)) {
+  :host(:not(${nativeDisabledState})) {
     cursor: pointer;
   }
 

--- a/packages/web-components/src/styles/states/index.ts
+++ b/packages/web-components/src/styles/states/index.ts
@@ -36,6 +36,16 @@ export const descriptionState = stateSelector('description');
 export const disabledState = stateSelector('disabled');
 
 /**
+ * Selector for the native `disabled` state for elements that are
+ * form-associated, which supports the native `:disabled` pseudo class when
+ * the `disabled` attribute is present. The `disabled` attribute selector is
+ * for SSR support because `:disabled` is not supported before the element is
+ * defined (as a form-associated custom element).
+ * @public
+ */
+export const nativeDisabledState = ':is([disabled], :disabled)';
+
+/**
  * Selector for the `error` state.
  * @public
  */

--- a/packages/web-components/src/switch/switch.styles.css
+++ b/packages/web-components/src/switch/switch.styles.css
@@ -31,7 +31,7 @@
 :host(:active) {
   border-color: var(--colorNeutralStrokeAccessiblePressed);
 }
-:host(:disabled),
+:host(:is([disabled], :disabled)),
 :host([readonly]) {
   border: 1px solid var(--colorNeutralStrokeDisabled);
   background-color: none;
@@ -49,7 +49,7 @@
   background: var(--colorCompoundBrandBackgroundPressed);
   border-color: var(--colorCompoundBrandBackgroundPressed);
 }
-:host(:state(checked):disabled) {
+:host(:state(checked):is([disabled], :disabled)) {
   background: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
 }
@@ -79,11 +79,11 @@
 :host(:active) .checked-indicator {
   background-color: var(--colorNeutralForeground3Pressed);
 }
-:host(:disabled) .checked-indicator,
+:host(:is([disabled], :disabled)) .checked-indicator,
 :host([readonly]) .checked-indicator {
   background: var(--colorNeutralForegroundDisabled);
 }
-:host(:state(checked):disabled) .checked-indicator {
+:host(:state(checked):is([disabled], :disabled)) .checked-indicator {
   background: var(--colorNeutralForegroundDisabled);
 }
 
@@ -118,8 +118,8 @@
   :host(:state(checked):active) .checked-indicator {
     background-color: ButtonFace;
   }
-  :host(:disabled) .checked-indicator,
-  :host(:state(checked):disabled) .checked-indicator {
+  :host(:is([disabled], :disabled)) .checked-indicator,
+  :host(:state(checked):is([disabled], :disabled)) .checked-indicator {
     background-color: GrayText;
   }
 }

--- a/packages/web-components/src/switch/switch.styles.ts
+++ b/packages/web-components/src/switch/switch.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@microsoft/fast-element';
-import { checkedState } from '../styles/states/index.js';
+import { checkedState, nativeDisabledState } from '../styles/states/index.js';
 import {
   borderRadiusCircular,
   colorCompoundBrandBackground,
@@ -57,7 +57,7 @@ export const styles = css`
   :host(:active) {
     border-color: ${colorNeutralStrokeAccessiblePressed};
   }
-  :host(:disabled),
+  :host(${nativeDisabledState}),
   :host([readonly]) {
     border: 1px solid ${colorNeutralStrokeDisabled};
     background-color: none;
@@ -75,7 +75,7 @@ export const styles = css`
     background: ${colorCompoundBrandBackgroundPressed};
     border-color: ${colorCompoundBrandBackgroundPressed};
   }
-  :host(${checkedState}:disabled) {
+  :host(${checkedState}${nativeDisabledState}) {
     background: ${colorNeutralBackgroundDisabled};
     border-color: ${colorNeutralStrokeDisabled};
   }
@@ -105,11 +105,11 @@ export const styles = css`
   :host(:active) .checked-indicator {
     background-color: ${colorNeutralForeground3Pressed};
   }
-  :host(:disabled) .checked-indicator,
+  :host(${nativeDisabledState}) .checked-indicator,
   :host([readonly]) .checked-indicator {
     background: ${colorNeutralForegroundDisabled};
   }
-  :host(${checkedState}:disabled) .checked-indicator {
+  :host(${checkedState}${nativeDisabledState}) .checked-indicator {
     background: ${colorNeutralForegroundDisabled};
   }
 
@@ -144,8 +144,8 @@ export const styles = css`
     :host(${checkedState}:active) .checked-indicator {
       background-color: ButtonFace;
     }
-    :host(:disabled) .checked-indicator,
-    :host(${checkedState}:disabled) .checked-indicator {
+    :host(${nativeDisabledState}) .checked-indicator,
+    :host(${checkedState}${nativeDisabledState}) .checked-indicator {
       background-color: GrayText;
     }
   }

--- a/packages/web-components/src/text-input/text-input.styles.css
+++ b/packages/web-components/src/text-input/text-input.styles.css
@@ -122,13 +122,13 @@
 :host(:focus-within) .control {
   color: var(--colorNeutralForeground1);
 }
-:host([disabled]) .root {
+:host(:is([disabled], :disabled)) .root {
   background: var(--colorTransparentBackground);
   border: var(--strokeWidthThin) solid var(--colorNeutralStrokeDisabled);
 }
-:host([disabled]) .control::placeholder,
-:host([disabled]) ::slotted([slot='start']),
-:host([disabled]) ::slotted([slot='end']) {
+:host(:is([disabled], :disabled)) .control::placeholder,
+:host(:is([disabled], :disabled)) ::slotted([slot='start']),
+:host(:is([disabled], :disabled)) ::slotted([slot='end']) {
   color: var(--colorNeutralForegroundDisabled);
 }
 ::selection {
@@ -179,7 +179,7 @@
   border: 0;
   border-bottom-color: var(--colorNeutralStrokeAccessiblePressed);
 }
-:host([appearance='underline'][disabled]) .root {
+:host([appearance='underline']:is([disabled], :disabled)) .root {
   border-bottom-color: var(--colorNeutralStrokeDisabled);
 }
 :host([appearance='filled-lighter']) .root,

--- a/packages/web-components/src/text-input/text-input.styles.ts
+++ b/packages/web-components/src/text-input/text-input.styles.ts
@@ -1,5 +1,6 @@
 import type { ElementStyles } from '@microsoft/fast-element';
 import { css } from '@microsoft/fast-element';
+import { nativeDisabledState } from '../styles/states/index.js';
 import {
   borderRadiusMedium,
   colorCompoundBrandStroke,
@@ -174,13 +175,13 @@ export const styles: ElementStyles = css`
   :host(:focus-within) .control {
     color: ${colorNeutralForeground1};
   }
-  :host([disabled]) .root {
+  :host(${nativeDisabledState}) .root {
     background: ${colorTransparentBackground};
     border: ${strokeWidthThin} solid ${colorNeutralStrokeDisabled};
   }
-  :host([disabled]) .control::placeholder,
-  :host([disabled]) ::slotted([slot='start']),
-  :host([disabled]) ::slotted([slot='end']) {
+  :host(${nativeDisabledState}) .control::placeholder,
+  :host(${nativeDisabledState}) ::slotted([slot='start']),
+  :host(${nativeDisabledState}) ::slotted([slot='end']) {
     color: ${colorNeutralForegroundDisabled};
   }
   ::selection {
@@ -231,7 +232,7 @@ export const styles: ElementStyles = css`
     border: 0;
     border-bottom-color: ${colorNeutralStrokeAccessiblePressed};
   }
-  :host([appearance='underline'][disabled]) .root {
+  :host([appearance='underline']${nativeDisabledState}) .root {
     border-bottom-color: ${colorNeutralStrokeDisabled};
   }
   :host([appearance='filled-lighter']) .root,

--- a/packages/web-components/src/textarea/textarea.styles.css
+++ b/packages/web-components/src/textarea/textarea.styles.css
@@ -78,15 +78,15 @@
   --control-padding-inline: var(--spacingHorizontalSNudge);
 }
 
-:host([resize='both']:not(:disabled)) {
+:host([resize='both']:not(:is([disabled], :disabled))) {
   --resize: both;
 }
 
-:host([resize='horizontal']:not(:disabled)) {
+:host([resize='horizontal']:not(:is([disabled], :disabled))) {
   --resize: horizontal;
 }
 
-:host([resize='vertical']:not(:disabled)) {
+:host([resize='vertical']:not(:is([disabled], :disabled))) {
   --resize: vertical;
 }
 
@@ -116,7 +116,7 @@
   --border-block-end-color: var(--colorPaletteRedBorder2);
 }
 
-:host(:disabled) {
+:host(:is([disabled], :disabled)) {
   --color: var(--colorNeutralForegroundDisabled);
   --background-color: var(--colorTransparentBackground);
   --border-color: var(--colorNeutralStrokeDisabled);
@@ -174,7 +174,7 @@
 }
 
 :host([readonly]) .root::after,
-:host(:disabled) .root::after {
+:host(:is([disabled], :disabled)) .root::after {
   content: none;
 }
 
@@ -253,7 +253,7 @@ label[hidden] {
     --border-block-end-color: Highlight;
   }
 
-  :host(:disabled) {
+  :host(:is([disabled], :disabled)) {
     --color: GrayText;
     --border-color: GrayText;
     --border-block-end-color: GrayText;

--- a/packages/web-components/src/textarea/textarea.styles.ts
+++ b/packages/web-components/src/textarea/textarea.styles.ts
@@ -43,7 +43,7 @@ import {
   strokeWidthThin,
 } from '../theme/design-tokens.js';
 import { display } from '../utils/display.js';
-import { userInvalidState } from '../styles/states/index.js';
+import { nativeDisabledState, userInvalidState } from '../styles/states/index.js';
 
 /**
  * Styles for the TextArea component.
@@ -126,15 +126,15 @@ export const styles: ElementStyles = css`
     --control-padding-inline: ${spacingHorizontalSNudge};
   }
 
-  :host([resize='both']:not(:disabled)) {
+  :host([resize='both']:not(${nativeDisabledState})) {
     --resize: both;
   }
 
-  :host([resize='horizontal']:not(:disabled)) {
+  :host([resize='horizontal']:not(${nativeDisabledState})) {
     --resize: horizontal;
   }
 
-  :host([resize='vertical']:not(:disabled)) {
+  :host([resize='vertical']:not(${nativeDisabledState})) {
     --resize: vertical;
   }
 
@@ -164,7 +164,7 @@ export const styles: ElementStyles = css`
     --border-block-end-color: ${colorPaletteRedBorder2};
   }
 
-  :host(:disabled) {
+  :host(${nativeDisabledState}) {
     --color: ${colorNeutralForegroundDisabled};
     --background-color: ${colorTransparentBackground};
     --border-color: ${colorNeutralStrokeDisabled};
@@ -222,7 +222,7 @@ export const styles: ElementStyles = css`
   }
 
   :host([readonly]) .root::after,
-  :host(:disabled) .root::after {
+  :host(${nativeDisabledState}) .root::after {
     content: none;
   }
 
@@ -301,7 +301,7 @@ export const styles: ElementStyles = css`
       --border-block-end-color: Highlight;
     }
 
-    :host(:disabled) {
+    :host(${nativeDisabledState}) {
       --color: GrayText;
       --border-color: GrayText;
       --border-block-end-color: GrayText;

--- a/packages/web-components/src/toggle-button/toggle-button.styles.css
+++ b/packages/web-components/src/toggle-button/toggle-button.styles.css
@@ -213,33 +213,60 @@
   border-color: transparent;
 }
 
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover),
-:host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable]):hover:active) {
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      )
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover
+  ),
+:host(
+    :is(
+        :disabled,
+        [disabled],
+        [disabled-focusable],
+        [appearance]:disabled,
+        [appearance][disabled],
+        [appearance][disabled-focusable]
+      ):hover:active
+  ) {
   background-color: var(--colorNeutralBackgroundDisabled);
   border-color: var(--colorNeutralStrokeDisabled);
   color: var(--colorNeutralForegroundDisabled);
   cursor: not-allowed;
 }
 
-:host([appearance='primary']:is(:disabled, [disabled-focusable])),
-:host([appearance='primary']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='primary']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
 }
 
-:host([appearance='outline']:is(:disabled, [disabled-focusable])),
-:host([appearance='outline']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='outline']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
 }
 
-:host([appearance='subtle']:is(:disabled, [disabled-focusable])),
-:host([appearance='subtle']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='subtle']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   background-color: var(--colorTransparentBackground);
   border-color: transparent;
 }
 
-:host([appearance='transparent']:is(:disabled, [disabled-focusable])),
-:host([appearance='transparent']:is(:disabled, [disabled-focusable]):is(:hover, :hover:active)) {
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable])),
+:host([appearance='transparent']:is(:disabled, [disabled], [disabled-focusable]):is(:hover, :hover:active)) {
   border-color: transparent;
   background-color: var(--colorTransparentBackground);
 }
@@ -260,7 +287,16 @@
     forced-color-adjust: none;
   }
 
-  :host(:is(:disabled, [disabled-focusable], [appearance]:disabled, [appearance][disabled-focusable])) {
+  :host(
+      :is(
+          :disabled,
+          [disabled],
+          [disabled-focusable],
+          [appearance]:disabled,
+          [appearance][disabled],
+          [appearance][disabled-focusable]
+        )
+    ) {
     background-color: ButtonFace;
     color: GrayText;
     border-color: ButtonText;


### PR DESCRIPTION
## Previous Behavior

If a custom element is form-associated, we can use `:disabled` interchangably with `[disabled]` in CSS, but only after the element is defined. Some components currently only use `:disabled` to style their disabled state, which doesn’t work before the component is defined. This is important for SSR use cases.

## New Behavior

Changed the selector from `:disabled` to `:is([disabled], :disabled)`.