### PR TITLE
fix(react-headless-components-preview): export useFieldContext and useFieldControlProps hooks

### DIFF
--- a/change/@fluentui-react-headless-components-preview-1a467385-d556-41f2-8228-efdc7c495f8c.json
+++ b/change/@fluentui-react-headless-components-preview-1a467385-d556-41f2-8228-efdc7c495f8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export useFieldContext and useFieldControlProps hooks",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/field.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/field.api.md
@@ -11,6 +11,8 @@ import type { FieldSlots as FieldSlots_2 } from '@fluentui/react-field';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
 import { renderField_unstable as renderField } from '@fluentui/react-field';
+import { useFieldContext_unstable as useFieldContext } from '@fluentui/react-field';
+import { useFieldControlProps_unstable as useFieldControlProps } from '@fluentui/react-field';
 
 // @public
 export const Field: ForwardRefComponent<FieldProps>;
@@ -33,8 +35,12 @@ export { renderField }
 // @public
 export const useField: (props: FieldProps, ref: React_2.Ref<HTMLDivElement>) => FieldState;
 
+export { useFieldContext }
+
 // @public
 export const useFieldContextValues: (state: FieldState) => FieldContextValues;
+
+export { useFieldControlProps }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Field/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Field/index.ts
@@ -1,5 +1,5 @@
 export { Field } from './Field';
 export { renderField } from './renderField';
 export { useField } from './useField';
-export { useFieldContextValues } from './useFieldContextValues';
+export { useFieldContextValues, useFieldContext, useFieldControlProps } from './useFieldContextValues';
 export type { FieldSlots, FieldProps, FieldState } from './Field.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Field/useFieldContextValues.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Field/useFieldContextValues.ts
@@ -4,6 +4,11 @@ import { useFieldContextValues_unstable } from '@fluentui/react-field';
 
 import type { FieldState, FieldContextValues } from './Field.types';
 
+export {
+  useFieldContext_unstable as useFieldContext,
+  useFieldControlProps_unstable as useFieldControlProps,
+} from '@fluentui/react-field';
+
 /**
  * Returns the context values for a Field component, given its state.
  */

--- a/packages/react-components/react-headless-components-preview/library/src/field.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/field.ts
@@ -1,2 +1,9 @@
-export { Field, renderField, useField, useFieldContextValues } from './components/Field/index';
+export {
+  Field,
+  renderField,
+  useField,
+  useFieldContextValues,
+  useFieldContext,
+  useFieldControlProps,
+} from './components/Field/index';
 export type { FieldSlots, FieldProps, FieldState } from './components/Field/index';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

`useFieldContext` and `useFieldControlProps` hooks were not re-exported from headless, so consumers can't use them directly and needed to import from `@fluentui/react-field` or `@fluentui/react-components`

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

export `useFieldContext` and `useFieldControlProps` hooks `@fluentui/react-headless-components-preview`, so consumers can use them directly and not need to install other dependencies

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Fixes #
