### PR TITLE
fix(react-tag-picker): allow base states in render functions

### DIFF
--- a/change/@fluentui-react-tag-picker-6d250fbd-dba9-48f7-a206-e47abc8fbb2b.json
+++ b/change/@fluentui-react-tag-picker-6d250fbd-dba9-48f7-a206-e47abc8fbb2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: allow base states in TagPicker render functions",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
+++ b/packages/react-components/react-tag-picker/library/etc/react-tag-picker.api.md
@@ -29,6 +29,7 @@ import type { OptionState } from '@fluentui/react-combobox';
 import * as React_2 from 'react';
 import type { Slot } from '@fluentui/react-utilities';
 import type { SlotClassNames } from '@fluentui/react-utilities';
+import type { TagGroupBaseState } from '@fluentui/react-tags';
 import { TagGroupContextValues } from '@fluentui/react-tags';
 import type { TagGroupSlots } from '@fluentui/react-tags';
 import type { TagGroupState } from '@fluentui/react-tags';
@@ -37,16 +38,16 @@ import type { TagGroupState } from '@fluentui/react-tags';
 export const renderTagPicker_unstable: (state: TagPickerState, contexts: TagPickerContextValues) => JSXElement;
 
 // @public
-export const renderTagPickerButton_unstable: (state: TagPickerButtonState) => JSXElement;
+export const renderTagPickerButton_unstable: (state: TagPickerButtonBaseState) => JSXElement;
 
 // @public
-export const renderTagPickerControl_unstable: (state: TagPickerControlState) => JSXElement;
+export const renderTagPickerControl_unstable: (state: TagPickerControlBaseState) => JSXElement;
 
 // @public (undocumented)
-export function renderTagPickerGroup_unstable(state: TagPickerGroupState, contexts: TagGroupContextValues): JSXElement | null;
+export function renderTagPickerGroup_unstable(state: TagPickerGroupBaseState, contexts: TagGroupContextValues): JSXElement | null;
 
 // @public
-export const renderTagPickerInput_unstable: (state: TagPickerInputState) => JSXElement;
+export const renderTagPickerInput_unstable: (state: TagPickerInputBaseState) => JSXElement;
 
 // @public
 export const renderTagPickerList_unstable: (state: TagPickerListState) => JSXElement;
@@ -155,6 +156,11 @@ export type TagPickerControlState = ComponentState<TagPickerControlSlots & TagPi
 
 // @public
 export const TagPickerGroup: ForwardRefComponent<TagPickerGroupProps>;
+
+// @public
+export type TagPickerGroupBaseState = TagGroupBaseState & {
+    hasSelectedOptions: boolean;
+};
 
 // @public (undocumented)
 export const tagPickerGroupClassNames: SlotClassNames<TagPickerGroupSlots>;

