### PR TITLE
fix(web-components): allow Node.js 26 in engines

### DIFF
--- a/change/@fluentui-web-components-ef9f5fd9-2df2-4e86-b95d-3e1e96c908bf.json
+++ b/change/@fluentui-web-components-ef9f5fd9-2df2-4e86-b95d-3e1e96c908bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow Node.js 26 in the engines range to fix EBADENGINE install warnings",
+  "packageName": "@fluentui/web-components",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -7,7 +7,7 @@
     "url": "https://discord.gg/FcSNfg4"
   },
   "engines": {
-    "node": "^22.0.0 || ^24.0.0"
+    "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Previous Behavior

Installing `@fluentui/web-components` on Node.js 26 prints a scary `EBADENGINE` warning, because the package says it only supports Node 22 and 24. That list was written before Node 26 existed.

## New Behavior

Installing on Node 26 is quiet and clean. The package now lists Node 22, 24, and 26 as supported — keeping the same "even LTS versions only" style the repo already uses, so odd versions (23, 25, 27) are still excluded on purpose.

## What changed

- One line in `packages/web-components/package.json`: the supported-Node list gains `^26.0.0`.
- A change file for the release notes.

## How to verify

Run `npm install @fluentui/web-components` on Node 26 — no more warning. We also checked the version range directly with semver: 22.x/24.x/26.x pass, 23/25/27 still don't.

## Related Issue(s)

- Fixes #36466
