### PR TITLE
chore(react-tabster): update to Tabster 9 canary

### DIFF
--- a/change/@fluentui-react-tabster-e01081c8-4afc-41d2-b775-ce68b138e367.json
+++ b/change/@fluentui-react-tabster-e01081c8-4afc-41d2-b775-ce68b138e367.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: update to Tabster 9 canary",
+  "packageName": "@fluentui/react-tabster",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-tabster/bundle-size/hooks.fixture.js
+++ b/packages/react-components/react-tabster/bundle-size/hooks.fixture.js
@@ -1,0 +1,12 @@
+import {
+  useArrowNavigationGroup,
+  useFocusableGroup,
+  useFocusFinders,
+  useMergedTabsterAttributes_unstable,
+} from '@fluentui/react-tabster';
+
+console.log(useFocusFinders, useMergedTabsterAttributes_unstable, useArrowNavigationGroup, useFocusableGroup);
+
+export default {
+  name: 'react-tabster hooks',
+};

--- a/packages/react-components/react-tabster/etc/react-tabster.api.md
+++ b/packages/react-components/react-tabster/etc/react-tabster.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-import { dispatchGroupperMoveFocusEvent } from 'tabster';
-import { dispatchMoverMoveFocusEvent } from 'tabster';
 import { EventsTypes } from 'tabster';
 import type { GriffelStyle } from '@griffel/react';
 import { GroupperMoveFocusActions } from 'tabster';
@@ -236,9 +234,11 @@ interface DeloserProps {
     restoreFocusOrder?: RestoreFocusOrder;
 }
 
-export { dispatchGroupperMoveFocusEvent }
+// @public @deprecated (undocumented)
+export function dispatchGroupperMoveFocusEvent(): void;
 
-export { dispatchMoverMoveFocusEvent }
+// @public @deprecated (undocumented)
+export function dispatchMoverMoveFocusEvent(): void;
 
 // @public (undocumented)
 interface Disposable {

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -18,7 +18,7 @@
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1",
     "keyborg": "^2.14.1",
-    "tabster": "^8.8.0"
+    "tabster": "9.0.0-canary.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -17,7 +17,7 @@
     "@fluentui/react-utilities": "^9.26.5",
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1",
-    "keyborg": "^2.14.1",
+    "keyborg": "^3.0.0",
     "tabster": "9.0.0-canary.0"
   },
   "peerDependencies": {

--- a/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
@@ -34,7 +34,7 @@ export const useFocusFinders = (): {
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
     (container: HTMLElement | null, acceptCondition?: (el: HTMLElement) => boolean) =>
-      (container && !!tabsterRef.current && findAll(tabsterRef.current, { container, acceptCondition })) || [],
+      (container && tabsterRef.current && findAll(tabsterRef.current, { container, acceptCondition })) || [],
     [tabsterRef],
   );
 

--- a/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
+++ b/packages/react-components/react-tabster/src/hooks/useFocusFinders.ts
@@ -2,6 +2,13 @@
 
 import * as React from 'react';
 import type { Types as TabsterTypes } from 'tabster';
+import {
+  findAllFocusable as findAll,
+  findFirstFocusable as findFirst,
+  findLastFocusable as findLast,
+  findNextFocusable as findNext,
+  findPrevFocusable as findPrev,
+} from 'tabster';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { useTabster } from './useTabster';
 
@@ -27,17 +34,17 @@ export const useFocusFinders = (): {
   // Narrow props for now and let need dictate additional props in the future
   const findAllFocusable = React.useCallback(
     (container: HTMLElement | null, acceptCondition?: (el: HTMLElement) => boolean) =>
-      (container && tabsterRef.current?.focusable.findAll({ container, acceptCondition })) || [],
+      (container && !!tabsterRef.current && findAll(tabsterRef.current, { container, acceptCondition })) || [],
     [tabsterRef],
   );
 
   const findFirstFocusable = React.useCallback(
-    (container: HTMLElement | null) => container && tabsterRef.current?.focusable.findFirst({ container }),
+    (container: HTMLElement | null) => container && tabsterRef.current && findFirst(tabsterRef.current, { container }),
     [tabsterRef],
   );
 
   const findLastFocusable = React.useCallback(
-    (container: HTMLElement | null) => container && tabsterRef.current?.focusable.findLast({ container }),
+    (container: HTMLElement | null) => container && tabsterRef.current && findLast(tabsterRef.current, { container }),
     [tabsterRef],
   );
 
@@ -49,7 +56,7 @@ export const useFocusFinders = (): {
 
       const { container = targetDocument.body } = options;
 
-      return tabsterRef.current.focusable.findNext({ currentElement, container });
+      return findNext(tabsterRef.current, { currentElement, container });
     },
     [tabsterRef, targetDocument],
   );
@@ -62,7 +69,7 @@ export const useFocusFinders = (): {
 
       const { container = targetDocument.body } = options;
 
-      return tabsterRef.current.focusable.findPrev({ currentElement, container });
+      return findPrev(tabsterRef.current, { currentElement, container });
     },
     [tabsterRef, targetDocument],
   );