--- a/packages/react-components/react-tag-picker/library/src/TagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/TagPickerGroup.ts
@@ -1,4 +1,9 @@
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './components/TagPickerGroup/index';
+export type {
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './components/TagPickerGroup/index';
 export {
   TagPickerGroup,
   renderTagPickerGroup_unstable,

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/renderTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/renderTagPickerButton.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { TagPickerButtonState, TagPickerButtonSlots } from './TagPickerButton.types';
+import type { TagPickerButtonBaseState, TagPickerButtonSlots } from './TagPickerButton.types';
 
 /**
  * Render the final JSX of PickerButton
  */
-export const renderTagPickerButton_unstable = (state: TagPickerButtonState): JSXElement => {
+export const renderTagPickerButton_unstable = (state: TagPickerButtonBaseState): JSXElement => {
   assertSlots<TagPickerButtonSlots>(state);
 
   return <state.root />;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/renderTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/renderTagPickerControl.tsx
@@ -4,7 +4,7 @@
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 import type {
-  TagPickerControlState,
+  TagPickerControlBaseState,
   TagPickerControlSlots,
   TagPickerControlInternalSlots,
 } from './TagPickerControl.types';
@@ -12,7 +12,7 @@ import type {
 /**
  * Render the final JSX of PickerControl
  */
-export const renderTagPickerControl_unstable = (state: TagPickerControlState): JSXElement => {
+export const renderTagPickerControl_unstable = (state: TagPickerControlBaseState): JSXElement => {
   assertSlots<TagPickerControlSlots & TagPickerControlInternalSlots>(state);
 
   return (

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.types.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/TagPickerGroup.types.ts
@@ -1,4 +1,4 @@
-import type { TagGroupSlots, TagGroupState } from '@fluentui/react-tags';
+import type { TagGroupBaseState, TagGroupSlots, TagGroupState } from '@fluentui/react-tags';
 import type { ComponentProps } from '@fluentui/react-utilities';
 
 export type TagPickerGroupSlots = TagGroupSlots;
@@ -12,5 +12,12 @@ export type TagPickerGroupProps = ComponentProps<TagPickerGroupSlots>;
  * State used in rendering TagPickerGroup
  */
 export type TagPickerGroupState = TagGroupState & {
+  hasSelectedOptions: boolean;
+};
+
+/**
+ * TagPickerGroup Base State - omits design-only state.
+ */
+export type TagPickerGroupBaseState = TagGroupBaseState & {
   hasSelectedOptions: boolean;
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/index.ts
@@ -1,5 +1,10 @@
 export { TagPickerGroup } from './TagPickerGroup';
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup.types';
+export type {
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './TagPickerGroup.types';
 export { renderTagPickerGroup_unstable } from './renderTagPickerGroup';
 export { useTagPickerGroup_unstable } from './useTagPickerGroup';
 export { tagPickerGroupClassNames, useTagPickerGroupStyles_unstable } from './useTagPickerGroupStyles.styles';

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/renderTagPickerGroup.ts
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerGroup/renderTagPickerGroup.ts
@@ -1,9 +1,9 @@
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { TagPickerGroupState } from './TagPickerGroup.types';
+import type { TagPickerGroupBaseState } from './TagPickerGroup.types';
 import { renderTagGroup_unstable, type TagGroupContextValues } from '@fluentui/react-tags';
 
 export function renderTagPickerGroup_unstable(
-  state: TagPickerGroupState,
+  state: TagPickerGroupBaseState,
   contexts: TagGroupContextValues,
 ): JSXElement | null {
   if (!state.hasSelectedOptions) {

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/renderTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/renderTagPickerInput.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { TagPickerInputState, TagPickerInputSlots } from './TagPickerInput.types';
+import type { TagPickerInputBaseState, TagPickerInputSlots } from './TagPickerInput.types';
 
 /**
  * Render the final JSX of TagPickerInput
  */
-export const renderTagPickerInput_unstable = (state: TagPickerInputState): JSXElement => {
+export const renderTagPickerInput_unstable = (state: TagPickerInputBaseState): JSXElement => {
   assertSlots<TagPickerInputSlots>(state);
 
   return <state.root />;

--- a/packages/react-components/react-tag-picker/library/src/index.ts
+++ b/packages/react-components/react-tag-picker/library/src/index.ts
@@ -84,7 +84,12 @@ export {
   useTagPickerGroupStyles_unstable,
   useTagPickerGroup_unstable,
 } from './TagPickerGroup';
-export type { TagPickerGroupProps, TagPickerGroupSlots, TagPickerGroupState } from './TagPickerGroup';
+export type {
+  TagPickerGroupBaseState,
+  TagPickerGroupProps,
+  TagPickerGroupSlots,
+  TagPickerGroupState,
+} from './TagPickerGroup';
 
 export {
   TagPickerOptionGroup,


### PR DESCRIPTION
## Summary

- type TagPicker Button, Control, Group, and Input render functions against their base states
- export `TagPickerGroupBaseState` consistently with the other TagPicker primitives
- allow headless consumers to reuse the render functions without unsafe casts

## Related

Split from the headless TagPicker work so the v9 API adjustment can be reviewed independently: #36285