### PR TITLE
fix(web-components): make TextInput spellcheck null-safe

### DIFF
--- a/change/@fluentui-web-components-40030ef5-6a38-4881-9523-ccd660fcadb2.json
+++ b/change/@fluentui-web-components-40030ef5-6a38-4881-9523-ccd660fcadb2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix TextInput spellcheck attribute converter throwing on null/undefined values",
+  "packageName": "@fluentui/web-components",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/text-input/text-input.base.ts
+++ b/packages/web-components/src/text-input/text-input.base.ts
@@ -270,8 +270,21 @@ export class BaseTextInput extends FASTElement {
    */
   @attr({
     converter: {
-      fromView: value => (typeof value === 'string' ? ['true', ''].includes(value.trim().toLowerCase()) : null),
-      toView: value => value.toString(),
+      fromView: (value: string | boolean | null | undefined): boolean | null => {
+        // fromView also runs for property writes, which pass booleans through unchanged.
+        if (typeof value === 'boolean') {
+          return value;
+        }
+
+        if (typeof value === 'string') {
+          return ['true', ''].includes(value.trim().toLowerCase());
+        }
+
+        return null;
+      },
+      // A nullish value removes the attribute rather than reflecting, since an empty
+      // string would mean `true` per the enumerated attribute's semantics.
+      toView: (value: boolean | null | undefined): string | null => (typeof value === 'boolean' ? `${value}` : null),
     },
   })
   public spellcheck!: boolean;

--- a/packages/web-components/src/text-input/text-input.spec.ts
+++ b/packages/web-components/src/text-input/text-input.spec.ts
@@ -70,6 +70,77 @@ test.describe('TextInput', () => {
     await expect(control).toHaveAttribute('spellcheck', 'true');
   });
 
+  test('should set `spellcheck="false"` on the internal control from the attribute', async ({ fastPage }) => {
+    const { element } = fastPage;
+    const control = element.locator('input');
+
+    await fastPage.setTemplate({ attributes: { spellcheck: 'false' } });
+
+    await expect(control).toHaveAttribute('spellcheck', 'false');
+  });
+
+  test('should reflect boolean `spellcheck` property values without throwing', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    const control = element.locator('input');
+
+    await fastPage.setTemplate();
+
+    let hasError = false;
+    page.on('pageerror', () => {
+      hasError = true;
+    });
+
+    await element.evaluate((node: TextInput) => {
+      node.spellcheck = false;
+    });
+
+    await expect(element).toHaveAttribute('spellcheck', 'false');
+    await expect(control).toHaveAttribute('spellcheck', 'false');
+
+    await element.evaluate((node: TextInput) => {
+      node.spellcheck = true;
+    });
+
+    await expect(element).toHaveAttribute('spellcheck', 'true');
+    await expect(control).toHaveAttribute('spellcheck', 'true');
+
+    expect(hasError).toBe(false);
+  });
+
+  test('should remove the `spellcheck` attribute when the property is set to null', async ({ fastPage, page }) => {
+    const { element } = fastPage;
+    const control = element.locator('input');
+
+    await fastPage.setTemplate({ attributes: { spellcheck: 'true' } });
+
+    let hasError = false;
+    page.on('pageerror', () => {
+      hasError = true;
+    });
+
+    await element.evaluate((node: TextInput) => {
+      (node as any).spellcheck = null;
+    });
+
+    await expect(element).not.toHaveAttribute('spellcheck');
+    await expect(control).not.toHaveAttribute('spellcheck');
+
+    expect(hasError).toBe(false);
+  });
+
+  test('should honor property writes after the `spellcheck` attribute is removed', async ({ fastPage }) => {
+    const { element } = fastPage;
+
+    await fastPage.setTemplate({ attributes: { spellcheck: 'true' } });
+
+    await element.evaluate((node: TextInput) => {
+      node.removeAttribute('spellcheck');
+      node.spellcheck = true;
+    });
+
+    await expect(element).toHaveAttribute('spellcheck', 'true');
+  });
+
   test('should set the `maxlength` attribute on the internal control', async ({ fastPage }) => {
     const { element } = fastPage;
     const control = element.locator('input');


### PR DESCRIPTION
## Previous Behavior

Setting the `spellcheck` property on `<fluent-text-input>` from JavaScript crashed the page with `TypeError: Cannot read properties of null (reading 'toString')`. This hit anyone using frameworks that set properties instead of attributes (React 19, Angular, Lit). On top of that, removing the `spellcheck` attribute silently broke the property forever — later writes just did nothing.

## New Behavior

`spellcheck` works like you'd expect in every direction: set it to `true`/`false` from JS and the attribute reflects correctly, set it to `null` and the attribute is removed, remove the attribute and the property still works afterwards. Plain attribute usage (`spellcheck="false"` in HTML) behaves exactly as before.

## What changed

- The attribute converter in `text-input.base.ts` now handles booleans and null instead of assuming it always gets a string.
- Four new Playwright tests cover the crash paths (they failed before the fix, pass after — verified in Chromium, Firefox, and WebKit, 225 tests total green).
- A change file for the release notes.

## How to verify

Before this fix, this one-liner crashes the page; now it works:
```js
document.querySelector('fluent-text-input').spellcheck = false;
```

## Related Issue(s)

- Fixes #36462
