### PR TITLE
chore: sync web components versions after broken release

### DIFF
--- a/change/@fluentui-chart-web-components-9e64eade-4a6e-4ef5-804e-0302dbe8d0cf.json
+++ b/change/@fluentui-chart-web-components-9e64eade-4a6e-4ef5-804e-0302dbe8d0cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fixing package bump issue to latest published version",
+  "packageName": "@fluentui/chart-web-components",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-2629fc8d-de98-44e1-aaaa-f6b149295390.json
+++ b/change/@fluentui-web-components-2629fc8d-de98-44e1-aaaa-f6b149295390.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: fixing package bump issue to latest published version",
+  "packageName": "@fluentui/web-components",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-web-components-9c7dc48c-180c-4d64-aeb6-b7e3f1415e45.json
+++ b/change/@fluentui-web-components-9c7dc48c-180c-4d64-aeb6-b7e3f1415e45.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix focusgroup in tree when focusgroup is natively supported",
-  "packageName": "@fluentui/web-components",
-  "email": "machi@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/charts/chart-web-components/CHANGELOG.json
+++ b/packages/charts/chart-web-components/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui/chart-web-components",
   "entries": [
     {
+      "date": "Mon, 13 Jul 2026 04:09:41 GMT",
+      "tag": "@fluentui/chart-web-components_v0.0.92",
+      "version": "0.0.92",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@fluentui/chart-web-components",
+            "comment": "Bump @fluentui/web-components to v3.0.2",
+            "commit": "bc5035bfcd53277a39075c596b14b9731020d1de"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 07 Jul 2026 04:09:50 GMT",
       "tag": "@fluentui/chart-web-components_v0.0.91",
       "version": "0.0.91",

--- a/packages/charts/chart-web-components/CHANGELOG.md
+++ b/packages/charts/chart-web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/chart-web-components
 
-This log was last generated on Tue, 07 Jul 2026 04:09:50 GMT and should not be manually modified.
+This log was last generated on Mon, 13 Jul 2026 04:09:41 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [0.0.92](https://github.com/microsoft/fluentui/tree/@fluentui/chart-web-components_v0.0.92)
+
+Mon, 13 Jul 2026 04:09:41 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/chart-web-components_v0.0.91..@fluentui/chart-web-components_v0.0.92)
+
+### Patches
+
+- Bump @fluentui/web-components to v3.0.2 ([PR #36379](https://github.com/microsoft/fluentui/pull/36379) by beachball)
 
 ## [0.0.91](https://github.com/microsoft/fluentui/tree/@fluentui/chart-web-components_v0.0.91)
 

--- a/packages/charts/chart-web-components/package.json
+++ b/packages/charts/chart-web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/chart-web-components",
   "description": "A library of Fluent Chart Web Components",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "author": {
     "name": "Microsoft"
   },
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@fluentui/tokens": "^1.0.0-alpha.23",
-    "@fluentui/web-components": "^3.0.1",
+    "@fluentui/web-components": "^3.0.2",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "@types/d3-selection": "^3.0.0",
     "@types/d3-shape": "^3.0.0",

--- a/packages/web-components/CHANGELOG.json
+++ b/packages/web-components/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui/web-components",
   "entries": [
     {
+      "date": "Mon, 13 Jul 2026 04:09:41 GMT",
+      "tag": "@fluentui/web-components_v3.0.2",
+      "version": "3.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "machi@microsoft.com",
+            "package": "@fluentui/web-components",
+            "commit": "bc5035bfcd53277a39075c596b14b9731020d1de",
+            "comment": "fix focusgroup in tree when focusgroup is natively supported"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 07 Jul 2026 04:09:49 GMT",
       "tag": "@fluentui/web-components_v3.0.1",
       "version": "3.0.1",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/web-components
 
-This log was last generated on Tue, 07 Jul 2026 04:09:49 GMT and should not be manually modified.
+This log was last generated on Mon, 13 Jul 2026 04:09:41 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [3.0.2](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.2)
+
+Mon, 13 Jul 2026 04:09:41 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/web-components_v3.0.1..@fluentui/web-components_v3.0.2)
+
+### Patches
+
+- fix focusgroup in tree when focusgroup is natively supported ([PR #36379](https://github.com/microsoft/fluentui/pull/36379) by machi@microsoft.com)
 
 ## [3.0.1](https://github.com/microsoft/fluentui/tree/@fluentui/web-components_v3.0.1)
 

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/web-components",
   "description": "A library of Fluent Web Components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,7 +2572,7 @@ __metadata:
   resolution: "@fluentui/chart-web-components@workspace:packages/charts/chart-web-components"
   dependencies:
     "@fluentui/tokens": "npm:^1.0.0-alpha.23"
-    "@fluentui/web-components": "npm:^3.0.1"
+    "@fluentui/web-components": "npm:^3.0.2"
     "@microsoft/fast-web-utilities": "npm:^6.0.0"
     "@storybook/html": "npm:9.1.17"
     "@storybook/html-vite": "npm:9.1.17"
@@ -6573,7 +6573,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/web-components@npm:*, @fluentui/web-components@npm:^3.0.1, @fluentui/web-components@workspace:packages/web-components":
+"@fluentui/web-components@npm:*, @fluentui/web-components@npm:^3.0.2, @fluentui/web-components@workspace:packages/web-components":
   version: 0.0.0-use.local
   resolution: "@fluentui/web-components@workspace:packages/web-components"
   dependencies:


### PR DESCRIPTION
## Previous Behavior

The `web-components_20260713.1` release published `@fluentui/web-components@3.0.2` and `@fluentui/chart-web-components@0.0.92`, but the generated Beachball commit did not reach `master`. The repository remained at 3.0.1 and 0.0.91 with the consumed change file still present.

## New Behavior

Synchronizes package manifests, changelogs, the chart dependency, and `yarn.lock` with the versions already published from #36379. Removes the consumed change file. No new change file is included because this PR records an existing npm release and must not trigger another version bump.

## Related Item

- #36379
- Pipeline: `web-components_20260713.1`

## Validation

- Compared versions, dependency, timestamp, and changelog entries with the published npm artifacts
- Parsed modified JSON and checked manifest/changelog consistency
- Confirmed the expected eight-file scope and reviewed the diff
- Local Nx checks could not start because `yarn install --immutable` hit a registry `ENOTCONN`; CI will run the repository checks