### PR TITLE
test(charts): cover sub-1 bar label formatting

### DIFF
--- a/change/@fluentui-react-charting-c2c3c338-7477-4975-9975-ddb029e2a64e.json
+++ b/change/@fluentui-react-charting-c2c3c338-7477-4975-9975-ddb029e2a64e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add regression tests: bar labels render plain decimals for values < 1 (no SI milli suffix)",
+  "packageName": "@fluentui/react-charting",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-charts-a9d3dba8-57e8-48bb-8acd-cd6a65f97fca.json
+++ b/change/@fluentui-react-charts-a9d3dba8-57e8-48bb-8acd-cd6a65f97fca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add regression tests: bar labels render plain decimals for values < 1 (no SI milli suffix)",
+  "packageName": "@fluentui/react-charts",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/charts/react-charting/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/charts/react-charting/src/utilities/UtilityUnitTests.test.ts
@@ -1216,6 +1216,15 @@ test('formatScientificLimitWidth should format a numeric value with appropriate 
   expect(utils.formatScientificLimitWidth(100990000)).toBe('101M');
 });
 
+test('formatScientificLimitWidth should not use SI notation for values with absolute value less than 1', () => {
+  expect(utils.formatScientificLimitWidth(0.9)).toBe('0.9');
+  expect(utils.formatScientificLimitWidth(0.18)).toBe('0.18');
+  expect(utils.formatScientificLimitWidth(0.123)).toBe('0.12');
+  expect(utils.formatScientificLimitWidth(0.0005)).toBe('0.0005');
+  expect(utils.formatScientificLimitWidth(0)).toBe('0');
+  expect(utils.formatScientificLimitWidth(-0.9)).toBe('−0.9');
+});
+
 describe('getClosestPairDiffAndRange', () => {
   it('should return undefined if data length is less than 2', () => {
     const data: number[] = [1];

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.test.tsx
@@ -1077,3 +1077,25 @@ describe('Render empty chart calling with respective to props', () => {
     expect(htmlAfter).not.toBe(htmlBefore);
   });
 });
+
+describe('Vertical bar chart - bar label formatting', () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  testWithWait(
+    'Should render bar labels as plain decimals for y values less than 1',
+    VerticalBarChart,
+    {
+      data: [
+        { x: 'a', y: 0.9, legend: 'First', color: 'aqua' },
+        { x: 'b', y: 0.18, legend: 'Second', color: 'blue' },
+      ],
+    },
+    container => {
+      // Assert
+      const labels = getByClass(container, /barLabel/i);
+      expect(labels).toHaveLength(2);
+      expect(Array.from(labels).map(label => label.textContent)).toEqual(['0.9', '0.18']);
+    },
+  );
+});

--- a/packages/charts/react-charts/library/src/utilities/UtilityUnitTests.test.ts
+++ b/packages/charts/react-charts/library/src/utilities/UtilityUnitTests.test.ts
@@ -1345,6 +1345,15 @@ test('formatScientificLimitWidth should format a numeric value with appropriate 
   expect(utils.formatScientificLimitWidth(100990000)).toBe('101M');
 });
 
+test('formatScientificLimitWidth should not use SI notation for values with absolute value less than 1', () => {
+  expect(utils.formatScientificLimitWidth(0.9)).toBe('0.9');
+  expect(utils.formatScientificLimitWidth(0.18)).toBe('0.18');
+  expect(utils.formatScientificLimitWidth(0.123)).toBe('0.12');
+  expect(utils.formatScientificLimitWidth(0.0005)).toBe('0.0005');
+  expect(utils.formatScientificLimitWidth(0)).toBe('0');
+  expect(utils.formatScientificLimitWidth(-0.9)).toBe('−0.9');
+});
+
 describe('getClosestPairDiffAndRange', () => {
   it('should return undefined if data length is less than 2', () => {
     const data: number[] = [1];


### PR DESCRIPTION
## Previous Behavior

This issue reported bar chart labels showing "900m" when the value was 0.9 (the "m" means *milli*, so 0.9 kg looked like 900 mg — very confusing). That bug was actually fixed on master by #34562, but nothing tested it, so it could quietly come back.

## New Behavior

No product code changes — this PR adds the missing safety net. New tests lock in that small values render as plain decimals ("0.9", not "900m") in both charting packages, including a rendering test that checks the actual label text on VerticalBarChart bars.

With the tests proving the fix is in place, this issue can be closed; anyone still seeing "900m" just needs to upgrade (`@fluentui/react-charts` 9.0.7+ / `@fluentui/react-charting` 5.24.1+).

## What changed

- Unit tests for the number formatter (values under 1) in v9 `react-charts` and v8 `react-charting`.
- A VerticalBarChart test asserting bar labels read "0.9" and "0.18" for fractional data.
- Release-notes change files (type "none" — tests only).

We confirmed the old formatter really did produce "900m" for 0.9, and that the full react-charts suite stays green (the only failures are 6 HeatMap snapshots that were already failing on untouched master).

## Related Issue(s)

- Closes #30213
