### PR TITLE
fix(docsite): restore LLM documentation after yarn v4 migration 

### DIFF
--- a/apps/chart-docsite/package.json
+++ b/apps/chart-docsite/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "description": "Fluent UI React Charts Preview documentation",
   "scripts": {
-    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
-    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/charts/ storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
-    "postbuild-storybook": "yarn rewrite-title && yarn generate-llms-docs",
+    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn rewrite-title && yarn generate-llms-docs",
+    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/charts/ storybook build -o ./dist/storybook --docs && yarn rewrite-title && yarn generate-llms-docs",
     "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI Charts v9' --distPath ./dist/storybook",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --distPath ./dist/storybook --summaryBaseUrl \"https://storybooks.fluentui.dev/charts/\" --summaryTitle \"Fluent UI Charts v9\" --summaryDescription \"Fluent UI React charts is a set of modern, accessible, interactive, lightweight and highly customizable visualization library representing the Microsoft design system. These charts are used across 100s of projects inside Microsoft across Microsoft 365, Copilot and Azure.\"",
     "clean": "yarn run -T just-scripts clean",

--- a/apps/chart-docsite/package.json
+++ b/apps/chart-docsite/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "description": "Fluent UI React Charts Preview documentation",
   "scripts": {
-    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs",
-    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/charts/ storybook build -o ./dist/storybook --docs",
+    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
+    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/charts/ storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
     "postbuild-storybook": "yarn rewrite-title && yarn generate-llms-docs",
-    "postbuild-storybook:docsite": "yarn postbuild-storybook",
     "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI Charts v9' --distPath ./dist/storybook",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --distPath ./dist/storybook --summaryBaseUrl \"https://storybooks.fluentui.dev/charts/\" --summaryTitle \"Fluent UI Charts v9\" --summaryDescription \"Fluent UI React charts is a set of modern, accessible, interactive, lightweight and highly customizable visualization library representing the Microsoft design system. These charts are used across 100s of projects inside Microsoft across Microsoft 365, Copilot and Azure.\"",
     "clean": "yarn run -T just-scripts clean",

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -30,7 +30,6 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn run -T just-scripts build",
-    "prebundle": "yarn build",
     "bundle": "yarn run -T just-scripts bundle",
     "lint": "yarn run -T eslint --ext .js,.ts,.tsx ./src",
     "just": "yarn run -T just-scripts",

--- a/apps/public-docsite-resources/project.json
+++ b/apps/public-docsite-resources/project.json
@@ -3,5 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "library",
   "implicitDependencies": [],
-  "tags": ["v8"]
+  "tags": ["v8"],
+  "targets": {
+    "bundle": {
+      "dependsOn": ["build", "^build"]
+    }
+  }
 }

--- a/apps/public-docsite-v9-headless/package.json
+++ b/apps/public-docsite-v9-headless/package.json
@@ -4,10 +4,9 @@
   "private": true,
   "description": "Fluent UI React Headless Components Preview documentation",
   "scripts": {
-    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs",
-    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/headless/ storybook build -o ./dist/storybook --docs",
+    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
+    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/headless/ storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
     "postbuild-storybook": "yarn generate-llms-docs",
-    "postbuild-storybook:docsite": "yarn postbuild-storybook",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --distPath ./dist/storybook --summaryBaseUrl \"https://storybooks.fluentui.dev/headless/\" --summaryTitle \"Fluent UI React Headless Components\" --summaryDescription \"Fluent UI React headless components provide unstyled, accessible component primitives that can be styled with any CSS approach.\"",
     "generate-browser-support": "node -r ../../scripts/ts-node/src/register ../../tools/web-features/src/generate.ts --output src/BrowserSupport/browser-support-data.generated.json --features popover,dialog,focusgroup,anchor-positioning=css.properties.anchor-name,anchor-name=anchor-positioning::css.properties.anchor-name,position-area=anchor-positioning::css.properties.position-area,position-try-fallbacks=anchor-positioning::css.properties.position-try-fallbacks,anchor-center=anchor-positioning::css.properties.place-self.anchor-center",
     "start": "yarn storybook:docs",

--- a/apps/public-docsite-v9-headless/package.json
+++ b/apps/public-docsite-v9-headless/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "description": "Fluent UI React Headless Components Preview documentation",
   "scripts": {
-    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
-    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/headless/ storybook build -o ./dist/storybook --docs && yarn postbuild-storybook",
-    "postbuild-storybook": "yarn generate-llms-docs",
+    "build-storybook": "yarn run -T storybook build -o ./dist/storybook --docs && yarn generate-llms-docs",
+    "build-storybook:docsite": "yarn run -T cross-env DEPLOY_PATH=/headless/ storybook build -o ./dist/storybook --docs && yarn generate-llms-docs",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --distPath ./dist/storybook --summaryBaseUrl \"https://storybooks.fluentui.dev/headless/\" --summaryTitle \"Fluent UI React Headless Components\" --summaryDescription \"Fluent UI React headless components provide unstyled, accessible component primitives that can be styled with any CSS approach.\"",
     "generate-browser-support": "node -r ../../scripts/ts-node/src/register ../../tools/web-features/src/generate.ts --output src/BrowserSupport/browser-support-data.generated.json --features popover,dialog,focusgroup,anchor-positioning=css.properties.anchor-name,anchor-name=anchor-positioning::css.properties.anchor-name,position-area=anchor-positioning::css.properties.position-area,position-try-fallbacks=anchor-positioning::css.properties.position-try-fallbacks,anchor-center=anchor-positioning::css.properties.place-self.anchor-center",
     "start": "yarn storybook:docs",

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Fluent UI React v9 documentation",
   "scripts": {
-    "build-storybook": "yarn run -T cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs",
+    "build-storybook": "yarn run -T cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs && yarn postbuild-storybook",
     "postbuild-storybook": "yarn rewrite-title && yarn generate-llms-docs",
     "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI React v9' --distPath ./dist/react",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --config storybook-llms.config.js",

--- a/apps/public-docsite-v9/package.json
+++ b/apps/public-docsite-v9/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "description": "Fluent UI React v9 documentation",
   "scripts": {
-    "build-storybook": "yarn run -T cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs && yarn postbuild-storybook",
-    "postbuild-storybook": "yarn rewrite-title && yarn generate-llms-docs",
+    "build-storybook": "yarn run -T cross-env NODE_OPTIONS=--max_old_space_size=3072 DEPLOY_PATH=/react/ storybook build -o ./dist/react --docs && yarn rewrite-title && yarn generate-llms-docs",
     "rewrite-title": "node -r ../../scripts/ts-node/src/register ../../scripts/storybook/src/scripts/rewrite-title.ts --title 'Fluent UI React v9' --distPath ./dist/react",
     "generate-llms-docs": "yarn run -T storybook-llms-extractor --config storybook-llms.config.js",
     "clean": "yarn run -T just-scripts clean",


### PR DESCRIPTION
Restores generated llms.txt documentation for the React v9, Charts, and Headless docsites after the Yarn 4 migration stopped running implicit post-build hooks. It also makes the v8 docsite resources build dependency explicit in Nx and prevents publishing incomplete LLM artifacts.

<img width="654" height="139" alt="Screenshot 2026-07-28 at 17 21 09" src="https://github.com/user-attachments/assets/a670f00a-1296-41a9-b391-286e58b4f081" />

## **llms.txt on docsite**: 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/616bc589-ef0e-406f-9105-1c855124824a" />
