### PR TITLE
feat(react-tooltip): add secondary content

### DIFF
--- a/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
@@ -33,7 +33,7 @@ export const BasicHighContrast = getStoryVariant(Basic, HIGH_CONTRAST);
 export const SecondaryContent = () => (
   <div className={useStyles().wrapper}>
     <Tooltip visible content="Bold" secondaryContent="Ctrl+B" relationship="label">
-      <button aria-keyshortcuts="Control+B">
+      <button>
         <TextBoldRegular />
       </button>
     </Tooltip>

--- a/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
+++ b/apps/vr-tests-react-components/src/stories/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { Meta } from '@storybook/react-webpack5';
 import { Tooltip } from '@fluentui/react-tooltip';
+import { TextBoldRegular } from '@fluentui/react-icons';
 
 import { useStyles } from './utils';
 import { DARK_MODE, getStoryVariant, HIGH_CONTRAST, TestWrapperDecorator } from '../../utilities';
@@ -28,6 +29,21 @@ Basic.storyName = 'basic';
 export const BasicDarkMode = getStoryVariant(Basic, DARK_MODE);
 
 export const BasicHighContrast = getStoryVariant(Basic, HIGH_CONTRAST);
+
+export const SecondaryContent = () => (
+  <div className={useStyles().wrapper}>
+    <Tooltip visible content="Bold" secondaryContent="Ctrl+B" relationship="label">
+      <button aria-keyshortcuts="Control+B">
+        <TextBoldRegular />
+      </button>
+    </Tooltip>
+  </div>
+);
+SecondaryContent.storyName = 'secondary content';
+
+export const SecondaryContentDarkMode = getStoryVariant(SecondaryContent, DARK_MODE);
+
+export const SecondaryContentHighContrast = getStoryVariant(SecondaryContent, HIGH_CONTRAST);
 
 export const Inverted = () => (
   <div className={useStyles().wrapper}>

--- a/change/@fluentui-react-tooltip-d906f048-c7cf-41ab-bb86-27edec248fed.json
+++ b/change/@fluentui-react-tooltip-d906f048-c7cf-41ab-bb86-27edec248fed.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "feat: add secondary content to Tooltip",
   "packageName": "@fluentui/react-tooltip",
   "email": "petrduda@microsoft.com",

--- a/change/@fluentui-react-tooltip-d906f048-c7cf-41ab-bb86-27edec248fed.json
+++ b/change/@fluentui-react-tooltip-d906f048-c7cf-41ab-bb86-27edec248fed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add secondary content to Tooltip",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "petrduda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { render, screen } from '@testing-library/react';
-import { resetIdsForTests } from '@fluentui/react-utilities';
+import { resetIdsForTests, SSRProvider } from '@fluentui/react-utilities';
 import { isConformant } from '../../testing/isConformant';
 import type { IsConformantOptions } from '@fluentui/react-conformance';
 import { Tooltip } from './Tooltip';
@@ -98,6 +99,80 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
     const target = screen.getByRole('button');
     expect(target).toHaveAttribute('aria-describedby', tooltip.id);
+  });
+
+  it('renders secondary content', () => {
+    render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible>
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const target = screen.getByRole('button');
+    expect(tooltip).toHaveTextContent('BoldCtrl+B');
+    expect(tooltip.querySelector('span')).toHaveTextContent('Ctrl+B');
+    expect(target).toHaveAttribute('aria-label', 'Bold Ctrl+B');
+    expect(target).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('includes secondary content in a rich accessible label', () => {
+    render(
+      <Tooltip content={<span>Bold</span>} secondaryContent="Ctrl+B" relationship="label">
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const target = screen.getByRole('button');
+    const secondaryContent = tooltip.querySelector(':scope > span');
+
+    expect(target).toHaveAttribute('aria-labelledby', tooltip.id);
+    expect(secondaryContent).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('keeps a string label with secondary content when the trigger popup is expanded', () => {
+    render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible>
+        <button aria-haspopup="menu" aria-expanded="true">
+          Trigger
+        </button>
+      </Tooltip>,
+    );
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Bold Ctrl+B');
+  });
+
+  it('keeps a generic secondary content label when the trigger popup is expanded', () => {
+    render(
+      <Tooltip content="Bold" secondaryContent={<span>Ctrl+B</span>} relationship="label" visible>
+        <button aria-haspopup="menu" aria-expanded="true">
+          Trigger
+        </button>
+      </Tooltip>,
+    );
+
+    const tooltip = document.querySelector('[role="tooltip"]');
+    const target = screen.getByRole('button');
+
+    expect(tooltip).not.toBeNull();
+    expect(target).not.toHaveAttribute('aria-label');
+    expect(target).toHaveAttribute('aria-labelledby', tooltip?.id);
+    expect(tooltip).toHaveTextContent('BoldCtrl+B');
+  });
+
+  it('keeps the primary string label during SSR with generic secondary content', () => {
+    const html = renderToStaticMarkup(
+      <SSRProvider>
+        <Tooltip content="Bold" secondaryContent={<span>Ctrl+B</span>} relationship="label">
+          <button />
+        </Tooltip>
+      </SSRProvider>,
+    );
+
+    expect(html).toContain('aria-label="Bold"');
+    expect(html).not.toContain('aria-labelledby');
   });
 
   it('renders arrow element when withArrow is true', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/renderTooltip.tsx
@@ -17,7 +17,14 @@ export const renderTooltip = (state: TooltipState): JSXElement => {
       {state.shouldRenderTooltip && (
         <state.content>
           {state.withArrow && <div ref={state.arrowRef} data-arrow="" />}
-          {state.content.children}
+          {state.secondaryContent ? (
+            <>
+              <div>{state.content.children}</div>
+              <state.secondaryContent />
+            </>
+          ) : (
+            state.content.children
+          )}
         </state.content>
       )}
     </>

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/useTooltip.ts
@@ -36,6 +36,7 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   const {
     children,
     content,
+    secondaryContent,
     positioning = 'above',
     withArrow = false,
     onVisibleChange,
@@ -44,17 +45,24 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
     hideDelay = 250,
   } = props;
 
+  const child = getTriggerChild(children);
+  const isPopupExpanded =
+    child?.props?.['aria-haspopup'] &&
+    (child?.props?.['aria-expanded'] === true || child?.props?.['aria-expanded'] === 'true');
+  const renderedVisible = visible && !isPopupExpanded;
+
   const state: TooltipState = {
     positioning,
     showDelay,
     hideDelay,
     relationship,
-    visible,
-    shouldRenderTooltip: visible,
+    visible: renderedVisible,
+    shouldRenderTooltip: renderedVisible,
     withArrow,
     // Slots
     components: {
       content: 'div',
+      secondaryContent: 'span',
     },
     content: slot.always(content, {
       defaultProps: {
@@ -63,11 +71,13 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
       },
       elementType: 'div',
     }),
+    secondaryContent: slot.optional(secondaryContent, {
+      elementType: 'span',
+    }),
   };
 
   const positioningOptions = resolvePositioningShorthand(positioning);
   const { targetRef, containerRef } = usePositioning(positioningOptions);
-
   state.content.id = useId('tooltip-', state.content.id);
 
   const contentRef = useMergedRefs(state.content.ref, containerRef);
@@ -105,7 +115,7 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
     el.addEventListener('toggle', onToggle);
 
     try {
-      if (visible) {
+      if (state.visible) {
         el.showPopover();
       } else if (el.matches(':popover-open')) {
         el.hidePopover();
@@ -126,7 +136,7 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
     return () => {
       el.removeEventListener('toggle', onToggle);
     };
-  }, [contentRef, visible, setVisible, onToggle]);
+  }, [contentRef, state.visible, setVisible, onToggle]);
 
   // Used to skip showing the tooltip  in certain situations when the trigger is focused.
   // See comments where this is set for more info.
@@ -213,16 +223,18 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
   // eslint-disable-next-line react-hooks/immutability, react-hooks/refs
   state.content.onBlur = mergeCallbacks(state.content.onBlur, onLeaveTrigger);
 
-  const child = getTriggerChild(children);
-
   const triggerAriaProps: Pick<TooltipTriggerProps, 'aria-label' | 'aria-labelledby' | 'aria-describedby'> = {};
-  const isPopupExpanded =
-    child?.props?.['aria-haspopup'] &&
-    (child?.props?.['aria-expanded'] === true || child?.props?.['aria-expanded'] === 'true');
 
   if (relationship === 'label') {
     // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
-    if (typeof state.content.children === 'string') {
+    if (
+      typeof state.content.children === 'string' &&
+      (!state.secondaryContent || typeof state.secondaryContent.children === 'string')
+    ) {
+      triggerAriaProps['aria-label'] = state.secondaryContent
+        ? `${state.content.children} ${state.secondaryContent.children}`
+        : state.content.children;
+    } else if (isServerSideRender && typeof state.content.children === 'string') {
       triggerAriaProps['aria-label'] = state.content.children;
     } else {
       triggerAriaProps['aria-labelledby'] = state.content.id;
@@ -237,9 +249,8 @@ export const useTooltip = (props: TooltipProps): TooltipState => {
     state.shouldRenderTooltip = true;
   }
 
-  // Case 1: Don't render the Tooltip in SSR to avoid hydration errors
-  // Case 2: Don't render the Tooltip, if it triggers Menu or another popup and it's already opened
-  if (isServerSideRender || isPopupExpanded) {
+  // Don't render the Tooltip in SSR to avoid hydration errors.
+  if (isServerSideRender) {
     // eslint-disable-next-line react-hooks/immutability
     state.shouldRenderTooltip = false;
   }

--- a/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
+++ b/packages/react-components/react-tooltip/library/etc/react-tooltip.api.md
@@ -50,6 +50,7 @@ export type TooltipProps = ComponentProps<TooltipSlots> & TriggerProps<TooltipTr
 // @public
 export type TooltipSlots = {
     content: NonNullable<Slot<'div'>>;
+    secondaryContent?: Slot<'span'>;
 };
 
 // @public
@@ -59,6 +60,8 @@ export type TooltipState = ComponentState<TooltipSlots> & Pick<TooltipProps, 'mo
     shouldRenderTooltip?: boolean;
     arrowRef?: React_2.Ref<HTMLDivElement>;
     arrowClassName?: string;
+    contentLayoutClassName?: string;
+    primaryContentClassName?: string;
 };
 
 // @public

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { Tooltip } from './Tooltip';
 import { isConformant } from '../../testing/isConformant';
 import type { IsConformantOptions } from '@fluentui/react-conformance';
 import type { RenderResult } from '@testing-library/react';
 import { act, fireEvent, render } from '@testing-library/react';
-import { resetIdsForTests } from '@fluentui/react-utilities';
+import { resetIdsForTests, SSRProvider } from '@fluentui/react-utilities';
 
 // testing-library's queryByRole function doesn't look inside portals
 function queryByRoleTooltip(result: RenderResult) {
@@ -95,10 +96,10 @@ describe('Tooltip', () => {
     expect(target.getAttribute('aria-labelledby')).toBe('the-tooltip-id');
   });
 
-  it('renders secondary content without including it in the accessible label', () => {
+  it('includes secondary content in the accessible label', () => {
     const result = render(
       <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible>
-        <button aria-keyshortcuts="Control+B" />
+        <button />
       </Tooltip>,
     );
 
@@ -107,15 +108,84 @@ describe('Tooltip', () => {
     const secondaryContent = tooltip.querySelector('.fui-Tooltip__secondaryContent');
 
     expect(tooltip.textContent).toBe('BoldCtrl+B');
-    expect(target.getAttribute('aria-label')).toBe('Bold');
-    expect(target.getAttribute('aria-keyshortcuts')).toBe('Control+B');
+    expect(target.getAttribute('aria-label')).toBe('Bold Ctrl+B');
+    expect(target.getAttribute('aria-labelledby')).toBeNull();
     expect(secondaryContent?.hasAttribute('aria-hidden')).toBe(false);
   });
 
-  it('renders secondary content without hiding it from assistive technologies', () => {
+  it('includes secondary content in a rich accessible label', () => {
+    const result = render(
+      <Tooltip content={<span>Bold</span>} secondaryContent="Ctrl+B" relationship="label">
+        <button />
+      </Tooltip>,
+    );
+
+    const tooltip = getByRoleTooltip(result);
+    const target = result.getByRole('button');
+    const secondaryContent = tooltip.querySelector('.fui-Tooltip__secondaryContent');
+
+    expect(target.getAttribute('aria-labelledby')).toBe(tooltip.id);
+    expect(secondaryContent?.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('keeps a string label with secondary content when the trigger popup is expanded', () => {
+    const result = render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible>
+        <button aria-haspopup="menu" aria-expanded="true" />
+      </Tooltip>,
+    );
+
+    expect(queryByRoleTooltip(result)).toBeNull();
+    expect(result.getByRole('button').getAttribute('aria-label')).toBe('Bold Ctrl+B');
+  });
+
+  it('keeps a generic secondary content label when the trigger popup is expanded', () => {
+    const result = render(
+      <Tooltip content="Bold" secondaryContent={<span>Ctrl+B</span>} relationship="label" visible>
+        <button aria-haspopup="menu" aria-expanded="true" />
+      </Tooltip>,
+    );
+
+    const tooltip = getByRoleTooltip(result);
+    const target = result.getByRole('button');
+
+    expect(target.getAttribute('aria-label')).toBeNull();
+    expect(target.getAttribute('aria-labelledby')).toBe(tooltip.id);
+    expect(tooltip.textContent).toBe('BoldCtrl+B');
+  });
+
+  it('dismisses internal visibility with Escape while the trigger popup is expanded', () => {
+    const onVisibleChange = jest.fn();
+    render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible onVisibleChange={onVisibleChange}>
+        <button aria-haspopup="menu" aria-expanded="true" />
+      </Tooltip>,
+    );
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(onVisibleChange).toHaveBeenCalledWith(undefined, expect.objectContaining({ visible: false }));
+  });
+
+  it('keeps the primary string label during SSR with generic secondary content', () => {
+    const html = renderToStaticMarkup(
+      <SSRProvider>
+        <Tooltip content="Bold" secondaryContent={<span>Ctrl+B</span>} relationship="label">
+          <button />
+        </Tooltip>
+      </SSRProvider>,
+    );
+
+    expect(html).toContain('aria-label="Bold"');
+    expect(html).not.toContain('aria-labelledby');
+  });
+
+  it('includes secondary content in the accessible description', () => {
     const result = render(
       <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="description">
-        <button aria-keyshortcuts="Control+B" />
+        <button />
       </Tooltip>,
     );
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.test.tsx
@@ -44,6 +44,13 @@ describe('Tooltip', () => {
       'consistent-callback-args': {
         legacyCallbacks: ['onVisibleChange'],
       },
+      'has-static-classnames': [
+        {
+          props: {
+            secondaryContent: 'Test secondary content',
+          },
+        },
+      ],
     },
   });
 
@@ -86,6 +93,38 @@ describe('Tooltip', () => {
     const target = result.getByRole('button');
     expect(tooltip.id).toBe('the-tooltip-id');
     expect(target.getAttribute('aria-labelledby')).toBe('the-tooltip-id');
+  });
+
+  it('renders secondary content without including it in the accessible label', () => {
+    const result = render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label" visible>
+        <button aria-keyshortcuts="Control+B" />
+      </Tooltip>,
+    );
+
+    const tooltip = getByRoleTooltip(result);
+    const target = result.getByRole('button');
+    const secondaryContent = tooltip.querySelector('.fui-Tooltip__secondaryContent');
+
+    expect(tooltip.textContent).toBe('BoldCtrl+B');
+    expect(target.getAttribute('aria-label')).toBe('Bold');
+    expect(target.getAttribute('aria-keyshortcuts')).toBe('Control+B');
+    expect(secondaryContent?.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('renders secondary content without hiding it from assistive technologies', () => {
+    const result = render(
+      <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="description">
+        <button aria-keyshortcuts="Control+B" />
+      </Tooltip>,
+    );
+
+    const tooltip = getByRoleTooltip(result);
+    const target = result.getByRole('button');
+    const secondaryContent = tooltip.querySelector('.fui-Tooltip__secondaryContent');
+
+    expect(target.getAttribute('aria-describedby')).toBe(tooltip.id);
+    expect(secondaryContent?.hasAttribute('aria-hidden')).toBe(false);
   });
 
   it('renders a description tooltip content always', () => {

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/Tooltip.types.ts
@@ -11,6 +11,11 @@ export type TooltipSlots = {
    * The text or JSX content of the tooltip.
    */
   content: NonNullable<Slot<'div'>>;
+
+  /**
+   * Secondary content rendered opposite the primary content (e.g. shortcut text).
+   */
+  secondaryContent?: Slot<'span'>;
 };
 
 /**
@@ -151,6 +156,16 @@ export type TooltipState = ComponentState<TooltipSlots> &
      * CSS class for the arrow element
      */
     arrowClassName?: string;
+
+    /**
+     * CSS class for the content layout when secondary content is present.
+     */
+    contentLayoutClassName?: string;
+
+    /**
+     * CSS class for the primary content when secondary content is present.
+     */
+    primaryContentClassName?: string;
   };
 
 export type TooltipBaseState = Omit<TooltipState, 'appearance'>;

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/renderTooltip.tsx
@@ -19,7 +19,14 @@ export const renderTooltip_unstable = (state: TooltipBaseState): JSXElement => {
         <Portal mountNode={state.mountNode}>
           <state.content>
             {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} />}
-            {state.content.children}
+            {state.secondaryContent ? (
+              <div className={state.contentLayoutClassName}>
+                <div className={state.primaryContentClassName}>{state.content.children}</div>
+                <state.secondaryContent />
+              </div>
+            ) : (
+              state.content.children
+            )}
           </state.content>
         </Portal>
       )}

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
@@ -48,6 +48,7 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
   const {
     children,
     content,
+    secondaryContent,
     withArrow = false,
     positioning = 'above',
     onVisibleChange,
@@ -70,12 +71,16 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
     // Slots
     components: {
       content: 'div',
+      secondaryContent: 'span',
     },
     content: slot.always(content, {
       defaultProps: {
         role: 'tooltip',
       },
       elementType: 'div',
+    }),
+    secondaryContent: slot.optional(secondaryContent, {
+      elementType: 'span',
     }),
   };
 

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipBase.tsx
@@ -58,15 +58,21 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
     mountNode,
   } = props;
 
+  const child = getTriggerChild(children);
+  const isPopupExpanded =
+    child?.props?.['aria-haspopup'] &&
+    (child?.props?.['aria-expanded'] === true || child?.props?.['aria-expanded'] === 'true');
+  const renderedVisible = visible && !isPopupExpanded;
+
   const state: TooltipBaseState = {
     withArrow,
     positioning,
     showDelay,
     hideDelay,
     relationship,
-    visible,
+    visible: renderedVisible,
     hidden,
-    shouldRenderTooltip: visible,
+    shouldRenderTooltip: renderedVisible,
     mountNode,
     // Slots
     components: {
@@ -83,7 +89,6 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
       elementType: 'span',
     }),
   };
-
   state.content.id = useId('tooltip-', state.content.id);
 
   const resolvedPositioning = resolvePositioningShorthand(state.positioning);
@@ -277,16 +282,18 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
   // eslint-disable-next-line react-hooks/immutability, react-hooks/refs
   state.content.onBlur = mergeCallbacks(state.content.onBlur, onLeaveTrigger);
 
-  const child = getTriggerChild(children);
-
   const triggerAriaProps: Pick<TooltipChildProps, 'aria-label' | 'aria-labelledby' | 'aria-describedby'> = {};
-  const isPopupExpanded =
-    child?.props?.['aria-haspopup'] &&
-    (child?.props?.['aria-expanded'] === true || child?.props?.['aria-expanded'] === 'true');
 
   if (relationship === 'label') {
     // aria-label only works if the content is a string. Otherwise, need to use aria-labelledby.
-    if (typeof state.content.children === 'string') {
+    if (
+      typeof state.content.children === 'string' &&
+      (!state.secondaryContent || typeof state.secondaryContent.children === 'string')
+    ) {
+      triggerAriaProps['aria-label'] = state.secondaryContent
+        ? `${state.content.children} ${state.secondaryContent.children}`
+        : state.content.children;
+    } else if (isServerSideRender && typeof state.content.children === 'string') {
       triggerAriaProps['aria-label'] = state.content.children;
     } else {
       triggerAriaProps['aria-labelledby'] = state.content.id;
@@ -301,9 +308,8 @@ export const useTooltipBase_unstable = (props: TooltipBaseProps): TooltipBaseSta
     state.shouldRenderTooltip = true;
   }
 
-  // Case 1: Don't render the Tooltip in SSR to avoid hydration errors
-  // Case 2: Don't render the Tooltip, if it triggers Menu or another popup and it's already opened
-  if (isServerSideRender || isPopupExpanded) {
+  // Don't render the Tooltip in SSR to avoid hydration errors.
+  if (isServerSideRender) {
     // eslint-disable-next-line react-hooks/immutability
     state.shouldRenderTooltip = false;
   }

--- a/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
+++ b/packages/react-components/react-tooltip/library/src/components/Tooltip/useTooltipStyles.styles.ts
@@ -9,6 +9,7 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 
 export const tooltipClassNames: SlotClassNames<TooltipSlots> = {
   content: 'fui-Tooltip__content',
+  secondaryContent: 'fui-Tooltip__secondaryContent',
 };
 
 /**
@@ -51,6 +52,33 @@ const useStyles = makeStyles({
   },
 
   arrow: createArrowStyles({ arrowHeight }),
+
+  contentLayout: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    columnGap: tokens.spacingHorizontalS,
+    rowGap: tokens.spacingVerticalXXS,
+  },
+
+  primaryContent: {
+    minWidth: 0,
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+
+  secondaryContent: {
+    marginInlineStart: 'auto',
+    whiteSpace: 'nowrap',
+    color: tokens.colorNeutralForeground3,
+
+    '@media (forced-colors: active)': {
+      color: 'inherit',
+    },
+  },
+
+  secondaryContentInverted: {
+    color: tokens.colorNeutralForegroundInverted2,
+  },
 });
 
 /**
@@ -71,6 +99,20 @@ export const useTooltipStyles_unstable = (state: TooltipState): TooltipState => 
 
   // eslint-disable-next-line react-hooks/immutability
   state.arrowClassName = styles.arrow;
+
+  if (state.secondaryContent) {
+    // eslint-disable-next-line react-hooks/immutability
+    state.contentLayoutClassName = styles.contentLayout;
+    // eslint-disable-next-line react-hooks/immutability
+    state.primaryContentClassName = styles.primaryContent;
+    // eslint-disable-next-line react-hooks/immutability
+    state.secondaryContent.className = mergeClasses(
+      tooltipClassNames.secondaryContent,
+      styles.secondaryContent,
+      state.appearance === 'inverted' && styles.secondaryContentInverted,
+      state.secondaryContent.className,
+    );
+  }
 
   return state;
 };

--- a/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipAccessibility.md
+++ b/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipAccessibility.md
@@ -4,4 +4,4 @@ Tooltips should always wrap interactive controls like buttons, links, form field
 
 Tooltips should not be used to provide a full-text alternative to truncated content. For more infomation on the accessibility of truncated content, see our [truncation docs](https://react.fluentui.dev/?path=/docs/concepts-developer-accessibility-truncation--docs).
 
-Use `secondaryContent` for short supporting information such as a keyboard shortcut. Set `aria-keyshortcuts` on the trigger to expose keyboard shortcuts semantically to assistive technologies.
+Use `secondaryContent` for short supporting information displayed opposite the primary content, such as a keyboard shortcut. Secondary content is included in the trigger's accessible label or description.

--- a/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipAccessibility.md
+++ b/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipAccessibility.md
@@ -3,3 +3,5 @@
 Tooltips should always wrap interactive controls like buttons, links, form fields, gridcells, etc. For tooltips that should be triggered by static icons, the `InfoLabel` control is available as an accessible tooltip-like pattern.
 
 Tooltips should not be used to provide a full-text alternative to truncated content. For more infomation on the accessibility of truncated content, see our [truncation docs](https://react.fluentui.dev/?path=/docs/concepts-developer-accessibility-truncation--docs).
+
+Use `secondaryContent` for short supporting information such as a keyboard shortcut. Set `aria-keyshortcuts` on the trigger to expose keyboard shortcuts semantically to assistive technologies.

--- a/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipSecondaryContent.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipSecondaryContent.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import type { JSXElement } from '@fluentui/react-components';
+import { Button, Tooltip } from '@fluentui/react-components';
+import { TextBoldRegular } from '@fluentui/react-icons';
+
+export const SecondaryContent = (): JSXElement => (
+  <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label">
+    <Button aria-keyshortcuts="Control+B" icon={<TextBoldRegular />} />
+  </Tooltip>
+);
+
+SecondaryContent.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `secondaryContent` for short supporting information such as a keyboard shortcut. ' +
+        'Use `aria-keyshortcuts` on the trigger to expose the keyboard shortcut semantically.',
+    },
+  },
+};

--- a/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipSecondaryContent.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/src/Tooltip/TooltipSecondaryContent.stories.tsx
@@ -5,7 +5,7 @@ import { TextBoldRegular } from '@fluentui/react-icons';
 
 export const SecondaryContent = (): JSXElement => (
   <Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label">
-    <Button aria-keyshortcuts="Control+B" icon={<TextBoldRegular />} />
+    <Button icon={<TextBoldRegular />} />
   </Tooltip>
 );
 
@@ -13,8 +13,7 @@ SecondaryContent.parameters = {
   docs: {
     description: {
       story:
-        'Use `secondaryContent` for short supporting information such as a keyboard shortcut. ' +
-        'Use `aria-keyshortcuts` on the trigger to expose the keyboard shortcut semantically.',
+        'Use `secondaryContent` for short supporting information displayed opposite the primary content, such as a keyboard shortcut.',
     },
   },
 };

--- a/packages/react-components/react-tooltip/stories/src/Tooltip/index.stories.tsx
+++ b/packages/react-components/react-tooltip/stories/src/Tooltip/index.stories.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from '@fluentui/react-components';
 import descriptionMd from './TooltipDescription.md';
 import accessibilityMd from './TooltipAccessibility.md';
 export { Default } from './TooltipDefault.stories';
+export { SecondaryContent } from './TooltipSecondaryContent.stories';
 export { RelationshipLabel } from './TooltipRelationshipLabel.stories';
 export { RelationshipDescription } from './TooltipRelationshipDescription.stories';
 export { Inverted } from './TooltipInverted.stories';


### PR DESCRIPTION
## Previous Behavior

Tooltip only supported a single `content` region. Applications commonly appended supporting information to the primary label instead of using the same primary/secondary hierarchy available in MenuItem.

## New Behavior

- Adds an optional `secondaryContent` slot to Tooltip, consistent with MenuItem.
- Renders secondary content opposite the primary content with wrapping, RTL-safe alignment, dark mode, and high-contrast support.
- Leaves existing Tooltip DOM and styling unchanged when `secondaryContent` is not provided.
- Includes secondary content in the trigger's accessible label or description, matching MenuItem semantics.
- Documents keyboard shortcuts as one common use case without making the API shortcut-specific.
- Adds unit, Storybook, API report, and visual-regression coverage.

```tsx
<Tooltip content="Bold" secondaryContent="Ctrl+B" relationship="label">
  <Button icon={<TextBoldRegular />} />
</Tooltip>
```

![Tooltip with Bold as primary content and Ctrl+B as secondary content](https://gist.githubusercontent.com/petdud/9e48423c8780405e4b9d9cba0404eb92/raw/309fffb01308ff98f456eda8d77d8656a44c5fe8/tooltip-secondary-content.svg)

## Design review

| Perspective | Feedback |
| --- | --- |
| UI engineering | Supported a constrained additive slot because it standardizes a recurring primary/secondary layout and aligns with MenuItem. |
| UX/accessibility | Supported the hierarchy; keyboard shortcuts are a valid use case, but the API should remain generic and have explicit accessible semantics. |
| Content design | Supported the `secondaryContent` name and the distinction between primary content and short supporting metadata. |
| Visual design | Supported a compact two-region layout with wrapping, RTL, dark-mode, and high-contrast behavior. |
| Product management | Agreed the user value is real, but initially preferred a documented JSX recipe. The API is justified when consistency and adoption across products are the goal. |

## Related Issue(s)

- Fixes #36491
