### PR TITLE
fix(react-charts): prevent histogram bar overlap

### DIFF
--- a/change/@fluentui-react-charts-00f29ed5-2001-4731-a88c-cdaebc2a2858.json
+++ b/change/@fluentui-react-charts-00f29ed5-2001-4731-a88c-cdaebc2a2858.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix histogram bar overlap on numeric x-axis",
+  "packageName": "@fluentui/react-charts",
+  "email": "24109638d@connect.polyu.hk",
+  "dependentChangeType": "patch"
+}

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.test.tsx
@@ -306,6 +306,13 @@ const simpleDatePoints = [
 
 const secondaryYScalePoints = [{ yMaxValue: 50000, yMinValue: 10000 }];
 
+const histogramBinCenterPoints: VerticalBarChartDataPoint[] = [
+  { x: 1550, y: 5, legend: 'Frequency', xAxisCalloutData: '1500-1599' },
+  { x: 1650, y: 19, legend: 'Frequency', xAxisCalloutData: '1600-1699' },
+  { x: 1750, y: 6, legend: 'Frequency', xAxisCalloutData: '1700-1799' },
+  { x: 1850, y: 3, legend: 'Frequency', xAxisCalloutData: '1800-1899' },
+];
+
 describe('Vertical bar chart rendering', () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
@@ -1076,4 +1083,33 @@ describe('Render empty chart calling with respective to props', () => {
     const htmlAfter = container.innerHTML;
     expect(htmlAfter).not.toBe(htmlBefore);
   });
+});
+
+describe('VerticalBarChart - histogram mode', () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  testWithWait(
+    'Should not overlap numeric histogram bars',
+    VerticalBarChart,
+    {
+      data: histogramBinCenterPoints,
+      mode: 'histogram',
+      barWidth: 'auto',
+      hideLegend: true,
+      hideLabels: true,
+    },
+    container => {
+      const bars = getById(container, /_VBC_bar/i);
+      expect(bars).toHaveLength(histogramBinCenterPoints.length);
+
+      for (let index = 1; index < bars.length; index++) {
+        const previousX = Number.parseFloat(bars[index - 1].getAttribute('x') || '0');
+        const previousWidth = Number.parseFloat(bars[index - 1].getAttribute('width') || '0');
+        const currentX = Number.parseFloat(bars[index].getAttribute('x') || '0');
+
+        expect(previousX + previousWidth).toBeLessThanOrEqual(currentX);
+      }
+    },
+  );
 });

--- a/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -1053,7 +1053,9 @@ export const VerticalBarChart: React.FunctionComponent<VerticalBarChartProps> = 
         props.mode,
       );
       _domainMargin += _barWidth / 2;
-      _domainMargin += _barWidth / 2;
+      if (props.mode !== 'histogram') {
+        _domainMargin += _barWidth / 2;
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary

- prevent numeric VerticalBarChart histograms from adding the extra half-bar domain margin used by non-histogram numeric bars
- add regression coverage that verifies adjacent numeric histogram bars do not overlap
- add a beachball patch change for @fluentui/react-charts

Fixes #36417

## Testing

- PASS: node_modules/.bin/jest --config jest.config.js src/components/VerticalBarChart/VerticalBarChart.test.tsx --runInBand
- PASS: corepack yarn prettier --check packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.tsx packages/charts/react-charts/library/src/components/VerticalBarChart/VerticalBarChart.test.tsx change/@fluentui-react-charts-00f29ed5-2001-4731-a88c-cdaebc2a2858.json
- PASS: commit hook ran prettier and node ./scripts/lint-staged/src/eslint on staged TS/TSX files

Notes: direct Nx targets (react-charts:test, react-charts:lint, react-charts:type-check) hung locally without output while building the project graph/plugin worker, so I used the package Jest command and targeted formatting/lint-staged verification.