### PR TITLE
fix: escape FluentProvider SSR style selectors

### DIFF
--- a/change/@fluentui-react-provider-2b661db2-e0ca-4c84-87bf-58e8825ae9d1.json
+++ b/change/@fluentui-react-provider-2b661db2-e0ca-4c84-87bf-58e8825ae9d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: escape SSR theme style selectors",
+  "packageName": "@fluentui/react-provider",
+  "email": "paulmardling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-prefix-node.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-prefix-node.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * @jest-environment node
+ */
+
+import { IdPrefixProvider } from '@fluentui/react-utilities';
+import * as React from 'react';
+import { renderToStaticMarkup, renderToString } from 'react-dom/server';
+
+import { FluentProvider } from './FluentProvider';
+
+const hostilePrefix = 'msrc</style><script data-test="inert"></script><style>';
+
+function expectSafeStyleRule(html: string): void {
+  expect(html).not.toContain('</style><script');
+  expect(html).not.toContain('<script');
+  expect(html).toContain('\\3C /style\\3E ');
+  expect(html).toContain('\\3C script data-test="inert"\\3E ');
+}
+
+describe('FluentProvider prefix SSR', () => {
+  it('escapes an IdPrefixProvider value in the theme style selector', () => {
+    const html = renderToStaticMarkup(
+      <IdPrefixProvider value={hostilePrefix}>
+        <FluentProvider theme={{ colorBrandBackground: 'red' }} />
+      </IdPrefixProvider>,
+    );
+
+    expectSafeStyleRule(html);
+  });
+
+  it('escapes React identifierPrefix in the theme style selector', () => {
+    const html = renderToString(<FluentProvider theme={{ colorBrandBackground: 'red' }} />, {
+      identifierPrefix: hostilePrefix,
+    });
+
+    expectSafeStyleRule(html);
+  });
+});

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
@@ -29,4 +29,12 @@ describe('createCSSRuleFromTheme', () => {
       `".selector { --colorBrandBackground: \\\\3C /style\\\\3E \\\\3C script\\\\3E alert(\\"xss\\")\\\\3C /script\\\\3E ;  }"`,
     );
   });
+
+  it('prevents XSS by replacing angle brackets in the selector', () => {
+    const result = createCSSRuleFromTheme('.selector</style><script>alert("xss")</script>', undefined);
+
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+    expect(result).toContain('\\3C /style\\3E \\3C script\\3E alert("xss")\\3C /script\\3E ');
+  });
 });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
@@ -22,13 +22,15 @@ function escapeForStyleTag(value: string): string {
  * Useful for scenarios when you want to apply theming statically to a top level elements like `body`.
  */
 export function createCSSRuleFromTheme(selector: string, theme: PartialTheme | undefined): string {
+  const escapedSelector = escapeForStyleTag(selector);
+
   if (theme) {
     const cssVarsAsString = (Object.keys(theme) as (keyof typeof theme)[]).reduce((cssVarRule, cssVar) => {
       return `${cssVarRule}--${cssVar}: ${theme[cssVar]}; `;
     }, '');
 
-    return `${selector} { ${escapeForStyleTag(cssVarsAsString)} }`;
+    return `${escapedSelector} { ${escapeForStyleTag(cssVarsAsString)} }`;
   }
 
-  return `${selector} {}`;
+  return `${escapedSelector} {}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,7 +2534,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/babel-preset-storybook-full-source@npm:^0.1.2, @fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source":
+"@fluentui/babel-preset-storybook-full-source@npm:^0.1.3, @fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source":
   version: 0.0.0-use.local
   resolution: "@fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source"
   dependencies:
@@ -5409,11 +5409,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/react-storybook-addon-export-to-sandbox@npm:*, @fluentui/react-storybook-addon-export-to-sandbox@npm:^0.3.0, @fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox":
+"@fluentui/react-storybook-addon-export-to-sandbox@npm:*, @fluentui/react-storybook-addon-export-to-sandbox@npm:^0.3.1, @fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox":
   version: 0.0.0-use.local
   resolution: "@fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox"
   dependencies:
-    "@fluentui/babel-preset-storybook-full-source": "npm:^0.1.2"
+    "@fluentui/babel-preset-storybook-full-source": "npm:^0.1.3"
     "@swc/helpers": "npm:^0.5.1"
     babel-loader: "npm:^9.1.3"
     codesandbox-import-utils: "npm:^2.2.3"
@@ -6331,7 +6331,7 @@ __metadata:
     "@fluentui/react-components": "npm:^9.74.4"
     "@fluentui/react-context-selector": "npm:^9.2.18"
     "@fluentui/react-icons": "npm:^2.0.245"
-    "@fluentui/react-storybook-addon-export-to-sandbox": "npm:^0.3.0"
+    "@fluentui/react-storybook-addon-export-to-sandbox": "npm:^0.3.1"
     "@fluentui/react-theme": "npm:^9.2.1"
     "@fluentui/react-utilities": "npm:^9.26.5"
     "@griffel/react": "npm:^1.5.32"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

During server-side rendering, `FluentProvider` inserted generated style selectors without escaping angle brackets. Prefixes supplied through `IdPrefixProvider` or React's `identifierPrefix` could therefore produce invalid inline style markup.

## New Behavior

`createCSSRuleFromTheme` now escapes angle brackets in selectors using CSS code-point escapes. This keeps server-rendered style markup valid while preserving the intended selector.

Regression tests cover both `IdPrefixProvider` and React's `identifierPrefix`.

## Related Issue(s)

- Fixes [MSRC - 129538](https://portal.microsofticm.com/imp/v5/incidents/details/31000000670576/msrc)