### PR TITLE
fix(react-teaching-popover): isolate bundled dismiss icon

### DIFF
--- a/change/@fluentui-react-teaching-popover-c2dda2cd-f30a-4bea-a04b-400a23471e90.json
+++ b/change/@fluentui-react-teaching-popover-c2dda2cd-f30a-4bea-a04b-400a23471e90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: separate headless teaching popover title state from bundled icon defaults",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/bundle-size/TeachingPopover.fixture.js
+++ b/packages/react-components/react-headless-components-preview/library/bundle-size/TeachingPopover.fixture.js
@@ -1,0 +1,7 @@
+import * as TeachingPopover from '@fluentui/react-headless-components-preview/teaching-popover';
+
+console.log(TeachingPopover);
+
+export default {
+  name: '@fluentui/react-headless-components-preview/teaching-popover',
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
@@ -3,8 +3,10 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { isConformant } from '../../testing/isConformant';
 import { TeachingPopover } from './TeachingPopover';
+import { TeachingPopoverHeader } from './TeachingPopoverHeader';
 import { TeachingPopoverTrigger } from './TeachingPopoverTrigger';
 import { TeachingPopoverSurface } from './TeachingPopoverSurface';
+import { TeachingPopoverTitle } from './TeachingPopoverTitle';
 
 describe('TeachingPopover', () => {
   isConformant({
@@ -41,6 +43,52 @@ describe('TeachingPopover', () => {
 
     expect(getByText('Trigger')).toBeInTheDocument();
     expect(getByText('Surface content')).toBeInTheDocument();
+  });
+
+  it('does not render default header or title icons', () => {
+    const { container, getByTestId } = render(
+      <TeachingPopover defaultOpen>
+        <TeachingPopoverTrigger>
+          <button>Trigger</button>
+        </TeachingPopoverTrigger>
+        <TeachingPopoverSurface>
+          <TeachingPopoverHeader data-testid="header">Tips</TeachingPopoverHeader>
+          <TeachingPopoverTitle data-testid="title">Title</TeachingPopoverTitle>
+        </TeachingPopoverSurface>
+      </TeachingPopover>,
+    );
+    const header = getByTestId('header');
+    const title = getByTestId('title');
+
+    expect(container.querySelector('svg')).toBeNull();
+    expect(header.querySelector('[aria-hidden="true"]')).toBeEmptyDOMElement();
+    expect(header.querySelector('button[aria-label="dismiss"]')).toBeEmptyDOMElement();
+    expect(title.querySelector('button')).toBeNull();
+  });
+
+  it('renders explicitly provided header and title slots', () => {
+    const { getByTestId } = render(
+      <TeachingPopover defaultOpen>
+        <TeachingPopoverTrigger>
+          <button>Trigger</button>
+        </TeachingPopoverTrigger>
+        <TeachingPopoverSurface>
+          <TeachingPopoverHeader
+            icon={{ children: <span data-testid="header-icon">Tip</span> }}
+            dismissButton={{ children: <span data-testid="header-dismiss">Close header</span> }}
+          >
+            Tips
+          </TeachingPopoverHeader>
+          <TeachingPopoverTitle dismissButton={{ children: <span data-testid="title-dismiss">Close title</span> }}>
+            Title
+          </TeachingPopoverTitle>
+        </TeachingPopoverSurface>
+      </TeachingPopover>,
+    );
+
+    expect(getByTestId('header-icon')).toHaveTextContent('Tip');
+    expect(getByTestId('header-dismiss')).toHaveTextContent('Close header');
+    expect(getByTestId('title-dismiss')).toHaveTextContent('Close title');
   });
 
   it('renders an arrow by default (withArrow=true)', () => {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/index.ts
@@ -7,7 +7,8 @@ export type {
   TeachingPopoverTitleState,
 } from './TeachingPopoverTitle.types';
 export { renderTeachingPopoverTitle_unstable } from './renderTeachingPopoverTitle';
-export { useTeachingPopoverTitle_unstable, useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitle';
+export { useTeachingPopoverTitle_unstable } from './useTeachingPopoverTitle';
+export { useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitleBase';
 export {
   teachingPopoverTitleClassNames,
   useTeachingPopoverTitleStyles_unstable,

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitle.tsx
@@ -1,66 +1,12 @@
 'use client';
 
 import * as React from 'react';
-import { getIntrinsicElementProps, useEventCallback, slot } from '@fluentui/react-utilities';
-import type {
-  TeachingPopoverTitleBaseProps,
-  TeachingPopoverTitleBaseState,
-  TeachingPopoverTitleProps,
-  TeachingPopoverTitleState,
-} from './TeachingPopoverTitle.types';
 import { DismissFilled, DismissRegular, bundleIcon } from '@fluentui/react-icons';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
+import type { TeachingPopoverTitleProps, TeachingPopoverTitleState } from './TeachingPopoverTitle.types';
+import { useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitleBase';
 
 const DismissIcon = bundleIcon(DismissFilled, DismissRegular);
-
-/**
- * Base hook that builds TeachingPopoverTitle state for behavior and structure only.
- * Does not bundle/render the dismiss icon and does not read `appearance` from popover context.
- * @param props - TeachingPopoverTitle properties
- * @param ref - reference to root HTMLElement of TeachingPopoverTitle
- */
-export const useTeachingPopoverTitleBase_unstable = (
-  props: TeachingPopoverTitleBaseProps,
-  ref: React.Ref<HTMLDivElement>,
-): TeachingPopoverTitleBaseState => {
-  const { dismissButton } = props;
-
-  const setOpen = usePopoverContext_unstable(context => context.setOpen);
-  const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
-
-  const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
-    if (!ev.defaultPrevented) {
-      setOpen(ev, false);
-    }
-
-    if (triggerRef.current) {
-      triggerRef.current.focus();
-    }
-  });
-
-  return {
-    components: {
-      root: 'h2',
-      dismissButton: 'button',
-    },
-    root: slot.always(
-      getIntrinsicElementProps('h2', {
-        ref,
-        ...props,
-      }),
-      { elementType: 'h2' },
-    ),
-    dismissButton: slot.optional(dismissButton, {
-      renderByDefault: false,
-      defaultProps: {
-        onClick: onDismissButtonClick,
-        'aria-label': 'dismiss',
-        'aria-hidden': true,
-      },
-      elementType: 'button',
-    }),
-  };
-};
 
 /**
  * Returns the props and state required to render the component

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PopoverProvider } from '@fluentui/react-popover';
+import type { PopoverContextValue } from '@fluentui/react-popover';
+import { useTeachingPopoverTitleBase_unstable } from './useTeachingPopoverTitleBase';
+
+const defaultPopoverContext: PopoverContextValue = {
+  open: true,
+  setOpen: () => null,
+  toggleOpen: () => null,
+  triggerRef: { current: null },
+  contentRef: { current: null },
+  arrowRef: { current: null },
+  openOnContext: false,
+  openOnHover: false,
+  size: 'medium',
+  inline: false,
+};
+
+function makeWrapper(contextValue: Partial<PopoverContextValue> = {}) {
+  const value = { ...defaultPopoverContext, ...contextValue };
+  return ({ children }: { children: React.ReactNode }) => React.createElement(PopoverProvider, { value }, children);
+}
+
+describe('useTeachingPopoverTitleBase_unstable', () => {
+  it('returns structural state without styled defaults', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const { result } = renderHook(() => useTeachingPopoverTitleBase_unstable({ dismissButton: {} }, ref), {
+      wrapper: makeWrapper(),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({ root: 'h2', dismissButton: 'button' });
+    expect(result.current).not.toHaveProperty('appearance');
+    expect(result.current.dismissButton?.children).toBeUndefined();
+  });
+
+  it('dismisses the popover and restores focus', () => {
+    const ref = React.createRef<HTMLHeadingElement>();
+    const setOpen = jest.fn();
+    const focus = jest.fn();
+    const triggerRef = { current: { focus } as unknown as HTMLElement };
+    const { result } = renderHook(() => useTeachingPopoverTitleBase_unstable({ dismissButton: {} }, ref), {
+      wrapper: makeWrapper({ setOpen, triggerRef }),
+    });
+    const event = { defaultPrevented: false } as React.MouseEvent<HTMLButtonElement>;
+
+    result.current.dismissButton?.onClick?.(event);
+
+    expect(setOpen).toHaveBeenCalledWith(event, false);
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import type * as React from 'react';
+import { usePopoverContext_unstable } from '@fluentui/react-popover';
+import { getIntrinsicElementProps, slot, useEventCallback } from '@fluentui/react-utilities';
+import type { TeachingPopoverTitleBaseProps, TeachingPopoverTitleBaseState } from './TeachingPopoverTitle.types';
+
+/**
+ * Base hook that builds TeachingPopoverTitle state for behavior and structure only.
+ * Does not bundle/render the dismiss icon and does not read `appearance` from popover context.
+ * @param props - TeachingPopoverTitle properties
+ * @param ref - reference to root HTMLElement of TeachingPopoverTitle
+ */
+export const useTeachingPopoverTitleBase_unstable = (
+  props: TeachingPopoverTitleBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): TeachingPopoverTitleBaseState => {
+  const { dismissButton } = props;
+
+  const setOpen = usePopoverContext_unstable(context => context.setOpen);
+  const triggerRef = usePopoverContext_unstable(context => context.triggerRef);
+
+  const onDismissButtonClick = useEventCallback((ev: React.MouseEvent<HTMLButtonElement>) => {
+    if (!ev.defaultPrevented) {
+      setOpen(ev, false);
+    }
+
+    if (triggerRef.current) {
+      triggerRef.current.focus();
+    }
+  });
+
+  return {
+    components: {
+      root: 'h2',
+      dismissButton: 'button',
+    },
+    root: slot.always(
+      getIntrinsicElementProps('h2', {
+        ref,
+        ...props,
+      }),
+      { elementType: 'h2' },
+    ),
+    dismissButton: slot.optional(dismissButton, {
+      renderByDefault: false,
+      defaultProps: {
+        onClick: onDismissButtonClick,
+        'aria-label': 'dismiss',
+        'aria-hidden': true,
+      },
+      elementType: 'button',
+    }),
+  };
+};


### PR DESCRIPTION
- move the behavior-only `TeachingPopoverTitle` state hook into an icon-free module
- keep the styled `bundleIcon` default in `useTeachingPopoverTitle_unstable`
- avoid pulling the bundled dismiss icon and Griffel into the headless TeachingPopover entrypoint
- add focused tests, a bundle-size fixture, and patch change files