--- a/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
+++ b/packages/react-components/react-tabster/src/hooks/useModalAttributes.ts
@@ -40,7 +40,7 @@ const tabsterAccessibleCheck: TabsterTypes.ModalizerElementAccessibleCheck = ele
 };
 
 function initTabsterModules(tabster: TabsterTypes.TabsterCore) {
-  getModalizer(tabster, undefined, tabsterAccessibleCheck);
+  getModalizer(tabster, tabsterAccessibleCheck);
   getRestorer(tabster);
 }
 

--- a/packages/react-components/react-tabster/src/hooks/useTabster.test.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.test.ts
@@ -1,20 +1,23 @@
-import { createTabster, disposeTabster } from 'tabster';
+import { createTabster, disposeTabster, getRootDummyInputs } from 'tabster';
 import { renderHook } from '@testing-library/react-hooks';
 import { useTabster } from './useTabster';
 
 jest.mock('tabster', () => ({
   createTabster: jest.fn(() => 'mock-tabster-instance'),
   disposeTabster: jest.fn(),
+  getRootDummyInputs: jest.fn(),
 }));
 
 const createTabsterMock = createTabster as jest.Mock;
 const disposeTabsterMock = disposeTabster as jest.Mock;
+const getRootDummyInputsMock = getRootDummyInputs as jest.Mock;
 
 describe('useTabster', () => {
   it('returns a ref to the tabster instance', () => {
     const { result } = renderHook(() => useTabster());
 
     expect(createTabsterMock).toHaveBeenCalledTimes(1);
+    expect(getRootDummyInputsMock).toHaveBeenCalledWith('mock-tabster-instance');
     expect(result.current).toMatchObject({
       current: 'mock-tabster-instance',
     });

--- a/packages/react-components/react-tabster/src/hooks/useTabster.ts
+++ b/packages/react-components/react-tabster/src/hooks/useTabster.ts
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import type { Types as TabsterTypes } from 'tabster';
-import { createTabster, disposeTabster } from 'tabster';
+import { createTabster, disposeTabster, getRootDummyInputs } from 'tabster';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { getParent, useIsomorphicLayoutEffect, usePrevious } from '@fluentui/react-utilities';
 
@@ -27,7 +27,7 @@ export function createTabsterWithConfig(targetDocument: Document | undefined): T
   const shadowDOMAPI = (defaultView as WindowWithTabsterShadowDOMAPI | undefined)?.__tabsterShadowDOMAPI;
 
   if (defaultView) {
-    return createTabster(defaultView, {
+    const tabster = createTabster(defaultView, {
       autoRoot: {},
       controlTab: false,
       getParent,
@@ -38,6 +38,10 @@ export function createTabsterWithConfig(targetDocument: Document | undefined): T
         element.firstElementChild?.hasAttribute('data-is-focus-trap-zone-bumper') === true || undefined,
       DOMAPI: shadowDOMAPI,
     });
+
+    getRootDummyInputs(tabster);
+
+    return tabster;
   }
 }
 

--- a/packages/react-components/react-tabster/src/index.ts
+++ b/packages/react-components/react-tabster/src/index.ts
@@ -39,8 +39,6 @@ export { applyFocusVisiblePolyfill } from './focus/index';
 import {
   type Types,
   type EventsTypes,
-  dispatchGroupperMoveFocusEvent,
-  dispatchMoverMoveFocusEvent,
   MoverMoveFocusEventName,
   MoverMoveFocusEvent,
   MoverKeys,
@@ -65,11 +63,23 @@ import * as TabsterTypes6_0_1_DoNotUse from './tabster-types-6.0.1-do-not-use';
 export {
   /** @deprecated (Do not use! Exposed by mistake and will be removed in the next major version.)  */
   TabsterTypes6_0_1_DoNotUse as TabsterTypes,
-  /** @deprecated Use element.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape })) */
-  dispatchGroupperMoveFocusEvent,
-  /** @deprecated Use element.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys.ArrowDown })) */
-  dispatchMoverMoveFocusEvent,
 };
+
+/** @deprecated Use `element.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }))`. */
+export function dispatchGroupperMoveFocusEvent(): void {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'dispatchGroupperMoveFocusEvent is deprecated. Use element.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }))',
+  );
+}
+
+/** @deprecated Use `element.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys.ArrowDown }))`. */
+export function dispatchMoverMoveFocusEvent(): void {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'dispatchMoverMoveFocusEvent is deprecated. Use element.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys.ArrowDown }))',
+  );
+}
 
 /**
  * For all exports below, we don't do wildcard exports to keep Tabster API flexible. We export only required

--- a/yarn.lock
+++ b/yarn.lock
@@ -5580,7 +5580,7 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
     keyborg: "npm:^2.14.1"
-    tabster: "npm:^8.8.0"
+    tabster: "npm:9.0.0-canary.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     "@types/react-dom": ">=16.9.0 <20.0.0"
@@ -22439,10 +22439,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyborg@npm:^2.14.0, keyborg@npm:^2.14.1":
+"keyborg@npm:^2.14.1":
   version: 2.14.1
   resolution: "keyborg@npm:2.14.1"
   checksum: 10c0/5776649f12a572b4cca590451d0baf30c88329f533a71576b3fb4da4438eafe67f4636544483431fd98f539d3057370455b6853af2eb3ba44006fbd276bb7ee0
+  languageName: node
+  linkType: hard
+
+"keyborg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "keyborg@npm:3.0.0"
+  checksum: 10c0/2625f3a881eb2c1b319952faa1967973f16223ca83931615a94670b29ffd17a1328011bc6cf41730af538bf81cd2ceb79ccba542075c8a71463f1bb6bacccd87
   languageName: node
   linkType: hard
 
@@ -29993,13 +30000,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tabster@npm:^8.8.0":
-  version: 8.8.0
-  resolution: "tabster@npm:8.8.0"
+"tabster@npm:9.0.0-canary.0":
+  version: 9.0.0-canary.0
+  resolution: "tabster@npm:9.0.0-canary.0"
   dependencies:
-    keyborg: "npm:^2.14.0"
+    keyborg: "npm:^3.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/013e269b66af718d02401d26e0c6dfd5d169a18b30fb257198e68188521f43b9b093b933d6f6b56d0e7c9533e403217149bd48092db3fac3d95495964185b689
+  checksum: 10c0/afbb865dc59abb72f3fd39c7a3bae0f60e926c3f7d6642cacec4776effd0a3000797230f2727e2a149fce9ef48ae636cfcc50d17a82fa6d47e1e66ea5a3a324c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5579,7 +5579,7 @@ __metadata:
     "@fluentui/react-utilities": "npm:^9.26.5"
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
-    keyborg: "npm:^2.14.1"
+    keyborg: "npm:^3.0.0"
     tabster: "npm:9.0.0-canary.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
@@ -22436,13 +22436,6 @@ __metadata:
     jwa: "npm:^1.4.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/e770704533d92df358adad7d1261fdecad4d7b66fa153ba80d047e03ca0f1f73007ce5ed3fbc04d2eba09ba6e7e6e645f351e08e5ab51614df1b0aa4f384dfff
-  languageName: node
-  linkType: hard
-
-"keyborg@npm:^2.14.1":
-  version: 2.14.1
-  resolution: "keyborg@npm:2.14.1"
-  checksum: 10c0/5776649f12a572b4cca590451d0baf30c88329f533a71576b3fb4da4438eafe67f4636544483431fd98f539d3057370455b6853af2eb3ba44006fbd276bb7ee0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Previous Behavior

`@fluentui/react-tabster` depended on Tabster 8 APIs, including the `tabster.focusable` instance and event dispatch helpers removed in Tabster 9.

## New Behavior

Updates the dependency to `tabster@9.0.0-canary.0`, uses standalone focus finder APIs, adapts modalizer initialization, and preserves the deprecated dispatch exports as compatibility shims. Adds bundle-size coverage for the exported hooks.

## Related Issue(s)

- None

## Validation

- `yarn nx run-many -t type-check lint test -p react-tabster`
- `yarn nx e2e react-tabster`
- `yarn nx run react-tabster:generate-api --skipNxCache`
- `yarn beachball check --branch upstream/master`