### PR TITLE
fix(react-input, react-textarea): Fix Field control size handling

### DIFF
--- a/change/@fluentui-react-combobox-b197d28c-186b-49aa-b3ad-d2bb9373eec8.json
+++ b/change/@fluentui-react-combobox-b197d28c-186b-49aa-b3ad-d2bb9373eec8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix Field control size handling Combobox and Dropdown",
+  "packageName": "@fluentui/react-combobox",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-36da51cb-96eb-443d-989b-9f4b15fdb26f.json
+++ b/change/@fluentui-react-input-36da51cb-96eb-443d-989b-9f4b15fdb26f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix Field control size handling",
+  "packageName": "@fluentui/react-input",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-9672e973-eb59-40e0-9525-cdff3aab9639.json
+++ b/change/@fluentui-react-select-9672e973-eb59-40e0-9525-cdff3aab9639.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix Field control size handling for Select",
+  "packageName": "@fluentui/react-select",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-57f0bbb3-c577-4105-b6a8-25c92624073f.json
+++ b/change/@fluentui-react-textarea-57f0bbb3-c577-4105-b6a8-25c92624073f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: fix Field control size handling",
+  "packageName": "@fluentui/react-textarea",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useActiveDescendant } from '@fluentui/react-aria';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldContext_unstable, useFieldControlProps_unstable } from '@fluentui/react-field';
 import { ChevronDownRegular as ChevronDownIcon, DismissRegular as DismissIcon } from '@fluentui/react-icons';
 import {
   getPartitionedNativeProps,
@@ -213,7 +213,8 @@ export const useComboboxBase_unstable = (
  * @param ref - reference to root HTMLElement of Combobox
  */
 export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLInputElement>): ComboboxState => {
-  const { appearance = 'outline', size = 'medium', ...baseProps } = props;
+  const fieldContext = useFieldContext_unstable();
+  const { appearance = 'outline', size = fieldContext?.size ?? 'medium', ...baseProps } = props;
   const baseState = useComboboxBase_unstable(baseProps, ref);
 
   if (baseState.clearIcon) {

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldContext_unstable, useFieldControlProps_unstable } from '@fluentui/react-field';
 import { useActiveDescendant } from '@fluentui/react-aria';
 import { ChevronDownRegular as ChevronDownIcon, DismissRegular as DismissIcon } from '@fluentui/react-icons';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
@@ -162,7 +162,8 @@ export const useDropdownBase_unstable = (
  * @param ref - reference to root HTMLElement of Dropdown
  */
 export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLButtonElement>): DropdownState => {
-  const { appearance = 'outline', size = 'medium', ...baseProps } = props;
+  const fieldContext = useFieldContext_unstable();
+  const { appearance = 'outline', size = fieldContext?.size ?? 'medium', ...baseProps } = props;
   const baseState = useDropdownBase_unstable(baseProps, ref);
 
   if (baseState.clearButton) {

--- a/packages/react-components/react-input/library/src/components/Input/useInput.test.tsx
+++ b/packages/react-components/react-input/library/src/components/Input/useInput.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useInput_unstable } from './useInput';
+import type { InputProps } from './Input.types';
+import * as React from 'react';
+import { Field, type FieldProps } from '@fluentui/react-field';
+
+const createWrapper = (props: Partial<FieldProps>) => {
+  return ({ children }: { children: React.ReactNode }) => <Field {...props}>{children}</Field>;
+};
+
+describe('useInput', () => {
+  it('returns the correct initial state', () => {
+    const props: InputProps = {
+      value: 'test',
+      disabled: false,
+    };
+
+    const { result } = renderHook(() => useInput_unstable(props, React.createRef<HTMLInputElement>()));
+
+    expect(result.current.input.value).toBe('test');
+    expect(result.current.input.disabled).toBe(false);
+    expect(result.current.size).toBe('medium');
+    expect(result.current.input.required).toBeFalsy();
+  });
+
+  it('gets props from a surrounding Field', () => {
+    const props: InputProps = {
+      value: 'test',
+    };
+
+    const ref = React.createRef<HTMLInputElement>();
+
+    const { result } = renderHook(() => useInput_unstable(props, ref), {
+      wrapper: createWrapper({ size: 'small', required: true }),
+    });
+
+    expect(result.current.input.value).toBe('test');
+    expect(result.current.size).toBe('small');
+    expect(result.current.input.required).toBe(true);
+  });
+
+  it('overrides props from a surrounding Field', () => {
+    const props: InputProps = {
+      value: 'test',
+      // Override the size from the surrounding Field
+      size: 'large',
+    };
+
+    const { result } = renderHook(() => useInput_unstable(props, React.createRef<HTMLInputElement>()), {
+      wrapper: createWrapper({ size: 'small', required: true }),
+    });
+
+    expect(result.current.input.value).toBe('test');
+    expect(result.current.size).toBe('large');
+    expect(result.current.input.required).toBe(true);
+  });
+});

--- a/packages/react-components/react-input/library/src/components/Input/useInput.ts
+++ b/packages/react-components/react-input/library/src/components/Input/useInput.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type * as React from 'react';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldControlProps_unstable, useFieldContext_unstable } from '@fluentui/react-field';
 import { getPartitionedNativeProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { InputBaseProps, InputBaseState, InputProps, InputState } from './Input.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
@@ -17,8 +17,13 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useInput_unstable = (props: InputProps, ref: React.Ref<HTMLInputElement>): InputState => {
   const overrides = useOverrides();
+  const fieldContext = useFieldContext_unstable();
 
-  const { size = 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', ...baseProps } = props;
+  const {
+    size = fieldContext?.size ?? 'medium',
+    appearance = overrides.inputDefaultAppearance ?? 'outline',
+    ...baseProps
+  } = props;
 
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -51,7 +56,6 @@ export const useInputBase_unstable = (props: InputBaseProps, ref: React.Ref<HTML
   const fieldControlProps = useFieldControlProps_unstable(props, {
     supportsLabelFor: true,
     supportsRequired: true,
-    supportsSize: true,
   });
 
   const [value, setValue] = useControllableState({

--- a/packages/react-components/react-select/library/src/components/Select/useSelect.tsx
+++ b/packages/react-components/react-select/library/src/components/Select/useSelect.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldContext_unstable, useFieldControlProps_unstable } from '@fluentui/react-field';
 import { getPartitionedNativeProps, useEventCallback, slot } from '@fluentui/react-utilities';
 import { ChevronDownRegular } from '@fluentui/react-icons';
 import type { SelectBaseProps, SelectBaseState, SelectProps, SelectState } from './Select.types';
@@ -18,8 +18,13 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useSelect_unstable = (props: SelectProps, ref: React.Ref<HTMLSelectElement>): SelectState => {
   const overrides = useOverrides();
+  const fieldContext = useFieldContext_unstable();
 
-  const { appearance = overrides.inputDefaultAppearance ?? 'outline', size = 'medium', ...baseProps } = props;
+  const {
+    appearance = overrides.inputDefaultAppearance ?? 'outline',
+    size = fieldContext?.size ?? 'medium',
+    ...baseProps
+  } = props;
 
   const state = useSelectBase_unstable(baseProps, ref);
 

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextarea.test.tsx
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextarea.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useTextarea_unstable } from './useTextarea';
+import type { TextareaProps } from './Textarea.types';
+import * as React from 'react';
+import { Field, type FieldProps } from '@fluentui/react-field';
+
+const createWrapper = (props: Partial<FieldProps>) => {
+  return ({ children }: { children: React.ReactNode }) => <Field {...props}>{children}</Field>;
+};
+
+describe('useTextarea', () => {
+  it('returns the correct initial state', () => {
+    const props: TextareaProps = {
+      value: 'test',
+      disabled: false,
+    };
+
+    const { result } = renderHook(() => useTextarea_unstable(props, React.createRef<HTMLTextAreaElement>()));
+
+    expect(result.current.textarea.value).toBe('test');
+    expect(result.current.textarea.disabled).toBe(false);
+    expect(result.current.size).toBe('medium');
+    expect(result.current.textarea.required).toBeFalsy();
+  });
+
+  it('gets props from a surrounding Field', () => {
+    const props: TextareaProps = {
+      value: 'test',
+    };
+
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    const { result } = renderHook(() => useTextarea_unstable(props, ref), {
+      wrapper: createWrapper({ size: 'small', required: true }),
+    });
+
+    expect(result.current.textarea.value).toBe('test');
+    expect(result.current.size).toBe('small');
+    expect(result.current.textarea.required).toBe(true);
+  });
+
+  it('overrides props from a surrounding Field', () => {
+    const props: TextareaProps = {
+      value: 'test',
+      // Override the size from the surrounding Field
+      size: 'large',
+    };
+
+    const { result } = renderHook(() => useTextarea_unstable(props, React.createRef<HTMLTextAreaElement>()), {
+      wrapper: createWrapper({ size: 'small', required: true }),
+    });
+
+    expect(result.current.textarea.value).toBe('test');
+    expect(result.current.size).toBe('large');
+    expect(result.current.textarea.required).toBe(true);
+  });
+});

--- a/packages/react-components/react-textarea/library/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-textarea/library/src/components/Textarea/useTextarea.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type * as React from 'react';
-import { useFieldControlProps_unstable } from '@fluentui/react-field';
+import { useFieldContext_unstable, useFieldControlProps_unstable } from '@fluentui/react-field';
 import { getPartitionedNativeProps, useControllableState, useEventCallback, slot } from '@fluentui/react-utilities';
 import type { TextareaBaseProps, TextareaBaseState, TextareaProps, TextareaState } from './Textarea.types';
 import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-contexts';
@@ -17,8 +17,13 @@ import { useOverrides_unstable as useOverrides } from '@fluentui/react-shared-co
  */
 export const useTextarea_unstable = (props: TextareaProps, ref: React.Ref<HTMLTextAreaElement>): TextareaState => {
   const overrides = useOverrides();
+  const fieldContext = useFieldContext_unstable();
 
-  const { size = 'medium', appearance = overrides.inputDefaultAppearance ?? 'outline', ...baseProps } = props;
+  const {
+    size = fieldContext?.size ?? 'medium',
+    appearance = overrides.inputDefaultAppearance ?? 'outline',
+    ...baseProps
+  } = props;
 
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -52,7 +57,7 @@ export const useTextareaBase_unstable = (
   ref?: React.Ref<HTMLTextAreaElement>,
 ): TextareaBaseState => {
   // Merge props from surrounding <Field>, if any
-  props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true, supportsSize: true });
+  props = useFieldControlProps_unstable(props, { supportsLabelFor: true, supportsRequired: true });
 
   const { resize = 'none', onChange } = props;
 


### PR DESCRIPTION
Fixes Field control size handling for textfield-like controls.

### Changes
- Updated Input size resolution in `useInput` to default from Field context (`fieldContext?.size ?? 'medium'`).
- Updated Textarea size resolution in `useTextarea` to default from Field context (`fieldContext?.size ?? 'medium'`).
- Updated Combobox size resolution in `useCombobox` to default from Field context (`fieldContext?.size ?? 'medium'`).
- Updated Dropdown size resolution in `useDropdown` to default from Field context (`fieldContext?.size ?? 'medium'`).
- Updated Select size resolution in `useSelect` to default from Field context (`fieldContext?.size ?? 'medium'`).
- Removed `supportsSize: true` from `useFieldControlProps_unstable` options in Input and Textarea.

### Packages affected
- @fluentui/react-combobox (patch)
- @fluentui/react-input (patch)
- @fluentui/react-select (patch)
- @fluentui/react-textarea (patch)

Beachball change files have been created for all affected packages.

### Before (all inputs don't respect field size)

<img width="1040" height="506" alt="image" src="https://github.com/user-attachments/assets/6d3e7a65-3c75-4ef2-b433-d89b19396e92" />

### After (inputs respect field size)

<img width="1040" height="506" alt="image" src="https://github.com/user-attachments/assets/efd490fd-5b6c-4a82-ac57-4baf27630901" />
