### PR TITLE
fix(react-combobox,react-tag-picker): separate tabster logic from the base hooks

### DIFF
--- a/change/@fluentui-react-combobox-9f5fafcd-7082-45a1-a31e-9d2605a575fb.json
+++ b/change/@fluentui-react-combobox-9f5fafcd-7082-45a1-a31e-9d2605a575fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid headless bundle size regression from #36275",
+  "packageName": "@fluentui/react-combobox",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-509b8d02-9b8f-4508-83f4-0e88760058a0.json
+++ b/change/@fluentui-react-tag-picker-509b8d02-9b8f-4508-83f4-0e88760058a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid headless bundle size regression from #36275",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Combobox/useCombobox.tsx
@@ -27,6 +27,7 @@ import type {
 import { useListboxSlot } from '../../utils/useListboxSlot';
 import { useInputTriggerSlot } from './useInputTriggerSlot';
 import { isComboboxOptionElement } from '../../utils/isComboboxOptionElement';
+import { useTabsterEscapeIgnore } from '../../hooks/useTabsterEscapeIgnore';
 
 /**
  * Create the base state required to render Combobox, without design-only props.
@@ -228,5 +229,9 @@ export const useCombobox_unstable = (props: ComboboxProps, ref: React.Ref<HTMLIn
     ...baseState,
     appearance,
     size,
+    input: {
+      ...useTabsterEscapeIgnore(baseState.input, baseState.open),
+      ...baseState.input,
+    },
   };
 };

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdown.tsx
@@ -21,6 +21,7 @@ import { useListboxSlot } from '../../utils/useListboxSlot';
 import { useButtonTriggerSlot } from './useButtonTriggerSlot';
 import type { ComboboxOpenEvents } from '../Combobox/Combobox.types';
 import { isComboboxOptionElement } from '../../utils/isComboboxOptionElement';
+import { useTabsterEscapeIgnore } from '../../hooks/useTabsterEscapeIgnore';
 
 /**
  * Create the base state required to render Dropdown, without design-only props.
@@ -177,5 +178,9 @@ export const useDropdown_unstable = (props: DropdownProps, ref: React.Ref<HTMLBu
     ...baseState,
     appearance,
     size,
+    button: {
+      ...useTabsterEscapeIgnore(baseState.button, baseState.open),
+      ...baseState.button,
+    },
   };
 };

--- a/packages/react-components/react-combobox/library/src/hooks/useTabsterEscapeIgnore.ts
+++ b/packages/react-components/react-combobox/library/src/hooks/useTabsterEscapeIgnore.ts
@@ -1,15 +1,16 @@
 'use client';
 
-import { useMergedTabsterAttributes_unstable, useTabsterAttributes } from '@fluentui/react-tabster';
+import {
+  useMergedTabsterAttributes_unstable,
+  useTabsterAttributes,
+  type TabsterDOMAttribute,
+} from '@fluentui/react-tabster';
 
 /**
  * Hook to ignore Escape keydown events for a given element when Tabster is enabled.
  * @internal
  */
-export function useTabsterEscapeIgnore(
-  props: unknown,
-  shouldIgnoreEscape: boolean,
-): { 'data-tabster': string | undefined } {
+export function useTabsterEscapeIgnore(props: unknown, shouldIgnoreEscape: boolean): TabsterDOMAttribute {
   const ignoreEscapeKeyAttribute = useTabsterAttributes({
     focusable: {
       ignoreKeydown: { Escape: shouldIgnoreEscape },

--- a/packages/react-components/react-combobox/library/src/hooks/useTabsterEscapeIgnore.ts
+++ b/packages/react-components/react-combobox/library/src/hooks/useTabsterEscapeIgnore.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useMergedTabsterAttributes_unstable, useTabsterAttributes } from '@fluentui/react-tabster';
+
+/**
+ * Hook to ignore Escape keydown events for a given element when Tabster is enabled.
+ * @internal
+ */
+export function useTabsterEscapeIgnore(
+  props: unknown,
+  shouldIgnoreEscape: boolean,
+): { 'data-tabster': string | undefined } {
+  const ignoreEscapeKeyAttribute = useTabsterAttributes({
+    focusable: {
+      ignoreKeydown: { Escape: shouldIgnoreEscape },
+    },
+  });
+
+  return useMergedTabsterAttributes_unstable(ignoreEscapeKeyAttribute, typeof props === 'object' ? props : {});
+}

--- a/packages/react-components/react-combobox/library/src/utils/useTriggerSlot.ts
+++ b/packages/react-components/react-combobox/library/src/utils/useTriggerSlot.ts
@@ -1,11 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import {
-  useSetKeyboardNavigation,
-  useTabsterAttributes,
-  useMergedTabsterAttributes_unstable,
-} from '@fluentui/react-tabster';
+import { useSetKeyboardNavigation } from '@fluentui/react-tabster';
 import type { ActiveDescendantImperativeRef } from '@fluentui/react-aria';
 import { mergeCallbacks, slot, useEventCallback, useMergedRefs } from '@fluentui/react-utilities';
 import type { ExtractSlotProps, Slot, SlotComponentType } from '@fluentui/react-utilities';
@@ -52,26 +48,12 @@ export function useTriggerSlot(
     activeDescendantController,
   } = options;
 
-  // need to prevent tabster from also handling escape when the dropdown is open
-  // event.stopPropagation() isn't enough here, since tabster uses the capture phase
-  const ignoreEscapeKeyAttribute = useTabsterAttributes({
-    focusable: {
-      ignoreKeydown: { Escape: open },
-    },
-  });
-
-  const tabsterOverrides = useMergedTabsterAttributes_unstable(
-    ignoreEscapeKeyAttribute,
-    typeof defaultProps === 'object' ? defaultProps : {},
-  );
-
   const trigger = slot.always(triggerSlotFromProp, {
     defaultProps: {
       type: 'text',
       'aria-expanded': open,
       role: 'combobox',
       ...(typeof defaultProps === 'object' && defaultProps),
-      ...tabsterOverrides,
     },
     elementType,
   });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerButton/useTagPickerButton.tsx
@@ -10,6 +10,7 @@ import type {
 } from './TagPickerButton.types';
 import { useTagPickerContext_unstable } from '../../contexts/TagPickerContext';
 import { useButtonTriggerSlot } from '@fluentui/react-combobox';
+import { useTabsterEscapeIgnore } from '../../utils/useTabsterEscapeIgnore';
 
 /**
  * Create the base state required to render TagPickerButton, without design-only props.
@@ -79,10 +80,15 @@ export const useTagPickerButton_unstable = (
   ref: React.Ref<HTMLButtonElement>,
 ): TagPickerButtonState => {
   const baseState = useTagPickerButtonBase_unstable(props, ref);
+  const open = useTagPickerContext_unstable(ctx => ctx.open);
   const size = useTagPickerContext_unstable(ctx => ctx.size);
 
   return {
     ...baseState,
     size,
+    root: {
+      ...useTabsterEscapeIgnore(baseState.root, open),
+      ...baseState.root,
+    },
   };
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerInput/useTagPickerInput.tsx
@@ -21,6 +21,7 @@ import { useInputTriggerSlot } from '@fluentui/react-combobox';
 import { useFieldControlProps_unstable } from '@fluentui/react-field';
 import { tagPickerInputCSSRules } from '../../utils/tokens';
 import { useFocusFinders } from '@fluentui/react-tabster';
+import { useTabsterEscapeIgnore } from '../../utils/useTabsterEscapeIgnore';
 
 /**
  * Create the base state required to render TagPickerInput, without design-only props.
@@ -160,11 +161,16 @@ export const useTagPickerInput_unstable = (
   });
 
   const baseState = useTagPickerInputBase_unstable({ ...props, onKeyDown }, ref);
+  const open = useTagPickerContext_unstable(ctx => ctx.open);
   const size = useTagPickerContext_unstable(ctx => ctx.size);
 
   return {
     ...baseState,
     size,
+    root: {
+      ...useTabsterEscapeIgnore(baseState.root, open),
+      ...baseState.root,
+    },
   };
 };
 

--- a/packages/react-components/react-tag-picker/library/src/utils/useTabsterEscapeIgnore.ts
+++ b/packages/react-components/react-tag-picker/library/src/utils/useTabsterEscapeIgnore.ts
@@ -1,12 +1,16 @@
 'use client';
 
-import { useMergedTabsterAttributes_unstable, useTabsterAttributes } from '@fluentui/react-tabster';
+import {
+  useMergedTabsterAttributes_unstable,
+  useTabsterAttributes,
+  type TabsterDOMAttribute,
+} from '@fluentui/react-tabster';
 
 /**
  * Hook to ignore Escape keydown events for a given element when Tabster is enabled.
  * @internal
  */
-export const useTabsterEscapeIgnore = (props: unknown, shouldIgnoreEscape: boolean) => {
+export function useTabsterEscapeIgnore(props: unknown, shouldIgnoreEscape: boolean): TabsterDOMAttribute {
   const ignoreEscapeKeyAttribute = useTabsterAttributes({
     focusable: {
       ignoreKeydown: { Escape: shouldIgnoreEscape },
@@ -14,4 +18,4 @@ export const useTabsterEscapeIgnore = (props: unknown, shouldIgnoreEscape: boole
   });
 
   return useMergedTabsterAttributes_unstable(ignoreEscapeKeyAttribute, typeof props === 'object' ? props : {});
-};
+}

--- a/packages/react-components/react-tag-picker/library/src/utils/useTabsterEscapeIgnore.ts
+++ b/packages/react-components/react-tag-picker/library/src/utils/useTabsterEscapeIgnore.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useMergedTabsterAttributes_unstable, useTabsterAttributes } from '@fluentui/react-tabster';
+
+/**
+ * Hook to ignore Escape keydown events for a given element when Tabster is enabled.
+ * @internal
+ */
+export const useTabsterEscapeIgnore = (props: unknown, shouldIgnoreEscape: boolean) => {
+  const ignoreEscapeKeyAttribute = useTabsterAttributes({
+    focusable: {
+      ignoreKeydown: { Escape: shouldIgnoreEscape },
+    },
+  });
+
+  return useMergedTabsterAttributes_unstable(ignoreEscapeKeyAttribute, typeof props === 'object' ? props : {});
+};


### PR DESCRIPTION
## Previous Behavior

The headless bundle included additional Tabster Escape-ignore attribute handling in a shared trigger slot path, which caused a bundle size regression after https://github.com/microsoft/fluentui/pull/36275.

## New Behavior

Escape-ignore Tabster attributes are applied only where needed in Combobox, Dropdown, and TagPicker wrapper logic. This preserves Escape behavior when popup content is open while removing unnecessary shared-path overhead that affected headless bundle size.


Bundle size report is available below: https://github.com/microsoft/fluentui/pull/36497#issuecomment-5166394196


## Related Issue(s)

- Regression introduced by https://github.com/microsoft/fluentui/pull/36275
