### PR TITLE
docs(react-examples): fix GroupedList example a11y

### DIFF
--- a/packages/react-examples/src/react/GroupedList/GroupedList.Custom.Example.tsx
+++ b/packages/react-examples/src/react/GroupedList/GroupedList.Custom.Example.tsx
@@ -36,16 +36,25 @@ const onRenderHeader = (props?: IGroupHeaderProps): JSXElement | null => {
       props.onToggleCollapse!(props.group!);
     };
     return (
-      <div className={classNames.header}>
-        This is a custom header for {props.group!.name}
-        &nbsp; (
-        <Link
-          // eslint-disable-next-line react/jsx-no-bind
-          onClick={toggleCollapse}
-        >
-          {props.group!.isCollapsed ? 'Expand' : 'Collapse'}
-        </Link>
-        )
+      <div
+        className={classNames.header}
+        role="row"
+        aria-level={props.ariaLevel}
+        aria-setsize={props.ariaSetSize}
+        aria-posinset={props.ariaPosInSet}
+        aria-expanded={!props.group!.isCollapsed}
+      >
+        <div role="gridcell">
+          This is a custom header for {props.group!.name}
+          &nbsp; (
+          <Link
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={toggleCollapse}
+          >
+            {props.group!.isCollapsed ? 'Expand' : 'Collapse'}
+          </Link>
+          )
+        </div>
       </div>
     );
   }
@@ -64,7 +73,11 @@ const onRenderCell = (nestingDepth?: number, item?: IExampleItem, itemIndex?: nu
 };
 
 const onRenderFooter = (props?: IGroupFooterProps): JSXElement | null => {
-  return props ? <div className={classNames.footer}>This is a custom footer for {props.group!.name}</div> : null;
+  return props ? (
+    <div className={classNames.footer} role="row">
+      <div role="gridcell">This is a custom footer for {props.group!.name}</div>
+    </div>
+  ) : null;
 };
 
 const groupedListProps = {

--- a/packages/react-examples/src/react/GroupedList/GroupedListV2.Custom.Example.tsx
+++ b/packages/react-examples/src/react/GroupedList/GroupedListV2.Custom.Example.tsx
@@ -37,16 +37,25 @@ const onRenderHeader = (props?: IGroupHeaderProps): JSXElement | null => {
       props.onToggleCollapse!(props.group!);
     };
     return (
-      <div className={classNames.header}>
-        This is a custom header for {props.group!.name}
-        &nbsp; (
-        <Link
-          // eslint-disable-next-line react/jsx-no-bind
-          onClick={toggleCollapse}
-        >
-          {props.group!.isCollapsed ? 'Expand' : 'Collapse'}
-        </Link>
-        )
+      <div
+        className={classNames.header}
+        role="row"
+        aria-level={props.ariaLevel}
+        aria-setsize={props.ariaSetSize}
+        aria-posinset={props.ariaPosInSet}
+        aria-expanded={!props.group!.isCollapsed}
+      >
+        <div role="gridcell">
+          This is a custom header for {props.group!.name}
+          &nbsp; (
+          <Link
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={toggleCollapse}
+          >
+            {props.group!.isCollapsed ? 'Expand' : 'Collapse'}
+          </Link>
+          )
+        </div>
       </div>
     );
   }
@@ -65,7 +74,11 @@ const onRenderCell = (nestingDepth?: number, item?: IExampleItem, itemIndex?: nu
 };
 
 const onRenderFooter = (props?: IGroupFooterProps): JSXElement | null => {
-  return props ? <div className={classNames.footer}>This is a custom footer for {props.group!.name}</div> : null;
+  return props ? (
+    <div className={classNames.footer} role="row">
+      <div role="gridcell">This is a custom footer for {props.group!.name}</div>
+    </div>
+  ) : null;
 };
 
 const groupedListProps = {


### PR DESCRIPTION
## Previous Behavior

The GroupedList "custom header and footer" documentation examples (V1 and V2) returned plain divs with no ARIA roles. Those divs sit directly inside the list's `treegrid`, which is only allowed to contain rows — so accessibility scanners (like Accessibility Insights, as reported in the issue) flag the example, and anyone copying it ships the same problem.

## New Behavior

The example header and footer carry the same semantics as the built-in group header: a `row` containing a `gridcell`, with the standard level/position/expanded attributes on the header. Visually nothing changes — the added wrappers are unstyled.

## What changed

- Both example files (`GroupedList.Custom.Example.tsx` and `GroupedListV2.Custom.Example.tsx`) updated with the role pattern the built-in GroupHeader uses.
- Verified by rendering the example and asserting the row/gridcell structure (the original markup demonstrably lacks it), plus an axe pass on the fixed example; the react-examples build (the CI type gate) succeeds.
- No release-notes file needed — the examples package is private.

One honest note: current axe versions descend through generic divs and no longer flag this pattern by themselves, but the ARIA structure requirement is real and the scanner in the issue does flag it. The built-in GroupFooter has the same flaw at component level — left as a follow-up since changing component DOM could affect existing apps.

## Related Issue(s)

- Fixes #33765
