### PR TITLE
chore: fix beachball pre-commit after yarn v4

### DIFF
--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process';
+
 import headlessConfig from './release-headless.config';
 import toolsConfig from './release-tools.config';
 import v8Config from './release-v8.config';
@@ -5,8 +7,24 @@ import vNextConfig from './release-vNext.config';
 import webComponentsConfig from './release-web-components.config';
 import { config as sharedConfig } from './shared.config';
 
+jest.mock('child_process', () => ({
+  ...jest.requireActual<typeof import('child_process')>('child_process'),
+  execSync: jest.fn(),
+}));
+
 describe(`beachball configs`, () => {
   const excludedPackagesFromReleaseProcess = ['!packages/fluentui/*'];
+  const execSyncMock = jest.mocked(execSync);
+  const precommit = sharedConfig.hooks.precommit;
+
+  if (!precommit) {
+    throw new Error('Expected the shared Beachball config to define a precommit hook');
+  }
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    execSyncMock.mockReturnValue(Buffer.from(''));
+  });
 
   it(`should generate shared config`, () => {
     expect(sharedConfig).toEqual({
@@ -46,6 +64,30 @@ describe(`beachball configs`, () => {
         },
       },
     });
+  });
+
+  it(`should normalize package dependencies and update the lockfile before committing`, () => {
+    precommit(process.cwd());
+
+    expect(execSyncMock.mock.calls).toEqual([
+      ['yarn nx g @fluentui/workspace-plugin:dependency-mismatch'],
+      ['yarn nx g @fluentui/workspace-plugin:normalize-package-dependencies'],
+      ['yarn install --mode=update-lockfile'],
+    ]);
+  });
+
+  it(`should log precommit finalization failures`, () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const error = new Error('dependency normalization failed');
+    execSyncMock.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() => precommit(process.cwd())).not.toThrow();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it(`should generate v8 release config`, () => {

--- a/scripts/beachball/src/shared.config.ts
+++ b/scripts/beachball/src/shared.config.ts
@@ -33,6 +33,9 @@ export const config: typeof baseConfig & Required<Pick<BeachballConfig, 'changel
           const out = execSync(cmd);
           console.log(out.toString());
         });
+
+        const out = execSync('yarn install --mode=update-lockfile');
+        console.log(out.toString());
       } catch (err) {
         console.error(err);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,7 +2534,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/babel-preset-storybook-full-source@npm:^0.1.2, @fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source":
+"@fluentui/babel-preset-storybook-full-source@npm:^0.1.3, @fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source":
   version: 0.0.0-use.local
   resolution: "@fluentui/babel-preset-storybook-full-source@workspace:packages/react-components/babel-preset-storybook-full-source"
   dependencies:
@@ -5409,11 +5409,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/react-storybook-addon-export-to-sandbox@npm:*, @fluentui/react-storybook-addon-export-to-sandbox@npm:^0.3.0, @fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox":
+"@fluentui/react-storybook-addon-export-to-sandbox@npm:*, @fluentui/react-storybook-addon-export-to-sandbox@npm:^0.3.1, @fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox":
   version: 0.0.0-use.local
   resolution: "@fluentui/react-storybook-addon-export-to-sandbox@workspace:packages/react-components/react-storybook-addon-export-to-sandbox"
   dependencies:
-    "@fluentui/babel-preset-storybook-full-source": "npm:^0.1.2"
+    "@fluentui/babel-preset-storybook-full-source": "npm:^0.1.3"
     "@swc/helpers": "npm:^0.5.1"
     babel-loader: "npm:^9.1.3"
     codesandbox-import-utils: "npm:^2.2.3"
@@ -6331,7 +6331,7 @@ __metadata:
     "@fluentui/react-components": "npm:^9.74.4"
     "@fluentui/react-context-selector": "npm:^9.2.18"
     "@fluentui/react-icons": "npm:^2.0.245"
-    "@fluentui/react-storybook-addon-export-to-sandbox": "npm:^0.3.0"
+    "@fluentui/react-storybook-addon-export-to-sandbox": "npm:^0.3.1"
     "@fluentui/react-theme": "npm:^9.2.1"
     "@fluentui/react-utilities": "npm:^9.26.5"
     "@griffel/react": "npm:^1.5.32"


### PR DESCRIPTION
## Previous Behavior

The tools release pipeline ran `yarn install --immutable` before Beachball changed package manifests. Beachball then bumped workspace package versions and internal dependency ranges and pushed the release commit without regenerating `yarn.lock`.

This was tolerated by Yarn Classic because workspace packages were not represented by range-specific lockfile descriptors. Yarn 4 records those descriptors, so the tools release commit left the manifests and lockfile inconsistent. Master CI consequently failed during installation with `YN0028`: `The lockfile would have been modified by this install, which is explicitly forbidden.`

## New Behavior

- Regenerates Yarn lockfile metadata with `yarn install --mode=update-lockfile` after Beachball finishes dependency normalization and before Beachball stages the release commit.
- Repairs the four stale workspace descriptors introduced by the failed tools release.
- Applies the fix through the shared Beachball configuration, protecting tools, v8, vNext, headless, and web-components release flows.
- Keeps CI's `yarn install --immutable` check unchanged as the independent consistency guard.
- Preserves the existing precommit error handling, which logs finalization errors without changing the established release behavior.

Beachball runs the `precommit` hook before `git add .`, so future manifest and `yarn.lock` updates are included atomically in the same release commit.

## Validation

- `yarn nx run scripts-beachball:test --skip-nx-cache`
- `yarn nx run scripts-beachball:lint --skip-nx-cache`
- `yarn nx run scripts-beachball:type-check`
- Confirmed `yarn install --immutable` no longer reports the original `YN0028` mismatch

## Related Issue(s)

- Related master CI failure: https://github.com/microsoft/fluentui/actions/runs/30551461188/job/90900909917
