### PR TITLE
feat(react-headless-components-preview): expose missing state data attributes

### DIFF
--- a/change/@fluentui-react-headless-components-preview-c80196b7-476b-4a8e-8501-c7ddf249a46c.json
+++ b/change/@fluentui-react-headless-components-preview-c80196b7-476b-4a8e-8501-c7ddf249a46c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: expose missing resolved state through additive data attributes",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/README.md
+++ b/packages/react-components/react-headless-components-preview/library/README.md
@@ -5,3 +5,9 @@
 > [!WARNING] > **This package is in preview and not production-ready.** APIs may change without notice before final release. **Do not use in production.**
 >
 > This package exposes unstyled, headless Fluent UI v9 primitives for teams building custom design systems. For most teams, [`@fluentui/react-components`](https://www.npmjs.com/package/@fluentui/react-components) remains the recommended default.
+
+## State selector contract
+
+Headless components expose resolved interaction and structural state through `data-*` attributes. Consumers that wrap these components, including visual-system packages, must preserve the attributes on the slot where headless emits them.
+
+Existing attributes retain their current names and value semantics. Visual axes such as appearance, size, and shape are intentionally not part of the headless contract.

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
@@ -4,15 +4,15 @@
 
 ```ts
 
+import type { AvatarGroupBaseProps } from '@fluentui/react-avatar';
+import type { AvatarGroupBaseState } from '@fluentui/react-avatar';
 import { AvatarGroupContextValue } from '@fluentui/react-avatar';
 import { AvatarGroupContextValues } from '@fluentui/react-avatar';
 import type { AvatarGroupItemBaseProps } from '@fluentui/react-avatar';
 import { AvatarGroupItemSlots } from '@fluentui/react-avatar';
 import { AvatarGroupItemBaseState as AvatarGroupItemState } from '@fluentui/react-avatar';
-import { AvatarGroupBaseProps as AvatarGroupProps } from '@fluentui/react-avatar';
 import type { AvatarGroupProps as AvatarGroupProps_2 } from '@fluentui/react-avatar';
 import { AvatarGroupSlots } from '@fluentui/react-avatar';
-import { AvatarGroupBaseState as AvatarGroupState } from '@fluentui/react-avatar';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
 import type { EventData } from '@fluentui/react-utilities';
@@ -77,11 +77,17 @@ export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & 
     popover: AvatarGroupPopoverPopoverProps;
 };
 
-export { AvatarGroupProps }
+// @public (undocumented)
+export type AvatarGroupProps = AvatarGroupBaseProps;
 
 export { AvatarGroupSlots }
 
-export { AvatarGroupState }
+// @public (undocumented)
+export type AvatarGroupState = AvatarGroupBaseState & {
+    root: {
+        'data-layout'?: AvatarGroupBaseState['layout'];
+    };
+};
 
 export { PartitionAvatarGroupItems }
 
@@ -97,7 +103,7 @@ export { renderAvatarGroupItem }
 export const renderAvatarGroupPopover: (state: AvatarGroupPopoverState, contextValues: AvatarGroupContextValues) => JSXElement;
 
 // @public
-export const useAvatarGroup: (props: AvatarGroupProps, ref: React_2.Ref<HTMLElement>) => AvatarGroupState;
+export const useAvatarGroup: (props: AvatarGroupProps, ref: React_2.Ref<HTMLDivElement>) => AvatarGroupState;
 
 // @public
 export const useAvatarGroupContextValues: (state: AvatarGroupState) => AvatarGroupContextValues;

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
-import type { AvatarGroupBaseProps } from '@fluentui/react-avatar';
 import type { AvatarGroupBaseState } from '@fluentui/react-avatar';
 import { AvatarGroupContextValue } from '@fluentui/react-avatar';
 import { AvatarGroupContextValues } from '@fluentui/react-avatar';
 import type { AvatarGroupItemBaseProps } from '@fluentui/react-avatar';
 import { AvatarGroupItemSlots } from '@fluentui/react-avatar';
 import { AvatarGroupItemBaseState as AvatarGroupItemState } from '@fluentui/react-avatar';
+import { AvatarGroupBaseProps as AvatarGroupProps } from '@fluentui/react-avatar';
 import type { AvatarGroupProps as AvatarGroupProps_2 } from '@fluentui/react-avatar';
 import { AvatarGroupSlots } from '@fluentui/react-avatar';
 import type { ComponentProps } from '@fluentui/react-utilities';
@@ -77,8 +77,7 @@ export type AvatarGroupPopoverState = ComponentState<AvatarGroupPopoverSlots> & 
     popover: AvatarGroupPopoverPopoverProps;
 };
 
-// @public (undocumented)
-export type AvatarGroupProps = AvatarGroupBaseProps;
+export { AvatarGroupProps }
 
 export { AvatarGroupSlots }
 

--- a/packages/react-components/react-headless-components-preview/library/etc/button.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/button.api.md
@@ -26,6 +26,7 @@ export type ButtonState = ButtonBaseState & {
         'data-disabled'?: string;
         'data-disabled-focusable'?: string;
         'data-icon-only'?: string;
+        'data-icon-position'?: ButtonBaseState['iconPosition'];
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/card.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/card.api.md
@@ -78,6 +78,7 @@ export type CardSlots = CardSlots_2;
 export type CardState = CardBaseState & {
     root: {
         'data-selected'?: string;
+        'data-disabled'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/checkbox.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/checkbox.api.md
@@ -25,6 +25,7 @@ export type CheckboxState = CheckboxBaseState & {
     root: {
         'data-disabled'?: string;
         'data-checked'?: string;
+        'data-label-position'?: CheckboxBaseState['labelPosition'];
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/combobox.api.md
@@ -84,6 +84,7 @@ export type OptionState = OptionState_2 & {
     root: {
         'data-disabled'?: string;
         'data-selected'?: string;
+        'data-multiselect'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
@@ -81,6 +81,7 @@ export type OptionState = OptionState_2 & {
     root: {
         'data-disabled'?: string;
         'data-selected'?: string;
+        'data-multiselect'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/info-label.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/info-label.api.md
@@ -31,7 +31,11 @@ export type InfoButtonSlots = {
 };
 
 // @public
-export type InfoButtonState = ComponentState<InfoButtonSlots>;
+export type InfoButtonState = ComponentState<InfoButtonSlots> & {
+    root: {
+        'data-open'?: string;
+    };
+};
 
 // @public
 export const InfoLabel: ForwardRefComponent<InfoLabelProps>;

--- a/packages/react-components/react-headless-components-preview/library/etc/input.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/input.api.md
@@ -24,6 +24,7 @@ export type InputSlots = InputSlots_2;
 export type InputState = InputBaseState & {
     root: {
         'data-disabled'?: string;
+        'data-invalid'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/label.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/label.api.md
@@ -24,6 +24,7 @@ export type LabelSlots = LabelSlots_2;
 export type LabelState = LabelBaseState & {
     root: {
         'data-disabled'?: string;
+        'data-required'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/link.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/link.api.md
@@ -25,6 +25,7 @@ export type LinkState = LinkBaseState & {
     root: {
         'data-disabled'?: string;
         'data-disabled-focusable'?: string;
+        'data-inline'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/link.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/link.api.md
@@ -25,7 +25,6 @@ export type LinkState = LinkBaseState & {
     root: {
         'data-disabled'?: string;
         'data-disabled-focusable'?: string;
-        'data-inline'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/menu-button.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/menu-button.api.md
@@ -24,6 +24,7 @@ export type MenuButtonState = MenuButtonBaseState & {
         'data-disabled'?: string;
         'data-disabled-focusable'?: string;
         'data-icon-only'?: string;
+        'data-open'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
@@ -24,8 +24,8 @@ import { MenuItemLinkProps } from '@fluentui/react-menu';
 import { MenuItemLinkSlots } from '@fluentui/react-menu';
 import { MenuItemLinkState } from '@fluentui/react-menu';
 import type { MenuItemProps as MenuItemProps_2 } from '@fluentui/react-menu';
-import { MenuItemRadioBaseProps as MenuItemRadioProps } from '@fluentui/react-menu';
-import { MenuItemRadioBaseState as MenuItemRadioState } from '@fluentui/react-menu';
+import type { MenuItemRadioBaseProps } from '@fluentui/react-menu';
+import type { MenuItemRadioBaseState } from '@fluentui/react-menu';
 import { MenuItemSlots } from '@fluentui/react-menu';
 import type { MenuItemState as MenuItemState_2 } from '@fluentui/react-menu';
 import { MenuItemSwitchProps } from '@fluentui/react-menu';
@@ -64,10 +64,6 @@ import { useMenuDivider_unstable as useMenuDivider } from '@fluentui/react-menu'
 import { useMenuGroup_unstable as useMenuGroup } from '@fluentui/react-menu';
 import { useMenuGroupContextValues_unstable as useMenuGroupContextValues } from '@fluentui/react-menu';
 import { useMenuGroupHeader_unstable as useMenuGroupHeader } from '@fluentui/react-menu';
-import { useMenuItemCheckboxBase_unstable as useMenuItemCheckbox } from '@fluentui/react-menu';
-import { useMenuItemLinkBase_unstable as useMenuItemLink } from '@fluentui/react-menu';
-import { useMenuItemRadioBase_unstable as useMenuItemRadio } from '@fluentui/react-menu';
-import { useMenuItemSwitchBase_unstable as useMenuItemSwitch } from '@fluentui/react-menu';
 import { useMenuListContextValues_unstable as useMenuListContextValues } from '@fluentui/react-menu';
 
 // @public
@@ -113,14 +109,14 @@ export { MenuGroupState }
 export const MenuItem: ForwardRefComponent<MenuItemProps>;
 
 // @public
-export const MenuItemCheckbox: ForwardRefComponent<MenuItemCheckboxProps>;
+export const MenuItemCheckbox: ForwardRefComponent<MenuItemCheckboxProps_2>;
 
 export { MenuItemCheckboxProps }
 
 export { MenuItemCheckboxState }
 
 // @public
-export const MenuItemLink: ForwardRefComponent<MenuItemLinkProps>;
+export const MenuItemLink: ForwardRefComponent<MenuItemLinkProps_2>;
 
 export { MenuItemLinkProps }
 
@@ -134,9 +130,18 @@ export type MenuItemProps = MenuItemProps_2;
 // @public
 export const MenuItemRadio: ForwardRefComponent<MenuItemRadioProps>;
 
-export { MenuItemRadioProps }
+// @public (undocumented)
+export type MenuItemRadioProps = MenuItemRadioBaseProps;
 
-export { MenuItemRadioState }
+// @public (undocumented)
+export type MenuItemRadioState = MenuItemRadioBaseState & {
+    root: {
+        'data-disabled'?: string;
+        'data-has-submenu'?: string;
+        'data-submenu-open'?: string;
+        'data-checked'?: string;
+    };
+};
 
 export { MenuItemSlots }
 
@@ -144,11 +149,14 @@ export { MenuItemSlots }
 export type MenuItemState = MenuItemState_2 & {
     root: {
         focusgroupstart?: string;
+        'data-disabled'?: string;
+        'data-has-submenu'?: string;
+        'data-submenu-open'?: string;
     };
 };
 
 // @public
-export const MenuItemSwitch: ForwardRefComponent<MenuItemSwitchProps>;
+export const MenuItemSwitch: ForwardRefComponent<MenuItemSwitchProps_2>;
 
 export { MenuItemSwitchProps }
 
@@ -254,13 +262,17 @@ export { useMenuGroupHeader }
 // @public
 export const useMenuItem: (props: MenuItemProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemState;
 
-export { useMenuItemCheckbox }
+// @public (undocumented)
+export const useMenuItemCheckbox: (props: MenuItemCheckboxProps_2, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemCheckboxState_2;
 
-export { useMenuItemLink }
+// @public (undocumented)
+export const useMenuItemLink: (props: MenuItemLinkProps_2, ref: React_2.Ref<HTMLAnchorElement>) => MenuItemLinkState_2;
 
-export { useMenuItemRadio }
+// @public (undocumented)
+export const useMenuItemRadio: (props: MenuItemRadioProps, ref: React_2.Ref<ARIAButtonElement<"div">>) => MenuItemRadioState;
 
-export { useMenuItemSwitch }
+// @public (undocumented)
+export const useMenuItemSwitch: (props: MenuItemSwitchProps_2, ref: React_2.Ref<HTMLDivElement>) => MenuItemSwitchState_2;
 
 // @public
 export const useMenuList: (props: MenuListProps, ref: React_2.Ref<HTMLElement>) => MenuListState;

--- a/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
@@ -31,17 +31,17 @@ import { DrawerFooterProps as NavDrawerFooterProps } from '@fluentui/react-drawe
 import { DrawerFooterSlots as NavDrawerFooterSlots } from '@fluentui/react-drawer';
 import { DrawerHeaderProps as NavDrawerHeaderProps } from '@fluentui/react-drawer';
 import { DrawerHeaderSlots as NavDrawerHeaderSlots } from '@fluentui/react-drawer';
-import { NavItemBaseProps as NavItemProps } from '@fluentui/react-nav';
+import type { NavItemBaseProps } from '@fluentui/react-nav';
+import type { NavItemBaseState } from '@fluentui/react-nav';
 import { NavItemRegisterData } from '@fluentui/react-nav';
 import { NavItemSlots } from '@fluentui/react-nav';
-import { NavItemBaseState as NavItemState } from '@fluentui/react-nav';
 import { NavItemValue } from '@fluentui/react-nav';
 import { NavBaseProps as NavProps } from '@fluentui/react-nav';
 import { NavProvider } from '@fluentui/react-nav';
 import { NavSlots } from '@fluentui/react-nav';
-import { NavSubItemBaseProps as NavSubItemProps } from '@fluentui/react-nav';
+import type { NavSubItemBaseProps } from '@fluentui/react-nav';
+import type { NavSubItemBaseState } from '@fluentui/react-nav';
 import { NavSubItemSlots } from '@fluentui/react-nav';
-import { NavSubItemBaseState as NavSubItemState } from '@fluentui/react-nav';
 import { OnNavItemSelectData } from '@fluentui/react-nav';
 import type { OverlayDrawerProps as OverlayDrawerProps_2 } from '@fluentui/react-drawer';
 import * as React_2 from 'react';
@@ -53,8 +53,6 @@ import { useNavCategoryContext_unstable as useNavCategoryContext } from '@fluent
 import { useNavCategoryContextValues_unstable as useNavCategoryContextValues } from '@fluentui/react-nav';
 import { useNavCategoryItemContext_unstable as useNavCategoryItemContext } from '@fluentui/react-nav';
 import { useNavContext_unstable as useNavContext } from '@fluentui/react-nav';
-import { useNavItemBase_unstable as useNavItem } from '@fluentui/react-nav';
-import { useNavSubItemBase_unstable as useNavSubItem } from '@fluentui/react-nav';
 
 // @public
 export const Nav: ForwardRefComponent<NavProps>;
@@ -99,6 +97,10 @@ export type NavCategoryItemSlots = {
 // @public
 export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> & NavCategoryItemContextValue & {
     selected: boolean;
+    root: {
+        'data-open'?: string;
+        'data-selected'?: string;
+    };
 };
 
 export { NavCategoryProps }
@@ -177,13 +179,19 @@ export type NavDrawerState = ComponentState<NavDrawerSlots> & Omit<NavContextVal
 // @public
 export const NavItem: ForwardRefComponent<NavItemProps>;
 
-export { NavItemProps }
+// @public (undocumented)
+export type NavItemProps = NavItemBaseProps;
 
 export { NavItemRegisterData }
 
 export { NavItemSlots }
 
-export { NavItemState }
+// @public (undocumented)
+export type NavItemState = NavItemBaseState & {
+    root: {
+        'data-selected'?: string;
+    };
+};
 
 export { NavItemValue }
 
@@ -233,11 +241,17 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
     open: boolean;
 };
 
-export { NavSubItemProps }
+// @public (undocumented)
+export type NavSubItemProps = NavSubItemBaseProps;
 
 export { NavSubItemSlots }
 
-export { NavSubItemState }
+// @public (undocumented)
+export type NavSubItemState = NavSubItemBaseState & {
+    root: {
+        'data-selected'?: string;
+    };
+};
 
 export { OnNavItemSelectData }
 
@@ -315,12 +329,14 @@ export const useNavDrawerFooter: (props: NavDrawerFooterProps, ref: React_2.Ref<
 // @public
 export const useNavDrawerHeader: (props: NavDrawerHeaderProps, ref: React_2.Ref<HTMLElement>) => NavDrawerHeaderState;
 
-export { useNavItem }
+// @public (undocumented)
+export const useNavItem: (props: NavItemProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => NavItemState;
 
 // @public
 export const useNavSectionHeader: (props: NavSectionHeaderProps, ref: React_2.Ref<HTMLDivElement>) => NavSectionHeaderState;
 
-export { useNavSubItem }
+// @public (undocumented)
+export const useNavSubItem: (props: NavSubItemProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => NavSubItemState;
 
 // @public
 export const useNavSubItemGroup: (props: NavSubItemGroupProps, ref: React_2.Ref<HTMLDivElement>) => NavSubItemGroupState;

--- a/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
@@ -39,8 +39,8 @@ import { NavItemValue } from '@fluentui/react-nav';
 import { NavBaseProps as NavProps } from '@fluentui/react-nav';
 import { NavProvider } from '@fluentui/react-nav';
 import { NavSlots } from '@fluentui/react-nav';
-import type { NavSubItemBaseProps } from '@fluentui/react-nav';
 import type { NavSubItemBaseState } from '@fluentui/react-nav';
+import { NavSubItemBaseProps as NavSubItemProps } from '@fluentui/react-nav';
 import { NavSubItemSlots } from '@fluentui/react-nav';
 import { OnNavItemSelectData } from '@fluentui/react-nav';
 import type { OverlayDrawerProps as OverlayDrawerProps_2 } from '@fluentui/react-drawer';
@@ -241,8 +241,7 @@ export type NavSubItemGroupState = ComponentState<NavSubItemGroupSlots> & {
     open: boolean;
 };
 
-// @public (undocumented)
-export type NavSubItemProps = NavSubItemBaseProps;
+export { NavSubItemProps }
 
 export { NavSubItemSlots }
 

--- a/packages/react-components/react-headless-components-preview/library/etc/persona.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/persona.api.md
@@ -27,7 +27,11 @@ export type PersonaSlots = Omit<PersonaSlots_2, 'avatar' | 'presence'> & {
 };
 
 // @public
-export type PersonaState = ComponentState<PersonaSlots> & Pick<PersonaState_2, 'textPosition' | 'numTextLines'>;
+export type PersonaState = ComponentState<PersonaSlots> & Pick<PersonaState_2, 'textPosition' | 'numTextLines'> & {
+    root: {
+        'data-text-position'?: PersonaState_2['textPosition'];
+    };
+};
 
 // @public (undocumented)
 export const renderPersona: (state: PersonaState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/progress-bar.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/progress-bar.api.md
@@ -21,7 +21,11 @@ export type ProgressBarProps = ProgressBarBaseProps;
 export type ProgressBarSlots = ProgressBarSlots_2;
 
 // @public
-export type ProgressBarState = ProgressBarBaseState;
+export type ProgressBarState = ProgressBarBaseState & {
+    root: {
+        'data-indeterminate'?: string;
+    };
+};
 
 // @public
 export const renderProgressBar: (state: ProgressBarState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/radio-group.api.md
@@ -48,6 +48,7 @@ export type RadioSlots = RadioSlots_2;
 export type RadioState = RadioBaseState & {
     root: {
         'data-disabled'?: string;
+        'data-label-position'?: RadioBaseState['labelPosition'];
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/select.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/select.api.md
@@ -26,6 +26,7 @@ export type SelectSlots = SelectSlots_2;
 export type SelectState = SelectBaseState & {
     root: {
         'data-disabled'?: string;
+        'data-invalid'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/spin-button.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/spin-button.api.md
@@ -28,6 +28,7 @@ export type SpinButtonState = SpinButtonBaseState & {
         'data-disabled'?: string;
         'data-spin-state'?: string;
         'data-at-bound'?: string;
+        'data-invalid'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/switch.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/switch.api.md
@@ -28,6 +28,7 @@ export type SwitchState = SwitchBaseState & {
         'data-disabled'?: string;
         'data-disabled-focusable'?: string;
         'data-checked'?: string;
+        'data-label-position'?: SwitchBaseState['labelPosition'];
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
@@ -52,6 +52,7 @@ export type TabState = TabBaseState & {
         focusgroupstart?: string;
         'data-icon-only'?: string;
         'data-selected'?: string;
+        'data-disabled'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/teaching-popover.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/teaching-popover.api.md
@@ -29,9 +29,9 @@ import { TeachingPopoverCarouselCardState } from '@fluentui/react-teaching-popov
 import { TeachingPopoverCarouselFooterButtonBaseProps as TeachingPopoverCarouselFooterButtonProps } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselFooterButtonSlots } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselFooterButtonBaseState as TeachingPopoverCarouselFooterButtonState } from '@fluentui/react-teaching-popover';
-import { TeachingPopoverCarouselNavButtonBaseProps as TeachingPopoverCarouselNavButtonProps } from '@fluentui/react-teaching-popover';
+import type { TeachingPopoverCarouselNavButtonBaseProps } from '@fluentui/react-teaching-popover';
+import type { TeachingPopoverCarouselNavButtonBaseState } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselNavButtonSlots } from '@fluentui/react-teaching-popover';
-import { TeachingPopoverCarouselNavButtonBaseState as TeachingPopoverCarouselNavButtonState } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselNavBaseProps as TeachingPopoverCarouselNavProps } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselNavSlots } from '@fluentui/react-teaching-popover';
 import { TeachingPopoverCarouselNavBaseState as TeachingPopoverCarouselNavState } from '@fluentui/react-teaching-popover';
@@ -57,7 +57,6 @@ import { useTeachingPopoverCarouselCard_unstable as useTeachingPopoverCarouselCa
 import type { useTeachingPopoverCarouselContextValues_unstable } from '@fluentui/react-teaching-popover';
 import { useTeachingPopoverCarouselFooterButtonBase_unstable as useTeachingPopoverCarouselFooterButton } from '@fluentui/react-teaching-popover';
 import { useTeachingPopoverCarouselNavBase_unstable as useTeachingPopoverCarouselNav } from '@fluentui/react-teaching-popover';
-import { useTeachingPopoverCarouselNavButtonBase_unstable as useTeachingPopoverCarouselNavButton } from '@fluentui/react-teaching-popover';
 import { useTeachingPopoverCarouselPageCount_unstable as useTeachingPopoverCarouselPageCount } from '@fluentui/react-teaching-popover';
 import { useTeachingPopoverFooterBase_unstable as useTeachingPopoverFooter } from '@fluentui/react-teaching-popover';
 import { useTeachingPopoverHeaderBase_unstable as useTeachingPopoverHeader } from '@fluentui/react-teaching-popover';
@@ -168,11 +167,17 @@ export const TeachingPopoverCarouselNav: ForwardRefComponent<TeachingPopoverCaro
 // @public (undocumented)
 export const TeachingPopoverCarouselNavButton: ForwardRefComponent<TeachingPopoverCarouselNavButtonProps>;
 
-export { TeachingPopoverCarouselNavButtonProps }
+// @public (undocumented)
+export type TeachingPopoverCarouselNavButtonProps = TeachingPopoverCarouselNavButtonBaseProps;
 
 export { TeachingPopoverCarouselNavButtonSlots }
 
-export { TeachingPopoverCarouselNavButtonState }
+// @public (undocumented)
+export type TeachingPopoverCarouselNavButtonState = TeachingPopoverCarouselNavButtonBaseState & {
+    root: {
+        'data-selected'?: string;
+    };
+};
 
 export { TeachingPopoverCarouselNavProps }
 
@@ -288,7 +293,8 @@ export { useTeachingPopoverCarouselFooterButton }
 
 export { useTeachingPopoverCarouselNav }
 
-export { useTeachingPopoverCarouselNavButton }
+// @public (undocumented)
+export const useTeachingPopoverCarouselNavButton: (props: TeachingPopoverCarouselNavButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => TeachingPopoverCarouselNavButtonState;
 
 export { useTeachingPopoverCarouselPageCount }
 

--- a/packages/react-components/react-headless-components-preview/library/etc/textarea.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/textarea.api.md
@@ -23,7 +23,13 @@ export type TextareaProps = TextareaBaseProps;
 export type TextareaSlots = TextareaSlots_2;
 
 // @public
-export type TextareaState = TextareaBaseState;
+export type TextareaState = TextareaBaseState & {
+    root: {
+        'data-disabled'?: string;
+        'data-invalid'?: string;
+        'data-resize'?: TextareaBaseState['resize'];
+    };
+};
 
 // @public
 export const useTextarea: (props: TextareaProps, ref: React_2.Ref<HTMLTextAreaElement>) => TextareaState;

--- a/packages/react-components/react-headless-components-preview/library/etc/toggle-button.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/toggle-button.api.md
@@ -31,6 +31,7 @@ export type ToggleButtonState = ToggleButtonBaseState & {
         'data-disabled-focusable'?: string;
         'data-icon-only'?: string;
         'data-checked'?: string;
+        'data-icon-position'?: ToggleButtonBaseState['iconPosition'];
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
@@ -28,7 +28,11 @@ export type TooltipProps = Omit<TooltipBaseProps, 'mountNode'>;
 export { TooltipSlots }
 
 // @public
-export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'>;
+export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'> & {
+    content: {
+        'data-open'?: string;
+    };
+};
 
 export { TooltipTriggerProps }
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
@@ -28,7 +28,11 @@ export type TooltipProps = Omit<TooltipBaseProps, 'mountNode'>;
 export { TooltipSlots }
 
 // @public
-export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'>;
+export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'> & {
+    content: {
+        'data-visible'?: string;
+    };
+};
 
 export { TooltipTriggerProps }
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -1,8 +1,11 @@
-import type { AvatarGroupBaseProps, AvatarGroupBaseState } from '@fluentui/react-avatar';
+import type { AvatarGroupBaseState } from '@fluentui/react-avatar';
 
-export type { AvatarGroupContextValue, AvatarGroupContextValues, AvatarGroupSlots } from '@fluentui/react-avatar';
-
-export type AvatarGroupProps = AvatarGroupBaseProps;
+export type {
+  AvatarGroupContextValue,
+  AvatarGroupContextValues,
+  AvatarGroupSlots,
+  AvatarGroupBaseProps as AvatarGroupProps,
+} from '@fluentui/react-avatar';
 
 export type AvatarGroupState = AvatarGroupBaseState & {
   root: {

--- a/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -1,7 +1,11 @@
-export type {
-  AvatarGroupBaseProps as AvatarGroupProps,
-  AvatarGroupBaseState as AvatarGroupState,
-  AvatarGroupContextValue,
-  AvatarGroupContextValues,
-  AvatarGroupSlots,
-} from '@fluentui/react-avatar';
+import type { AvatarGroupBaseProps, AvatarGroupBaseState } from '@fluentui/react-avatar';
+
+export type { AvatarGroupContextValue, AvatarGroupContextValues, AvatarGroupSlots } from '@fluentui/react-avatar';
+
+export type AvatarGroupProps = AvatarGroupBaseProps;
+
+export type AvatarGroupState = AvatarGroupBaseState & {
+  root: {
+    'data-layout'?: AvatarGroupBaseState['layout'];
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/useAvatarGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/useAvatarGroup.ts
@@ -9,7 +9,11 @@ import type { AvatarGroupProps, AvatarGroupState } from './AvatarGroup.types';
  * Returns the state for an AvatarGroup component, given its props and ref.
  * The returned state can be modified with hooks before being passed to `renderAvatarGroup`.
  */
-export const useAvatarGroup = useAvatarGroupBase_unstable as (
-  props: AvatarGroupProps,
-  ref: React.Ref<HTMLElement>,
-) => AvatarGroupState;
+export const useAvatarGroup = (props: AvatarGroupProps, ref: React.Ref<HTMLDivElement>): AvatarGroupState => {
+  const state: AvatarGroupState = useAvatarGroupBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-layout'] = state.layout;
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Button/Button.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Button/Button.types.ts
@@ -29,5 +29,10 @@ export type ButtonState = ButtonBaseState & {
      * Data attribute set when the button renders only an icon.
      */
     'data-icon-only'?: string;
+
+    /**
+     * Data attribute reflecting the icon position when an icon slot is present.
+     */
+    'data-icon-position'?: ButtonBaseState['iconPosition'];
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Button/useButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Button/useButton.ts
@@ -20,6 +20,8 @@ export const useButton = (props: ButtonProps, ref: React.Ref<HTMLButtonElement |
   state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-icon-position'] = state.icon ? state.iconPosition : undefined;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Card/Card.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Card/Card.types.ts
@@ -28,6 +28,7 @@ export type CardProps = Omit<CardBaseProps, 'focusMode'>;
 export type CardState = CardBaseState & {
   root: {
     'data-selected'?: string;
+    'data-disabled'?: string;
   };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Card/useCard.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Card/useCard.ts
@@ -15,6 +15,8 @@ export const useCard = (props: CardProps, ref: React.Ref<HTMLDivElement>): CardS
 
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-selected'] = stringifyDataAttribute(state.selected);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/Checkbox.types.ts
@@ -25,5 +25,10 @@ export type CheckboxState = CheckboxBaseState & {
      * Data attribute set when the checkbox is checked. Value is 'mixed' when in the indeterminate state.
      */
     'data-checked'?: string;
+
+    /**
+     * Data attribute reflecting the label position.
+     */
+    'data-label-position'?: CheckboxBaseState['labelPosition'];
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/useCheckbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Checkbox/useCheckbox.ts
@@ -22,6 +22,8 @@ export const useCheckbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElemen
   state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-checked'] = stringifyDataAttribute(state.checked);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-label-position'] = state.labelPosition;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/Option.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/Option.types.ts
@@ -24,5 +24,9 @@ export type OptionState = OptionBaseState & {
      * Whether the option is currently selected.
      */
     'data-selected'?: string;
+    /**
+     * Whether the option belongs to a multiselect listbox.
+     */
+    'data-multiselect'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/useOption.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Option/useOption.ts
@@ -17,6 +17,8 @@ export const useOption = (props: OptionProps, ref: React.Ref<HTMLElement>): Opti
   state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-selected'] = stringifyDataAttribute(state.selected);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-multiselect'] = stringifyDataAttribute(state.multiselect);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.test.tsx
@@ -1,5 +1,7 @@
+import * as React from 'react';
 import { InfoButton } from './InfoButton';
 import { isConformant } from '../../../testing/isConformant';
+import { render } from '@testing-library/react';
 
 describe('InfoButton', () => {
   isConformant({
@@ -9,5 +11,11 @@ describe('InfoButton', () => {
       info: "This is an InfoButton's information.",
     },
     disabledTests: ['component-has-static-classnames-object', 'exported-top-level', 'has-top-level-file-extra'],
+  });
+
+  it('exposes open state on the trigger', () => {
+    const { getByRole } = render(<InfoButton info="Information" popover={{ open: true }} />);
+
+    expect(getByRole('button', { name: 'information' })).toHaveAttribute('data-open');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.test.tsx
@@ -14,8 +14,19 @@ describe('InfoButton', () => {
   });
 
   it('exposes open state on the trigger', () => {
-    const { getByRole } = render(<InfoButton info="Information" popover={{ open: true }} />);
+    const { getByRole, rerender } = render(<InfoButton info="Information" popover={{ open: true }} />);
+    const trigger = getByRole('button', { name: 'information' });
 
-    expect(getByRole('button', { name: 'information' })).toHaveAttribute('data-open');
+    expect(trigger).toHaveAttribute('data-open', '');
+
+    rerender(<InfoButton info="Information" popover={{ open: false }} />);
+
+    expect(trigger).not.toHaveAttribute('data-open');
+  });
+
+  it('does not expose open state by default', () => {
+    const { getByRole } = render(<InfoButton info="Information" />);
+
+    expect(getByRole('button', { name: 'information' })).not.toHaveAttribute('data-open');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/InfoButton.types.ts
@@ -28,4 +28,8 @@ export type InfoButtonProps = Omit<ComponentProps<Partial<InfoButtonSlots>>, 'di
 /**
  * State used in rendering InfoButton
  */
-export type InfoButtonState = ComponentState<InfoButtonSlots>;
+export type InfoButtonState = ComponentState<InfoButtonSlots> & {
+  root: {
+    'data-open'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/useInfoButton.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/InfoLabel/InfoButton/useInfoButton.tsx
@@ -14,6 +14,7 @@ import {
 import type { InfoButtonProps, InfoButtonState } from './InfoButton.types';
 import { Popover, PopoverSurface } from '../../Popover';
 import type { PopoverProps } from '../../Popover';
+import { stringifyDataAttribute } from '../../../utils';
 
 /**
  * Create the state required to render InfoButton.
@@ -66,6 +67,7 @@ export const useInfoButton = (props: InfoButtonProps, ref: React.Ref<HTMLButtonE
   });
 
   state.popover.open = popoverOpen;
+  state.root['data-open'] = stringifyDataAttribute(popoverOpen);
   state.popover.onOpenChange = mergeCallbacks(state.popover.onOpenChange, (_e, data) => setPopoverOpen(data.open));
 
   const infoRef = useMergedRefs(state.info.ref);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Input/Input.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Input/Input.test.tsx
@@ -11,12 +11,23 @@ describe('Input', () => {
   });
 
   it('renders a default state', () => {
-    const { getByRole } = render(<Input placeholder="Input your text" />);
+    const { container, getByRole } = render(<Input placeholder="Input your text" />);
+    const root = container.firstElementChild!;
     const input = getByRole('textbox');
 
+    expect(root).not.toHaveAttribute('data-invalid');
     expect(input).toBeInTheDocument();
     expect(input).toHaveAttribute('placeholder', 'Input your text');
     expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('exposes invalid state on the root while preserving aria-invalid on the input', () => {
+    const { container, getByRole } = render(<Input aria-invalid />);
+    const root = container.firstElementChild!;
+    const input = getByRole('textbox');
+
+    expect(root).toHaveAttribute('data-invalid', '');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
   });
 
   it('renders with data-disabled when disabled', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Input/Input.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Input/Input.types.ts
@@ -19,5 +19,10 @@ export type InputState = InputBaseState & {
      * Data attribute set when the input is disabled.
      */
     'data-disabled'?: string;
+
+    /**
+     * Data attribute set when the input is invalid.
+     */
+    'data-invalid'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Input/useInput.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Input/useInput.ts
@@ -16,6 +16,10 @@ export const useInput = (props: InputProps, ref: React.Ref<HTMLInputElement>): I
   // Set data attribute for disabled state to simplify styling.
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled'] = stringifyDataAttribute(state.input.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-invalid'] = stringifyDataAttribute(
+    state.input['aria-invalid'] === true || state.input['aria-invalid'] === 'true',
+  );
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Label/Label.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Label/Label.types.ts
@@ -19,5 +19,10 @@ export type LabelState = LabelBaseState & {
      * Data attribute set when the label is disabled.
      */
     'data-disabled'?: string;
+
+    /**
+     * Data attribute set when the required indicator is rendered.
+     */
+    'data-required'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Label/useLabel.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Label/useLabel.ts
@@ -16,6 +16,8 @@ export const useLabel = (props: LabelProps, ref: React.Ref<HTMLLabelElement>): L
   // Set data attribute for disabled state to simplify styling.
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-required'] = stringifyDataAttribute(Boolean(state.required));
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Link/Link.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Link/Link.types.ts
@@ -24,5 +24,10 @@ export type LinkState = LinkBaseState & {
      * Data attribute set when the link is disabled but still focusable.
      */
     'data-disabled-focusable'?: string;
+
+    /**
+     * Data attribute set when the link is rendered inline.
+     */
+    'data-inline'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Link/Link.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Link/Link.types.ts
@@ -24,10 +24,5 @@ export type LinkState = LinkBaseState & {
      * Data attribute set when the link is disabled but still focusable.
      */
     'data-disabled-focusable'?: string;
-
-    /**
-     * Data attribute set when the link is rendered inline.
-     */
-    'data-inline'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Link/useLink.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Link/useLink.ts
@@ -17,6 +17,8 @@ export const useLink = (props: LinkProps, ref: React.Ref<HTMLElement>): LinkStat
   state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-inline'] = stringifyDataAttribute(state.inline);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.test.tsx
@@ -195,6 +195,40 @@ describe('Menu', () => {
     expect(getAllByRole('menuitem')).toHaveLength(2);
   });
 
+  it('exposes MenuItem interaction state through data attributes', () => {
+    const { getByText, getByTestId } = render(
+      <Menu defaultOpen>
+        <MenuTrigger>
+          <button>Trigger</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem disabled data-testid="disabled-item">
+              Disabled item
+            </MenuItem>
+            <Menu>
+              <MenuTrigger>
+                <MenuItem hasSubmenu data-testid="submenu-item">
+                  Submenu item
+                </MenuItem>
+              </MenuTrigger>
+              <MenuPopover>
+                <MenuList>
+                  <MenuItem>Nested item</MenuItem>
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    expect(getByTestId('disabled-item')).toHaveAttribute('data-disabled');
+    expect(getByTestId('submenu-item')).toHaveAttribute('data-has-submenu');
+    userEvent.click(getByText('Submenu item'));
+    expect(getByTestId('submenu-item')).toHaveAttribute('data-submenu-open');
+  });
+
   it('renders MenuDivider with role="presentation" and aria-hidden', () => {
     const { container } = render(
       <Menu defaultOpen>
@@ -294,6 +328,7 @@ describe('Menu', () => {
       );
 
       expect(getByRole('menuitemcheckbox')).toBeInTheDocument();
+      expect(getByRole('menuitemcheckbox')).not.toHaveAttribute('data-checked');
     });
 
     it('toggles aria-checked on click via controlled checkedValues', () => {
@@ -338,6 +373,7 @@ describe('Menu', () => {
       );
 
       expect(getByRole('menuitemcheckbox')).toHaveAttribute('aria-checked', 'true');
+      expect(getByRole('menuitemcheckbox')).toHaveAttribute('data-checked');
     });
   });
 
@@ -385,6 +421,7 @@ describe('Menu', () => {
 
       const [name, size] = getAllByRole('menuitemradio');
       expect(name).toHaveAttribute('aria-checked', 'true');
+      expect(name).toHaveAttribute('data-checked');
       expect(size).toHaveAttribute('aria-checked', 'false');
 
       userEvent.click(size);
@@ -404,7 +441,9 @@ describe('Menu', () => {
           </MenuTrigger>
           <MenuPopover>
             <MenuList>
-              <MenuItemLink href="https://example.com">Docs</MenuItemLink>
+              <MenuItemLink href="https://example.com" disabled>
+                Docs
+              </MenuItemLink>
             </MenuList>
           </MenuPopover>
         </Menu>,
@@ -413,13 +452,14 @@ describe('Menu', () => {
       const link = getByRole('menuitem');
       expect(link.tagName).toBe('A');
       expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveAttribute('data-disabled');
     });
   });
 
   describe('MenuItemSwitch', () => {
     it('renders an item with switchIndicator slot', () => {
       const { getByText, container } = render(
-        <Menu defaultOpen>
+        <Menu defaultOpen defaultCheckedValues={{ view: ['grid'] }}>
           <MenuTrigger>
             <button>Trigger</button>
           </MenuTrigger>
@@ -435,6 +475,7 @@ describe('Menu', () => {
 
       expect(getByText('Grid view')).toBeInTheDocument();
       expect(container.querySelector('[data-testid="switch"]')).toBeInTheDocument();
+      expect(getByText('Grid view').closest('[role="menuitemcheckbox"]')).toHaveAttribute('data-checked');
     });
   });
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -7,5 +7,8 @@ export type MenuItemProps = MenuItemBaseProps;
 export type MenuItemState = MenuItemBaseState & {
   root: {
     focusgroupstart?: string;
+    'data-disabled'?: string;
+    'data-has-submenu'?: string;
+    'data-submenu-open'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/useMenuItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/useMenuItem.ts
@@ -5,6 +5,15 @@ import { useMenuItemBase_unstable } from '@fluentui/react-menu';
 import type { ARIAButtonElement } from '@fluentui/react-aria';
 
 import type { MenuItemProps, MenuItemState } from './MenuItem.types';
+import { stringifyDataAttribute } from '../../../utils';
+
+export const setMenuItemDataAttributes = (
+  state: Pick<MenuItemState, 'disabled' | 'hasSubmenu' | 'submenuOpen' | 'root'>,
+): void => {
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  state.root['data-has-submenu'] = stringifyDataAttribute(state.hasSubmenu);
+  state.root['data-submenu-open'] = stringifyDataAttribute(state.submenuOpen);
+};
 
 /** Returns the state for a MenuItem; adds `focusgroupstart` so the focusgroup polyfill anchors the initial tab stop on the first item. */
 export const useMenuItem = (props: MenuItemProps, ref: React.Ref<ARIAButtonElement<'div'>>): MenuItemState => {
@@ -12,6 +21,7 @@ export const useMenuItem = (props: MenuItemProps, ref: React.Ref<ARIAButtonEleme
 
   // eslint-disable-next-line react-hooks/immutability -- attribute is mutated to opt into the focusgroup polyfill.
   state.root.focusgroupstart = '';
+  setMenuItemDataAttributes(state);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/useMenuItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/useMenuItem.ts
@@ -7,21 +7,18 @@ import type { ARIAButtonElement } from '@fluentui/react-aria';
 import type { MenuItemProps, MenuItemState } from './MenuItem.types';
 import { stringifyDataAttribute } from '../../../utils';
 
-export const setMenuItemDataAttributes = (
-  state: Pick<MenuItemState, 'disabled' | 'hasSubmenu' | 'submenuOpen' | 'root'>,
-): void => {
-  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
-  state.root['data-has-submenu'] = stringifyDataAttribute(state.hasSubmenu);
-  state.root['data-submenu-open'] = stringifyDataAttribute(state.submenuOpen);
-};
-
 /** Returns the state for a MenuItem; adds `focusgroupstart` so the focusgroup polyfill anchors the initial tab stop on the first item. */
 export const useMenuItem = (props: MenuItemProps, ref: React.Ref<ARIAButtonElement<'div'>>): MenuItemState => {
   const state: MenuItemState = useMenuItemBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability -- attribute is mutated to opt into the focusgroup polyfill.
   state.root.focusgroupstart = '';
-  setMenuItemDataAttributes(state);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-has-submenu'] = stringifyDataAttribute(state.hasSubmenu);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-submenu-open'] = stringifyDataAttribute(state.submenuOpen);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -5,7 +5,7 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { ARIAButtonElement } from '@fluentui/react-aria';
 import { useMenuItemCheckbox } from './useMenuItemCheckbox';
 import { renderMenuItemCheckbox } from './renderMenuItemCheckbox';
-import type { MenuItemCheckboxProps } from '@fluentui/react-menu';
+import type { MenuItemCheckboxProps } from './MenuItemCheckbox.types';
 
 /**
  * Headless MenuItemCheckbox component.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/MenuItemCheckbox.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/MenuItemCheckbox.types.ts
@@ -1,0 +1,15 @@
+import type {
+  MenuItemCheckboxProps as MenuItemCheckboxBaseProps,
+  MenuItemCheckboxState as MenuItemCheckboxBaseState,
+} from '@fluentui/react-menu';
+
+export type MenuItemCheckboxProps = MenuItemCheckboxBaseProps;
+
+export type MenuItemCheckboxState = MenuItemCheckboxBaseState & {
+  root: {
+    'data-disabled'?: string;
+    'data-has-submenu'?: string;
+    'data-submenu-open'?: string;
+    'data-checked'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/index.ts
@@ -1,4 +1,4 @@
 export { MenuItemCheckbox } from './MenuItemCheckbox';
 export { useMenuItemCheckbox } from './useMenuItemCheckbox';
 export { renderMenuItemCheckbox } from './renderMenuItemCheckbox';
-export type { MenuItemCheckboxProps, MenuItemCheckboxState } from '@fluentui/react-menu';
+export type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -4,7 +4,6 @@ import type * as React from 'react';
 import type { ARIAButtonElement } from '@fluentui/react-aria';
 import { useMenuItemCheckboxBase_unstable } from '@fluentui/react-menu';
 import { stringifyDataAttribute } from '../../../utils';
-import { setMenuItemDataAttributes } from '../MenuItem/useMenuItem';
 import type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
 
 export const useMenuItemCheckbox = (
@@ -13,7 +12,12 @@ export const useMenuItemCheckbox = (
 ): MenuItemCheckboxState => {
   const state: MenuItemCheckboxState = useMenuItemCheckboxBase_unstable(props, ref);
 
-  setMenuItemDataAttributes(state);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-has-submenu'] = stringifyDataAttribute(state.hasSubmenu);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-submenu-open'] = stringifyDataAttribute(state.submenuOpen);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-checked'] = stringifyDataAttribute(state.checked);
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/useMenuItemCheckbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemCheckbox/useMenuItemCheckbox.ts
@@ -1,1 +1,21 @@
-export { useMenuItemCheckboxBase_unstable as useMenuItemCheckbox } from '@fluentui/react-menu';
+'use client';
+
+import type * as React from 'react';
+import type { ARIAButtonElement } from '@fluentui/react-aria';
+import { useMenuItemCheckboxBase_unstable } from '@fluentui/react-menu';
+import { stringifyDataAttribute } from '../../../utils';
+import { setMenuItemDataAttributes } from '../MenuItem/useMenuItem';
+import type { MenuItemCheckboxProps, MenuItemCheckboxState } from './MenuItemCheckbox.types';
+
+export const useMenuItemCheckbox = (
+  props: MenuItemCheckboxProps,
+  ref: React.Ref<ARIAButtonElement<'div'>>,
+): MenuItemCheckboxState => {
+  const state: MenuItemCheckboxState = useMenuItemCheckboxBase_unstable(props, ref);
+
+  setMenuItemDataAttributes(state);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-checked'] = stringifyDataAttribute(state.checked);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/MenuItemLink.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/MenuItemLink.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuItemLink } from './useMenuItemLink';
 import { renderMenuItemLink } from './renderMenuItemLink';
-import type { MenuItemLinkProps } from '@fluentui/react-menu';
+import type { MenuItemLinkProps } from './MenuItemLink.types';
 
 /**
  * Headless MenuItemLink component.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/MenuItemLink.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/MenuItemLink.types.ts
@@ -1,0 +1,15 @@
+import type {
+  MenuItemLinkProps as MenuItemLinkBaseProps,
+  MenuItemLinkState as MenuItemLinkBaseState,
+  MenuItemLinkSlots,
+} from '@fluentui/react-menu';
+
+export type { MenuItemLinkSlots };
+
+export type MenuItemLinkProps = MenuItemLinkBaseProps;
+
+export type MenuItemLinkState = MenuItemLinkBaseState & {
+  root: {
+    'data-disabled'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/index.ts
@@ -1,4 +1,4 @@
 export { MenuItemLink } from './MenuItemLink';
 export { useMenuItemLink } from './useMenuItemLink';
 export { renderMenuItemLink } from './renderMenuItemLink';
-export type { MenuItemLinkProps, MenuItemLinkSlots, MenuItemLinkState } from '@fluentui/react-menu';
+export type { MenuItemLinkProps, MenuItemLinkSlots, MenuItemLinkState } from './MenuItemLink.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/useMenuItemLink.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemLink/useMenuItemLink.ts
@@ -1,1 +1,15 @@
-export { useMenuItemLinkBase_unstable as useMenuItemLink } from '@fluentui/react-menu';
+'use client';
+
+import type * as React from 'react';
+import { useMenuItemLinkBase_unstable } from '@fluentui/react-menu';
+import { stringifyDataAttribute } from '../../../utils';
+import type { MenuItemLinkProps, MenuItemLinkState } from './MenuItemLink.types';
+
+export const useMenuItemLink = (props: MenuItemLinkProps, ref: React.Ref<HTMLAnchorElement>): MenuItemLinkState => {
+  const state: MenuItemLinkState = useMenuItemLinkBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(props.disabled);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/MenuItemRadio.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/MenuItemRadio.types.ts
@@ -1,4 +1,12 @@
-export type {
-  MenuItemRadioBaseProps as MenuItemRadioProps,
-  MenuItemRadioBaseState as MenuItemRadioState,
-} from '@fluentui/react-menu';
+import type { MenuItemRadioBaseProps, MenuItemRadioBaseState } from '@fluentui/react-menu';
+
+export type MenuItemRadioProps = MenuItemRadioBaseProps;
+
+export type MenuItemRadioState = MenuItemRadioBaseState & {
+  root: {
+    'data-disabled'?: string;
+    'data-has-submenu'?: string;
+    'data-submenu-open'?: string;
+    'data-checked'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/useMenuItemRadio.ts
@@ -4,7 +4,6 @@ import type * as React from 'react';
 import type { ARIAButtonElement } from '@fluentui/react-aria';
 import { useMenuItemRadioBase_unstable } from '@fluentui/react-menu';
 import { stringifyDataAttribute } from '../../../utils';
-import { setMenuItemDataAttributes } from '../MenuItem/useMenuItem';
 import type { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio.types';
 
 export const useMenuItemRadio = (
@@ -13,7 +12,12 @@ export const useMenuItemRadio = (
 ): MenuItemRadioState => {
   const state: MenuItemRadioState = useMenuItemRadioBase_unstable(props, ref);
 
-  setMenuItemDataAttributes(state);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-has-submenu'] = stringifyDataAttribute(state.hasSubmenu);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-submenu-open'] = stringifyDataAttribute(state.submenuOpen);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-checked'] = stringifyDataAttribute(state.checked);
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/useMenuItemRadio.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemRadio/useMenuItemRadio.ts
@@ -1,1 +1,21 @@
-export { useMenuItemRadioBase_unstable as useMenuItemRadio } from '@fluentui/react-menu';
+'use client';
+
+import type * as React from 'react';
+import type { ARIAButtonElement } from '@fluentui/react-aria';
+import { useMenuItemRadioBase_unstable } from '@fluentui/react-menu';
+import { stringifyDataAttribute } from '../../../utils';
+import { setMenuItemDataAttributes } from '../MenuItem/useMenuItem';
+import type { MenuItemRadioProps, MenuItemRadioState } from './MenuItemRadio.types';
+
+export const useMenuItemRadio = (
+  props: MenuItemRadioProps,
+  ref: React.Ref<ARIAButtonElement<'div'>>,
+): MenuItemRadioState => {
+  const state: MenuItemRadioState = useMenuItemRadioBase_unstable(props, ref);
+
+  setMenuItemDataAttributes(state);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-checked'] = stringifyDataAttribute(state.checked);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/MenuItemSwitch.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/MenuItemSwitch.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { useMenuItemSwitch } from './useMenuItemSwitch';
 import { renderMenuItemSwitch } from './renderMenuItemSwitch';
-import type { MenuItemSwitchProps } from '@fluentui/react-menu';
+import type { MenuItemSwitchProps } from './MenuItemSwitch.types';
 
 /**
  * Headless MenuItemSwitch component.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/MenuItemSwitch.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/MenuItemSwitch.types.ts
@@ -1,0 +1,16 @@
+import type {
+  MenuItemSwitchProps as MenuItemSwitchBaseProps,
+  MenuItemSwitchState as MenuItemSwitchBaseState,
+  MenuItemSwitchSlots,
+} from '@fluentui/react-menu';
+
+export type { MenuItemSwitchSlots };
+
+export type MenuItemSwitchProps = MenuItemSwitchBaseProps;
+
+export type MenuItemSwitchState = MenuItemSwitchBaseState & {
+  root: {
+    'data-disabled'?: string;
+    'data-checked'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/index.ts
@@ -1,4 +1,4 @@
 export { MenuItemSwitch } from './MenuItemSwitch';
 export { useMenuItemSwitch } from './useMenuItemSwitch';
 export { renderMenuItemSwitch } from './renderMenuItemSwitch';
-export type { MenuItemSwitchProps, MenuItemSwitchSlots, MenuItemSwitchState } from '@fluentui/react-menu';
+export type { MenuItemSwitchProps, MenuItemSwitchSlots, MenuItemSwitchState } from './MenuItemSwitch.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/useMenuItemSwitch.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItemSwitch/useMenuItemSwitch.ts
@@ -1,1 +1,17 @@
-export { useMenuItemSwitchBase_unstable as useMenuItemSwitch } from '@fluentui/react-menu';
+'use client';
+
+import type * as React from 'react';
+import { useMenuItemSwitchBase_unstable } from '@fluentui/react-menu';
+import { stringifyDataAttribute } from '../../../utils';
+import type { MenuItemSwitchProps, MenuItemSwitchState } from './MenuItemSwitch.types';
+
+export const useMenuItemSwitch = (props: MenuItemSwitchProps, ref: React.Ref<HTMLDivElement>): MenuItemSwitchState => {
+  const state: MenuItemSwitchState = useMenuItemSwitchBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-checked'] = stringifyDataAttribute(state.checked);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MenuButton/MenuButton.types.ts
@@ -21,5 +21,10 @@ export type MenuButtonState = MenuButtonBaseState & {
      * Data attribute set when the button renders only an icon.
      */
     'data-icon-only'?: string;
+
+    /**
+     * Data attribute set when the menu is open.
+     */
+    'data-open'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/MenuButton/useMenuButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/MenuButton/useMenuButton.ts
@@ -23,6 +23,10 @@ export const useMenuButton = (
   state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-open'] = stringifyDataAttribute(
+    state.root['aria-expanded'] === true || state.root['aria-expanded'] === 'true',
+  );
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.test.tsx
@@ -50,7 +50,9 @@ describe('Nav', () => {
     );
 
     expect(result.getByText('Item 1')).toHaveAttribute('aria-current', 'page');
+    expect(result.getByText('Item 1')).toHaveAttribute('data-selected');
     expect(result.getByText('Item 2')).not.toHaveAttribute('aria-current', 'page');
+    expect(result.getByText('Item 2')).not.toHaveAttribute('data-selected');
   });
 
   it('supports controlled selectedValue', () => {
@@ -87,6 +89,7 @@ describe('Nav', () => {
     );
 
     expect(result.getByText('Category 1')).toHaveAttribute('aria-expanded', 'true');
+    expect(result.getByText('Category 1')).toHaveAttribute('data-open');
     expect(result.getByText('Sub Item 1')).toBeInTheDocument();
   });
 
@@ -109,6 +112,7 @@ describe('Nav', () => {
     // Click to open
     fireEvent.click(result.getByText('Category 1'));
     expect(result.getByText('Category 1')).toHaveAttribute('aria-expanded', 'true');
+    expect(result.getByText('Category 1')).toHaveAttribute('data-open');
     expect(result.getByText('Sub Item 1')).toBeInTheDocument();
 
     // Click to close

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/NavCategoryItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/NavCategoryItem.types.ts
@@ -40,4 +40,8 @@ export type NavCategoryItemState = ComponentState<NavCategoryItemSlots> &
      * If this navCategoryItem is selected
      */
     selected: boolean;
+    root: {
+      'data-open'?: string;
+      'data-selected'?: string;
+    };
   };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/useNavCategoryItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/useNavCategoryItem.ts
@@ -5,6 +5,7 @@ import { getIntrinsicElementProps, mergeCallbacks, slot, useEventCallback } from
 import { useNavContext_unstable, useNavCategoryContext_unstable, type OnNavItemSelectData } from '@fluentui/react-nav';
 
 import type { NavCategoryItemProps, NavCategoryItemState } from './NavCategoryItem.types';
+import { stringifyDataAttribute } from '../../../utils';
 
 /**
  * Create the state required to render NavCategoryItem.
@@ -34,7 +35,7 @@ export const useNavCategoryItem = (
   const selected = selectedCategoryValue === value && !open;
   const validAriaCurrent: 'page' | 'false' = selected ? 'page' : 'false';
 
-  return {
+  const state: NavCategoryItemState = {
     open,
     value,
     selected,
@@ -60,4 +61,9 @@ export const useNavCategoryItem = (
       expandIcon: 'span',
     },
   };
+
+  state.root['data-open'] = stringifyDataAttribute(state.open);
+  state.root['data-selected'] = stringifyDataAttribute(state.selected);
+
+  return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavItem/NavItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavItem/NavItem.types.ts
@@ -1,5 +1,11 @@
-export type {
-  NavItemSlots,
-  NavItemBaseProps as NavItemProps,
-  NavItemBaseState as NavItemState,
-} from '@fluentui/react-nav';
+import type { NavItemBaseProps, NavItemBaseState } from '@fluentui/react-nav';
+
+export type { NavItemSlots } from '@fluentui/react-nav';
+
+export type NavItemProps = NavItemBaseProps;
+
+export type NavItemState = NavItemBaseState & {
+  root: {
+    'data-selected'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavItem/useNavItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavItem/useNavItem.ts
@@ -1,1 +1,18 @@
-export { useNavItemBase_unstable as useNavItem } from '@fluentui/react-nav';
+'use client';
+
+import type * as React from 'react';
+import { useNavItemBase_unstable } from '@fluentui/react-nav';
+import { stringifyDataAttribute } from '../../../utils';
+import type { NavItemProps, NavItemState } from './NavItem.types';
+
+export const useNavItem = (
+  props: NavItemProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): NavItemState => {
+  const state: NavItemState = useNavItemBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-selected'] = stringifyDataAttribute(state.selected);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/NavSubItem.types.ts
@@ -1,5 +1,11 @@
-export type {
-  NavSubItemSlots,
-  NavSubItemBaseProps as NavSubItemProps,
-  NavSubItemBaseState as NavSubItemState,
-} from '@fluentui/react-nav';
+import type { NavSubItemBaseProps, NavSubItemBaseState } from '@fluentui/react-nav';
+
+export type { NavSubItemSlots } from '@fluentui/react-nav';
+
+export type NavSubItemProps = NavSubItemBaseProps;
+
+export type NavSubItemState = NavSubItemBaseState & {
+  root: {
+    'data-selected'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/NavSubItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/NavSubItem.types.ts
@@ -1,8 +1,6 @@
-import type { NavSubItemBaseProps, NavSubItemBaseState } from '@fluentui/react-nav';
+import type { NavSubItemBaseState } from '@fluentui/react-nav';
 
-export type { NavSubItemSlots } from '@fluentui/react-nav';
-
-export type NavSubItemProps = NavSubItemBaseProps;
+export type { NavSubItemSlots, NavSubItemBaseProps as NavSubItemProps } from '@fluentui/react-nav';
 
 export type NavSubItemState = NavSubItemBaseState & {
   root: {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/useNavSubItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavSubItem/useNavSubItem.ts
@@ -1,1 +1,18 @@
-export { useNavSubItemBase_unstable as useNavSubItem } from '@fluentui/react-nav';
+'use client';
+
+import type * as React from 'react';
+import { useNavSubItemBase_unstable } from '@fluentui/react-nav';
+import { stringifyDataAttribute } from '../../../utils';
+import type { NavSubItemProps, NavSubItemState } from './NavSubItem.types';
+
+export const useNavSubItem = (
+  props: NavSubItemProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): NavSubItemState => {
+  const state: NavSubItemState = useNavSubItemBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-selected'] = stringifyDataAttribute(state.selected);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Persona/Persona.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Persona/Persona.types.ts
@@ -18,4 +18,9 @@ export type PersonaProps = ComponentProps<PersonaSlots> & Pick<PersonaBaseProps,
 /**
  * State used in rendering Persona
  */
-export type PersonaState = ComponentState<PersonaSlots> & Pick<PersonaBaseState, 'textPosition' | 'numTextLines'>;
+export type PersonaState = ComponentState<PersonaSlots> &
+  Pick<PersonaBaseState, 'textPosition' | 'numTextLines'> & {
+    root: {
+      'data-text-position'?: PersonaBaseState['textPosition'];
+    };
+  };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Persona/usePersona.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Persona/usePersona.ts
@@ -19,7 +19,7 @@ export const usePersona = (props: PersonaProps, ref: React.Ref<HTMLDivElement>):
   const { textPosition = 'after', ...baseProps } = props;
   const baseState = usePersonaBase_unstable(baseProps, ref);
 
-  return {
+  const state: PersonaState = {
     ...baseState,
     textPosition,
     components: {
@@ -35,4 +35,8 @@ export const usePersona = (props: PersonaProps, ref: React.Ref<HTMLDivElement>):
       elementType: Avatar,
     }),
   };
+
+  state.root['data-text-position'] = state.textPosition;
+
+  return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/ProgressBar.types.ts
@@ -14,4 +14,8 @@ export type ProgressBarProps = ProgressBarBaseProps;
 /**
  * State used in rendering ProgressBar
  */
-export type ProgressBarState = ProgressBarBaseState;
+export type ProgressBarState = ProgressBarBaseState & {
+  root: {
+    'data-indeterminate'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/useProgressBar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ProgressBar/useProgressBar.ts
@@ -4,6 +4,7 @@ import type * as React from 'react';
 import { useProgressBarBase_unstable } from '@fluentui/react-progress';
 
 import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
+import { stringifyDataAttribute } from '../../utils';
 
 /**
  * Create the state required to render ProgressBar.
@@ -15,7 +16,10 @@ import type { ProgressBarProps, ProgressBarState } from './ProgressBar.types';
  * @param ref - reference to root HTMLDivElement of ProgressBar
  */
 export const useProgressBar = (props: ProgressBarProps, ref: React.Ref<HTMLDivElement>): ProgressBarState => {
-  const state = useProgressBarBase_unstable(props, ref);
+  const state: ProgressBarState = useProgressBarBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-indeterminate'] = stringifyDataAttribute(state.value === undefined);
 
   if (state.bar && state.value !== undefined) {
     // eslint-disable-next-line react-hooks/immutability

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/Radio.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/Radio.types.ts
@@ -19,5 +19,10 @@ export type RadioState = RadioBaseState & {
      * Data attribute set when the radio is disabled.
      */
     'data-disabled'?: string;
+
+    /**
+     * Data attribute reflecting the label position.
+     */
+    'data-label-position'?: RadioBaseState['labelPosition'];
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/RadioGroup/Radio/useRadio.ts
@@ -16,6 +16,8 @@ export const useRadio = (props: RadioProps, ref: React.Ref<HTMLInputElement>): R
   // Set data attribute for disabled state to simplify styling.
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled'] = stringifyDataAttribute(state.input.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-label-position'] = state.labelPosition;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Select/Select.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Select/Select.types.ts
@@ -16,5 +16,10 @@ export type SelectState = SelectBaseState & {
      * Data attribute set when the select is disabled.
      */
     'data-disabled'?: string;
+
+    /**
+     * Data attribute set when the select is invalid.
+     */
+    'data-invalid'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Select/useSelect.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Select/useSelect.ts
@@ -20,6 +20,10 @@ export const useSelect = (props: SelectProps, ref: React.Ref<HTMLSelectElement>)
   // Set data attribute for disabled state to simplify styling.
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled'] = stringifyDataAttribute(state.select.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-invalid'] = stringifyDataAttribute(
+    state.select['aria-invalid'] === true || state.select['aria-invalid'] === 'true',
+  );
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/SpinButton.types.ts
@@ -33,5 +33,10 @@ export type SpinButtonState = SpinButtonBaseState & {
      * Data attribute set when the value is at a range boundary. Value is 'min', 'max', or 'both'.
      */
     'data-at-bound'?: string;
+
+    /**
+     * Data attribute set when the spin button is invalid.
+     */
+    'data-invalid'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/useSpinButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SpinButton/useSpinButton.ts
@@ -20,6 +20,10 @@ export const useSpinButton = (props: SpinButtonProps, ref: React.Ref<HTMLInputEl
   state.root['data-spin-state'] = state.spinState !== 'rest' ? state.spinState : undefined;
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-at-bound'] = state.atBound !== 'none' ? state.atBound : undefined;
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-invalid'] = stringifyDataAttribute(
+    state.input['aria-invalid'] === true || state.input['aria-invalid'] === 'true',
+  );
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Switch/Switch.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Switch/Switch.types.ts
@@ -29,5 +29,10 @@ export type SwitchState = SwitchBaseState & {
      * Data attribute set when the switch is checked (controlled mode only).
      */
     'data-checked'?: string;
+
+    /**
+     * Data attribute reflecting the label position.
+     */
+    'data-label-position'?: SwitchBaseState['labelPosition'];
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Switch/useSwitch.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Switch/useSwitch.ts
@@ -20,6 +20,8 @@ export const useSwitch = (props: SwitchProps, ref: React.Ref<HTMLInputElement>):
   state.root['data-disabled-focusable'] = stringifyDataAttribute(state.disabledFocusable);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-checked'] = stringifyDataAttribute(state.input.checked);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-label-position'] = state.labelPosition;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/Tab.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/Tab.types.ts
@@ -9,5 +9,6 @@ export type TabState = TabBaseState & {
     focusgroupstart?: string;
     'data-icon-only'?: string;
     'data-selected'?: string;
+    'data-disabled'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/useTab.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/useTab.ts
@@ -19,6 +19,8 @@ export const useTab = (props: TabProps, ref: React.Ref<HTMLElement>): TabState =
   state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-selected'] = stringifyDataAttribute(state.selected);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
@@ -5,6 +5,10 @@ import { isConformant } from '../../testing/isConformant';
 import { TeachingPopover } from './TeachingPopover';
 import { TeachingPopoverTrigger } from './TeachingPopoverTrigger';
 import { TeachingPopoverSurface } from './TeachingPopoverSurface';
+import { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
+import { TeachingPopoverCarouselCard } from './TeachingPopoverCarouselCard';
+import { TeachingPopoverCarouselNav } from './TeachingPopoverCarouselNav';
+import { TeachingPopoverCarouselNavButton } from './TeachingPopoverCarouselNavButton';
 
 describe('TeachingPopover', () => {
   isConformant({
@@ -113,5 +117,20 @@ describe('TeachingPopover', () => {
 
     expect(getByText('Surface')).toBeInTheDocument();
     expect(onOpenChange).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ open: true }));
+  });
+
+  it('exposes the selected carousel navigation button', () => {
+    const { getByRole } = render(
+      <TeachingPopoverCarousel defaultValue="one" announcement={index => `Page ${index + 1}`}>
+        <TeachingPopoverCarouselCard value="one">One</TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselCard value="two">Two</TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselNav>
+          {(value: string) => <TeachingPopoverCarouselNavButton aria-label={`Go to ${value}`} />}
+        </TeachingPopoverCarouselNav>
+      </TeachingPopoverCarousel>,
+    );
+
+    expect(getByRole('tab', { name: 'Go to one' })).toHaveAttribute('data-selected');
+    expect(getByRole('tab', { name: 'Go to two' })).not.toHaveAttribute('data-selected');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton.types.ts
@@ -1,5 +1,14 @@
-export type {
-  TeachingPopoverCarouselNavButtonBaseProps as TeachingPopoverCarouselNavButtonProps,
-  TeachingPopoverCarouselNavButtonBaseState as TeachingPopoverCarouselNavButtonState,
-  TeachingPopoverCarouselNavButtonSlots,
+import type {
+  TeachingPopoverCarouselNavButtonBaseProps,
+  TeachingPopoverCarouselNavButtonBaseState,
 } from '@fluentui/react-teaching-popover';
+
+export type { TeachingPopoverCarouselNavButtonSlots } from '@fluentui/react-teaching-popover';
+
+export type TeachingPopoverCarouselNavButtonProps = TeachingPopoverCarouselNavButtonBaseProps;
+
+export type TeachingPopoverCarouselNavButtonState = TeachingPopoverCarouselNavButtonBaseState & {
+  root: {
+    'data-selected'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopoverCarouselNavButton/useTeachingPopoverCarouselNavButton.ts
@@ -1,1 +1,21 @@
-export { useTeachingPopoverCarouselNavButtonBase_unstable as useTeachingPopoverCarouselNavButton } from '@fluentui/react-teaching-popover';
+'use client';
+
+import type * as React from 'react';
+import { useTeachingPopoverCarouselNavButtonBase_unstable } from '@fluentui/react-teaching-popover';
+import { stringifyDataAttribute } from '../../../utils';
+import type {
+  TeachingPopoverCarouselNavButtonProps,
+  TeachingPopoverCarouselNavButtonState,
+} from './TeachingPopoverCarouselNavButton.types';
+
+export const useTeachingPopoverCarouselNavButton = (
+  props: TeachingPopoverCarouselNavButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): TeachingPopoverCarouselNavButtonState => {
+  const state: TeachingPopoverCarouselNavButtonState = useTeachingPopoverCarouselNavButtonBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-selected'] = stringifyDataAttribute(state.isSelected);
+
+  return state;
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Textarea/Textarea.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Textarea/Textarea.test.tsx
@@ -11,11 +11,22 @@ describe('Textarea', () => {
   });
 
   it('renders a default state', () => {
-    const { getByRole } = render(<Textarea placeholder="Default Textarea" />);
+    const { container, getByRole } = render(<Textarea placeholder="Default Textarea" />);
+    const root = container.firstElementChild!;
     const textarea = getByRole('textbox');
 
+    expect(root).not.toHaveAttribute('data-invalid');
     expect(textarea).toBeInTheDocument();
     expect(textarea.tagName).toBe('TEXTAREA');
     expect(textarea).toHaveAttribute('placeholder', 'Default Textarea');
+  });
+
+  it('exposes invalid state on the root while preserving aria-invalid on the textarea', () => {
+    const { container, getByRole } = render(<Textarea aria-invalid />);
+    const root = container.firstElementChild!;
+    const textarea = getByRole('textbox');
+
+    expect(root).toHaveAttribute('data-invalid', '');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Textarea/Textarea.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Textarea/Textarea.types.ts
@@ -17,4 +17,10 @@ export type TextareaProps = TextareaBaseProps;
 /**
  * Textarea component state
  */
-export type TextareaState = TextareaBaseState;
+export type TextareaState = TextareaBaseState & {
+  root: {
+    'data-disabled'?: string;
+    'data-invalid'?: string;
+    'data-resize'?: TextareaBaseState['resize'];
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Textarea/useTextarea.ts
@@ -16,9 +16,7 @@ export const useTextarea = (props: TextareaProps, ref: React.Ref<HTMLTextAreaEle
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-disabled'] = stringifyDataAttribute(state.textarea.disabled);
   // eslint-disable-next-line react-hooks/immutability
-  state.root['data-invalid'] = stringifyDataAttribute(
-    state.textarea['aria-invalid'] === true || state.textarea['aria-invalid'] === 'true',
-  );
+  state.root['data-invalid'] = stringifyDataAttribute(state.textarea['aria-invalid']);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-resize'] = state.resize;
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Textarea/useTextarea.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Textarea/useTextarea.ts
@@ -4,13 +4,23 @@ import type * as React from 'react';
 import { useTextareaBase_unstable } from '@fluentui/react-textarea';
 
 import type { TextareaProps, TextareaState } from './Textarea.types';
+import { stringifyDataAttribute } from '../../utils';
 
 /**
  * Returns the state for a Textarea component, given its props and ref.
  * The returned state can be modified with hooks before being passed to `renderTextarea`.
  */
 export const useTextarea = (props: TextareaProps, ref: React.Ref<HTMLTextAreaElement>): TextareaState => {
-  const state = useTextareaBase_unstable(props, ref);
+  const state: TextareaState = useTextareaBase_unstable(props, ref);
+
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-disabled'] = stringifyDataAttribute(state.textarea.disabled);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-invalid'] = stringifyDataAttribute(
+    state.textarea['aria-invalid'] === true || state.textarea['aria-invalid'] === 'true',
+  );
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-resize'] = state.resize;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/ToggleButton.types.ts
@@ -35,5 +35,10 @@ export type ToggleButtonState = ToggleButtonBaseState & {
      * Data attribute set when the button is in a checked (pressed) state.
      */
     'data-checked'?: string;
+
+    /**
+     * Data attribute reflecting the icon position when an icon slot is present.
+     */
+    'data-icon-position'?: ToggleButtonBaseState['iconPosition'];
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/ToggleButton/useToggleButton.ts
@@ -25,6 +25,8 @@ export const useToggleButton = (
   state.root['data-icon-only'] = stringifyDataAttribute(state.iconOnly);
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-checked'] = stringifyDataAttribute(state.checked);
+  // eslint-disable-next-line react-hooks/immutability
+  state.root['data-icon-position'] = state.icon ? state.iconPosition : undefined;
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
@@ -51,6 +51,7 @@ describe('Tooltip', () => {
 
     expect(screen.getByLabelText('Default Tooltip')).toBeInTheDocument();
     expect(screen.getByRole('tooltip')).toHaveAttribute('popover', 'hint');
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-open');
   });
 
   it('renders only aria-label for a simple label tooltip', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
@@ -51,6 +51,7 @@ describe('Tooltip', () => {
 
     expect(screen.getByLabelText('Default Tooltip')).toBeInTheDocument();
     expect(screen.getByRole('tooltip')).toHaveAttribute('popover', 'hint');
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-visible');
   });
 
   it('renders only aria-label for a simple label tooltip', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.types.ts
@@ -16,4 +16,8 @@ export type TooltipProps = Omit<TooltipBaseProps, 'mountNode'>;
  *
  * Extends Tooltip base state with headless-specific data attributes used for styling hooks.
  */
-export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'>;
+export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'> & {
+  content: {
+    'data-open'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.types.ts
@@ -16,4 +16,8 @@ export type TooltipProps = Omit<TooltipBaseProps, 'mountNode'>;
  *
  * Extends Tooltip base state with headless-specific data attributes used for styling hooks.
  */
-export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'>;
+export type TooltipState = Omit<TooltipBaseState, 'mountNode' | 'hidden'> & {
+  content: {
+    'data-visible'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
@@ -21,6 +21,7 @@ import { KEYBORG_FOCUSIN, useIsNavigatingWithKeyboard } from '@fluentui/react-ta
 
 import type { OnVisibleChangeData, TooltipProps, TooltipState, TooltipTriggerProps } from './Tooltip.types';
 import { resolvePositioningShorthand, usePositioning } from '../../positioning';
+import { stringifyDataAttribute } from '../../utils';
 
 /**
  * Create the state required to render Tooltip.
@@ -69,6 +70,7 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   const { targetRef, containerRef } = usePositioning(positioningOptions);
 
   state.content.id = useId('tooltip-', state.content.id);
+  state.content['data-visible'] = stringifyDataAttribute(state.visible);
 
   const contentRef = useMergedRefs(state.content.ref, containerRef);
   state.content.ref = contentRef;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
@@ -21,6 +21,7 @@ import { KEYBORG_FOCUSIN, useIsNavigatingWithKeyboard } from '@fluentui/react-ta
 
 import type { OnVisibleChangeData, TooltipProps, TooltipState, TooltipTriggerProps } from './Tooltip.types';
 import { resolvePositioningShorthand, usePositioning } from '../../positioning';
+import { stringifyDataAttribute } from '../../utils';
 
 /**
  * Create the state required to render Tooltip.
@@ -69,6 +70,7 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   const { targetRef, containerRef } = usePositioning(positioningOptions);
 
   state.content.id = useId('tooltip-', state.content.id);
+  state.content['data-open'] = stringifyDataAttribute(state.visible);
 
   const contentRef = useMergedRefs(state.content.ref, containerRef);
   state.content.ref = contentRef;


### PR DESCRIPTION
- Expose missing resolved interaction and structural state as typed `data-*` attributes.
- Preserve all existing attribute names and value semantics.

FUI Modern builds on headless components and needs stable selectors for state-driven styling: 

```css
.fx-Modal:where([data-state="open"]) {
   ... 
}

.fx-Button:where([data-icon-position="left"]) {
   ...
}
```