### PR TITLE
feat(react-color-picker): expose headless base APIs

### DIFF
--- a/change/@fluentui-react-color-picker-414d04c8-72e8-4708-83a7-466c4d885578.json
+++ b/change/@fluentui-react-color-picker-414d04c8-72e8-4708-83a7-466c4d885578.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-color-picker): expose headless base APIs",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker/library/etc/react-color-picker.api.md
+++ b/packages/react-components/react-color-picker/library/etc/react-color-picker.api.md
@@ -6,6 +6,7 @@
 
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { ContextSelector } from '@fluentui/react-context-selector';
 import type { EventData } from '@fluentui/react-utilities';
 import type { EventHandler } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
@@ -16,6 +17,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 
 // @public
 export const AlphaSlider: ForwardRefComponent<AlphaSliderProps>;
+
+// @public
+export type AlphaSliderBaseProps = Omit<AlphaSliderProps, 'shape'>;
+
+// @public
+export type AlphaSliderBaseState = Omit<AlphaSliderState, 'shape'>;
 
 // @public (undocumented)
 export const alphaSliderClassNames: SlotClassNames<AlphaSliderSlots>;
@@ -33,6 +40,12 @@ export type AlphaSliderState = ComponentState<AlphaSliderSlots> & Pick<AlphaSlid
 
 // @public
 export const ColorArea: ForwardRefComponent<ColorAreaProps>;
+
+// @public
+export type ColorAreaBaseProps = Omit<ColorAreaProps, 'shape'>;
+
+// @public
+export type ColorAreaBaseState = ComponentState<Required<ColorAreaSlots>> & Pick<ColorAreaProps, 'color'>;
 
 // @public (undocumented)
 export const colorAreaClassNames: SlotClassNames<ColorAreaSlots>;
@@ -55,11 +68,32 @@ export type ColorAreaSlots = {
 // @public
 export type ColorAreaState = ComponentState<Required<ColorAreaSlots>> & Pick<ColorAreaProps, 'color' | 'shape'>;
 
+// @public (undocumented)
+export type ColorChannel = 'hue' | 'saturation' | 'value';
+
 // @public
 export const ColorPicker: ForwardRefComponent<ColorPickerProps>;
 
+// @public
+export type ColorPickerBaseProps = Omit<ColorPickerProps, 'shape'>;
+
+// @public
+export type ColorPickerBaseState = Omit<ColorPickerState, 'shape'>;
+
 // @public (undocumented)
 export const colorPickerClassNames: SlotClassNames<ColorPickerSlots>;
+
+// @public
+export type ColorPickerContextValue = Pick<ColorPickerProps, 'shape' | 'color'> & {
+    requestChange: (event: React_2.ChangeEvent<HTMLInputElement>, data: {
+        color: HsvColor;
+    }) => void;
+};
+
+// @public (undocumented)
+export type ColorPickerContextValues = {
+    colorPicker: ColorPickerContextValue;
+};
 
 // @public
 export type ColorPickerProps = Omit<ComponentProps<Partial<ColorPickerSlots>>, 'color'> & {
@@ -78,6 +112,12 @@ export type ColorPickerState = ComponentState<ColorPickerSlots> & ColorPickerCon
 
 // @public
 export const ColorSlider: ForwardRefComponent<ColorSliderProps>;
+
+// @public (undocumented)
+export type ColorSliderBaseProps = Omit<ColorSliderProps, 'shape'>;
+
+// @public (undocumented)
+export type ColorSliderBaseState = Omit<ColorSliderState, 'shape'>;
 
 // @public (undocumented)
 export const colorSliderClassNames: SlotClassNames<ColorSliderSlots>;
@@ -103,19 +143,22 @@ export type ColorSliderSlots = {
 export type ColorSliderState = ComponentState<ColorSliderSlots> & Pick<ColorSliderProps, 'vertical' | 'shape' | 'channel'>;
 
 // @public
-export const renderAlphaSlider_unstable: (state: AlphaSliderState) => JSXElement;
+export const renderAlphaSlider_unstable: (state: AlphaSliderBaseState) => JSXElement;
 
 // @public
-export const renderColorArea_unstable: (state: ColorAreaState) => JSXElement;
+export const renderColorArea_unstable: (state: ColorAreaBaseState) => JSXElement;
 
 // @public
-export const renderColorPicker_unstable: (state: ColorPickerState, contextValues: ColorPickerContextValues) => JSXElement;
+export const renderColorPicker_unstable: (state: ColorPickerBaseState, contextValues: ColorPickerContextValues) => JSXElement;
 
 // @public
-export const renderColorSlider_unstable: (state: ColorSliderState) => JSXElement;
+export const renderColorSlider_unstable: (state: ColorSliderBaseState) => JSXElement;
 
 // @public
 export const useAlphaSlider_unstable: (props: AlphaSliderProps, ref: React_2.Ref<HTMLInputElement>) => AlphaSliderState;
+
+// @public (undocumented)
+export const useAlphaSliderBase_unstable: (props: AlphaSliderBaseProps, ref: React_2.Ref<HTMLInputElement>) => AlphaSliderBaseState;
 
 // @public
 export const useAlphaSliderStyles_unstable: (state: AlphaSliderState) => AlphaSliderState;
@@ -124,16 +167,31 @@ export const useAlphaSliderStyles_unstable: (state: AlphaSliderState) => AlphaSl
 export const useColorArea_unstable: (props: ColorAreaProps, ref: React_2.Ref<HTMLDivElement>) => ColorAreaState;
 
 // @public
-export const useColorAreaStyles_unstable: (state: ColorAreaState) => ColorAreaState;
+export const useColorAreaBase_unstable: (props: ColorAreaBaseProps, ref: React_2.Ref<HTMLDivElement>) => ColorAreaBaseState;
 
 // @public
+export const useColorAreaStyles_unstable: (state: ColorAreaState) => ColorAreaState;
+
+// @public (undocumented)
 export const useColorPicker_unstable: (props: ColorPickerProps, ref: React_2.Ref<HTMLDivElement>) => ColorPickerState;
+
+// @public
+export const useColorPickerBase_unstable: (props: ColorPickerBaseProps, ref: React_2.Ref<HTMLDivElement>) => ColorPickerBaseState;
+
+// @public (undocumented)
+export const useColorPickerContextValue_unstable: <T>(selector: ContextSelector<ColorPickerContextValue, T>) => T;
+
+// @public (undocumented)
+export const useColorPickerContextValues: (state: ColorPickerState) => ColorPickerContextValues;
 
 // @public
 export const useColorPickerStyles_unstable: (state: ColorPickerState) => ColorPickerState;
 
 // @public
 export const useColorSlider_unstable: (props: ColorSliderProps, ref: React_2.Ref<HTMLInputElement>) => ColorSliderState;
+
+// @public
+export const useColorSliderBase_unstable: (props: ColorSliderBaseProps, ref: React_2.Ref<HTMLInputElement>) => ColorSliderBaseState;
 
 // @public
 export const useColorSliderStyles_unstable: (state: ColorSliderState) => ColorSliderState;

--- a/packages/react-components/react-color-picker/library/src/AlphaSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/AlphaSlider.ts
@@ -1,9 +1,16 @@
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './components/AlphaSlider/index';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './components/AlphaSlider/index';
 export {
   AlphaSlider,
   alphaSliderCSSVars,
   alphaSliderClassNames,
   renderAlphaSlider_unstable,
+  useAlphaSliderBase_unstable,
   useAlphaSliderStyles_unstable,
   useAlphaSlider_unstable,
 } from './components/AlphaSlider/index';

--- a/packages/react-components/react-color-picker/library/src/ColorArea.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorArea.ts
@@ -1,4 +1,6 @@
 export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
   ColorAreaOnColorChangeData,
   ColorAreaProps,
   ColorAreaSlots,
@@ -9,6 +11,7 @@ export {
   colorAreaCSSVars,
   colorAreaClassNames,
   renderColorArea_unstable,
+  useColorAreaBase_unstable,
   useColorAreaStyles_unstable,
   useColorArea_unstable,
 } from './components/ColorArea/index';

--- a/packages/react-components/react-color-picker/library/src/ColorPicker.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorPicker.ts
@@ -1,4 +1,6 @@
 export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
   ColorPickerOnChangeData,
   ColorPickerProps,
   ColorPickerSlots,
@@ -8,6 +10,9 @@ export {
   ColorPicker,
   colorPickerClassNames,
   renderColorPicker_unstable,
+  useColorPickerBaseContextValues_unstable,
+  useColorPickerBase_unstable,
+  useColorPickerContextValues,
   useColorPickerStyles_unstable,
   useColorPicker_unstable,
 } from './components/ColorPicker/index';

--- a/packages/react-components/react-color-picker/library/src/ColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/ColorSlider.ts
@@ -1,4 +1,7 @@
 export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
   ColorSliderProps,
   ColorSliderSlots,
   ColorSliderState,
@@ -9,6 +12,7 @@ export {
   colorSliderCSSVars,
   colorSliderClassNames,
   renderColorSlider_unstable,
+  useColorSliderBase_unstable,
   useColorSliderStyles_unstable,
   useColorSlider_unstable,
 } from './components/ColorSlider/index';

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.types.ts
@@ -19,8 +19,18 @@ export type AlphaSliderProps = Omit<ColorSliderProps, 'channel'> & {
 };
 
 /**
+ * AlphaSlider Base Props
+ */
+export type AlphaSliderBaseProps = Omit<AlphaSliderProps, 'shape'>;
+
+/**
  * State used in rendering AlphaSlider
  */
 export type AlphaSliderState = ComponentState<AlphaSliderSlots> &
   Pick<AlphaSliderProps, 'vertical'> &
   Omit<ColorSliderState, keyof ColorSliderSlots | 'components'>;
+
+/**
+ * State used in rendering unstyled AlphaSlider
+ */
+export type AlphaSliderBaseState = Omit<AlphaSliderState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/index.ts
@@ -1,7 +1,13 @@
 export { AlphaSlider } from './AlphaSlider';
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './AlphaSlider.types';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './AlphaSlider.types';
 export { renderAlphaSlider_unstable } from './renderAlphaSlider';
-export { useAlphaSlider_unstable } from './useAlphaSlider';
+export { useAlphaSliderBase_unstable, useAlphaSlider_unstable } from './useAlphaSlider';
 export {
   alphaSliderCSSVars,
   alphaSliderClassNames,

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/renderAlphaSlider.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/renderAlphaSlider.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { AlphaSliderState, AlphaSliderSlots } from './AlphaSlider.types';
+import type { AlphaSliderBaseState, AlphaSliderSlots } from './AlphaSlider.types';
 
 /**
  * Render the final JSX of AlphaSlider
  */
-export const renderAlphaSlider_unstable = (state: AlphaSliderState): JSXElement => {
+export const renderAlphaSlider_unstable = (state: AlphaSliderBaseState): JSXElement => {
   assertSlots<AlphaSliderSlots>(state);
 
   return (

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.ts
@@ -2,7 +2,12 @@
 
 import type * as React from 'react';
 import { getPartitionedNativeProps, useId, slot } from '@fluentui/react-utilities';
-import type { AlphaSliderProps, AlphaSliderState } from './AlphaSlider.types';
+import type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderState,
+} from './AlphaSlider.types';
 import { useAlphaSliderState_unstable } from './useAlphaSliderState';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 
@@ -20,6 +25,18 @@ export const useAlphaSlider_unstable = (
   ref: React.Ref<HTMLInputElement>,
 ): AlphaSliderState => {
   const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+  const { shape = shapeFromContext, ...baseProps } = props;
+
+  return {
+    ...useAlphaSliderBase_unstable(baseProps, ref),
+    shape,
+  };
+};
+
+export const useAlphaSliderBase_unstable = (
+  props: AlphaSliderBaseProps,
+  ref: React.Ref<HTMLInputElement>,
+): AlphaSliderBaseState => {
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
@@ -27,7 +44,6 @@ export const useAlphaSlider_unstable = (
   });
 
   const {
-    shape = shapeFromContext,
     vertical,
     // Slots
     root,
@@ -36,8 +52,7 @@ export const useAlphaSlider_unstable = (
     thumb,
   } = props;
 
-  const state: AlphaSliderState = {
-    shape,
+  const state: AlphaSliderBaseState = {
     vertical,
     components: {
       input: 'input',

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.types.ts
@@ -36,6 +36,16 @@ export type ColorAreaProps = Omit<ComponentProps<Partial<ColorAreaSlots>>, 'colo
   };
 
 /**
+ * ColorArea Base Props
+ */
+export type ColorAreaBaseProps = Omit<ColorAreaProps, 'shape'>;
+
+/**
  * State used in rendering ColorArea
  */
 export type ColorAreaState = ComponentState<Required<ColorAreaSlots>> & Pick<ColorAreaProps, 'color' | 'shape'>;
+
+/**
+ * ColorArea Base State
+ */
+export type ColorAreaBaseState = ComponentState<Required<ColorAreaSlots>> & Pick<ColorAreaProps, 'color'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/index.ts
@@ -1,5 +1,12 @@
 export { ColorArea } from './ColorArea';
-export type { ColorAreaOnColorChangeData, ColorAreaProps, ColorAreaSlots, ColorAreaState } from './ColorArea.types';
+export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
+  ColorAreaOnColorChangeData,
+  ColorAreaProps,
+  ColorAreaSlots,
+  ColorAreaState,
+} from './ColorArea.types';
 export { renderColorArea_unstable } from './renderColorArea';
-export { useColorArea_unstable } from './useColorArea';
+export { useColorAreaBase_unstable, useColorArea_unstable } from './useColorArea';
 export { colorAreaCSSVars, colorAreaClassNames, useColorAreaStyles_unstable } from './useColorAreaStyles.styles';

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/renderColorArea.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/renderColorArea.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { ColorAreaState, ColorAreaSlots } from './ColorArea.types';
+import type { ColorAreaBaseState, ColorAreaSlots } from './ColorArea.types';
 
 /**
  * Render the final JSX of ColorArea
  */
-export const renderColorArea_unstable = (state: ColorAreaState): JSXElement => {
+export const renderColorArea_unstable = (state: ColorAreaBaseState): JSXElement => {
   assertSlots<ColorAreaSlots>(state);
 
   return (

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { tinycolor } from '@ctrl/tinycolor';
 import { useId, slot, useMergedRefs, mergeCallbacks, getIntrinsicElementProps } from '@fluentui/react-utilities';
-import type { ColorAreaProps, ColorAreaState } from './ColorArea.types';
+import type { ColorAreaBaseProps, ColorAreaBaseState, ColorAreaProps, ColorAreaState } from './ColorArea.types';
 import type { HsvColor } from '../../types/color';
 import { colorAreaCSSVars } from './useColorAreaStyles.styles';
 import { useEventCallback, useControllableState } from '@fluentui/react-utilities';
@@ -14,15 +14,17 @@ import { getCoordinates } from '../../utils/getCoordinates';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 
 /**
- * Create the state required to render ColorArea.
+ * Create the state required to render unstyled ColorArea.
  *
- * The returned state can be modified with hooks such as useColorAreaStyles_unstable,
- * before being passed to renderColorArea_unstable.
+ * The returned state can be modified with hooks before being passed to renderColorArea_unstable.
  *
  * @param props - props from this instance of ColorArea
  * @param ref - reference to root HTMLDivElement of ColorArea
  */
-export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTMLDivElement>): ColorAreaState => {
+export const useColorAreaBase_unstable = (
+  props: ColorAreaBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): ColorAreaBaseState => {
   const { targetDocument } = useFluent();
   const rootRef = React.useRef<HTMLDivElement>(null);
   const xRef = React.useRef<HTMLInputElement>(null);
@@ -30,11 +32,9 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
   const focusWithinRef = useFocusWithin();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);
-  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
 
   const {
     onChange = onChangeFromContext as unknown as ColorAreaProps['onChange'],
-    shape = shapeFromContext,
     // Slots
     inputX,
     inputY,
@@ -164,8 +164,7 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
     [colorAreaCSSVars.thumbColorVar]: tinycolor(hsvColor).toRgbString(),
     [colorAreaCSSVars.mainColorVar]: `hsl(${hsvColor.h}, 100%, 50%)`,
   };
-  const state: ColorAreaState = {
-    shape,
+  const state: ColorAreaBaseState = {
     components: {
       inputX: 'input',
       inputY: 'input',
@@ -215,6 +214,28 @@ export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTML
 
   state.inputX.value = saturation;
   state.inputY.value = value;
+
+  return state;
+};
+
+/**
+ * Create the state required to render ColorArea.
+ *
+ * The returned state can be modified with hooks such as useColorAreaStyles_unstable,
+ * before being passed to renderColorArea_unstable.
+ *
+ * @param props - props from this instance of ColorArea
+ * @param ref - reference to root HTMLDivElement of ColorArea
+ */
+export const useColorArea_unstable = (props: ColorAreaProps, ref: React.Ref<HTMLDivElement>): ColorAreaState => {
+  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+
+  const { shape = shapeFromContext, ...rest } = props;
+
+  const state: ColorAreaState = {
+    ...useColorAreaBase_unstable(rest, ref),
+    shape,
+  };
 
   return state;
 };

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/ColorPicker.types.ts
@@ -32,7 +32,13 @@ export type ColorPickerProps = Omit<ComponentProps<Partial<ColorPickerSlots>>, '
   shape?: 'rounded' | 'square';
 };
 
+/** ColorPicker Base Props */
+export type ColorPickerBaseProps = Omit<ColorPickerProps, 'shape'>;
+
 /**
  * State used in rendering ColorPicker
  */
 export type ColorPickerState = ComponentState<ColorPickerSlots> & ColorPickerContextValue;
+
+/** State used in rendering unstyled ColorPicker */
+export type ColorPickerBaseState = Omit<ColorPickerState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/index.ts
@@ -1,10 +1,13 @@
 export { ColorPicker } from './ColorPicker';
 export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
   ColorPickerOnChangeData,
   ColorPickerProps,
   ColorPickerSlots,
   ColorPickerState,
 } from './ColorPicker.types';
 export { renderColorPicker_unstable } from './renderColorPicker';
-export { useColorPicker_unstable } from './useColorPicker';
+export { useColorPickerBase_unstable, useColorPicker_unstable } from './useColorPicker';
+export { useColorPickerBaseContextValues_unstable, useColorPickerContextValues } from './useColorPickerContextValues';
 export { colorPickerClassNames, useColorPickerStyles_unstable } from './useColorPickerStyles.styles';

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/renderColorPicker.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/renderColorPicker.tsx
@@ -3,7 +3,7 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { ColorPickerState, ColorPickerSlots } from './ColorPicker.types';
+import type { ColorPickerBaseState, ColorPickerSlots } from './ColorPicker.types';
 import type { ColorPickerContextValues } from '../../contexts/colorPicker';
 import { ColorPickerProvider } from '../../contexts/colorPicker';
 
@@ -11,7 +11,7 @@ import { ColorPickerProvider } from '../../contexts/colorPicker';
  * Render the final JSX of ColorPicker
  */
 export const renderColorPicker_unstable = (
-  state: ColorPickerState,
+  state: ColorPickerBaseState,
   contextValues: ColorPickerContextValues,
 ): JSXElement => {
   assertSlots<ColorPickerSlots>(state);

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.ts
@@ -2,7 +2,12 @@
 
 import type * as React from 'react';
 import { getIntrinsicElementProps, slot, useEventCallback } from '@fluentui/react-utilities';
-import type { ColorPickerProps, ColorPickerState } from './ColorPicker.types';
+import type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
+  ColorPickerProps,
+  ColorPickerState,
+} from './ColorPicker.types';
 /**
  * Create the state required to render ColorPicker.
  *
@@ -12,10 +17,13 @@ import type { ColorPickerProps, ColorPickerState } from './ColorPicker.types';
  * @param props - props from this instance of ColorPicker
  * @param ref - reference to root HTMLDivElement of ColorPicker
  */
-export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<HTMLDivElement>): ColorPickerState => {
-  const { color, onColorChange, shape, ...rest } = props;
+export const useColorPickerBase_unstable = (
+  props: ColorPickerBaseProps,
+  ref: React.Ref<HTMLDivElement>,
+): ColorPickerBaseState => {
+  const { color, onColorChange, ...rest } = props;
 
-  const requestChange: ColorPickerState['requestChange'] = useEventCallback((event, data) => {
+  const requestChange: ColorPickerBaseState['requestChange'] = useEventCallback((event, data) => {
     onColorChange?.(event, {
       type: 'change',
       event,
@@ -36,6 +44,14 @@ export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<
     ),
     color,
     requestChange,
+  };
+};
+
+export const useColorPicker_unstable = (props: ColorPickerProps, ref: React.Ref<HTMLDivElement>): ColorPickerState => {
+  const { shape, ...baseProps } = props;
+
+  return {
+    ...useColorPickerBase_unstable(baseProps, ref),
     shape,
   };
 };

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPickerContextValues.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPickerContextValues.ts
@@ -2,7 +2,22 @@
 
 import * as React from 'react';
 import type { ColorPickerContextValue, ColorPickerContextValues } from '../../contexts/colorPicker';
-import type { ColorPickerState } from './ColorPicker.types';
+import type { ColorPickerBaseState, ColorPickerState } from './ColorPicker.types';
+
+export const useColorPickerBaseContextValues_unstable = (state: ColorPickerBaseState): ColorPickerContextValues => {
+  const { color, requestChange } = state;
+
+  const colorPicker = React.useMemo<ColorPickerContextValue>(
+    () => ({
+      requestChange,
+      color,
+      shape: undefined,
+    }),
+    [requestChange, color],
+  );
+
+  return { colorPicker };
+};
 
 export const useColorPickerContextValues = (state: ColorPickerState): ColorPickerContextValues => {
   const { color, shape, requestChange } = state;

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.types.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.types.ts
@@ -52,8 +52,12 @@ export type ColorSliderProps = Omit<
     defaultColor?: HsvColor;
   };
 
+export type ColorSliderBaseProps = Omit<ColorSliderProps, 'shape'>;
+
 /**
  * State used in rendering ColorSlider
  */
 export type ColorSliderState = ComponentState<ColorSliderSlots> &
   Pick<ColorSliderProps, 'vertical' | 'shape' | 'channel'>;
+
+export type ColorSliderBaseState = Omit<ColorSliderState, 'shape'>;

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/index.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/index.ts
@@ -1,7 +1,15 @@
 export { ColorSlider } from './ColorSlider';
-export type { ColorSliderProps, ColorSliderSlots, ColorSliderState, SliderOnChangeData } from './ColorSlider.types';
+export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderSlots,
+  ColorSliderState,
+  SliderOnChangeData,
+} from './ColorSlider.types';
 export { renderColorSlider_unstable } from './renderColorSlider';
-export { useColorSlider_unstable } from './useColorSlider';
+export { useColorSliderBase_unstable, useColorSlider_unstable } from './useColorSlider';
 export {
   colorSliderCSSVars,
   colorSliderClassNames,

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/renderColorSlider.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/renderColorSlider.tsx
@@ -3,12 +3,12 @@
 
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
-import type { ColorSliderState, ColorSliderSlots } from './ColorSlider.types';
+import type { ColorSliderBaseState, ColorSliderSlots } from './ColorSlider.types';
 
 /**
  * Render the final JSX of ColorSlider
  */
-export const renderColorSlider_unstable = (state: ColorSliderState): JSXElement => {
+export const renderColorSlider_unstable = (state: ColorSliderBaseState): JSXElement => {
   assertSlots<ColorSliderSlots>(state);
 
   return (

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
@@ -11,7 +11,12 @@ import {
 } from '@fluentui/react-utilities';
 import { colorSliderCSSVars } from './useColorSliderStyles.styles';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import type { ColorSliderProps, ColorSliderState } from './ColorSlider.types';
+import type {
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderState,
+} from './ColorSlider.types';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
 import { MIN, HUE_MAX, MAX as COLOR_MAX } from '../../utils/constants';
 import { getPercent } from '../../utils/getPercent';
@@ -21,24 +26,22 @@ import type { HsvColor } from '../../types/color';
 import { INITIAL_COLOR_HSV } from '../../utils/constants';
 
 /**
- * Create the state required to render ColorSlider.
+ * Create the base state required to render unstyled ColorSlider.
  *
- * The returned state can be modified with hooks such as useColorSliderStyles_unstable,
- * before being passed to renderColorSlider_unstable.
+ * The returned state can be modified with hooks before being passed to renderColorSlider_unstable.
  *
  * @param props - props from this instance of ColorSlider
  * @param ref - reference to root HTMLInputElement of ColorSlider
  */
-export const useColorSlider_unstable = (
-  props: ColorSliderProps,
+export const useColorSliderBase_unstable = (
+  props: ColorSliderBaseProps,
   ref: React.Ref<HTMLInputElement>,
-): ColorSliderState => {
+): ColorSliderBaseState => {
   'use no memo'; // justified: compiler would optimize useColorSlider_unstable — manual opt-out to preserve runtime behavior
 
   const { dir } = useFluent();
   const onChangeFromContext = useColorPickerContextValue_unstable(ctx => ctx.requestChange);
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);
-  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
   const nativeProps = getPartitionedNativeProps({
     props,
     primarySlotTagName: 'input',
@@ -49,7 +52,6 @@ export const useColorSlider_unstable = (
     color,
     channel = 'hue',
     onChange = onChangeFromContext,
-    shape = shapeFromContext,
     vertical,
     // Slots
     root,
@@ -110,8 +112,7 @@ export const useColorSlider_unstable = (
         : `hsl(${hslColor.h} 100%, 50%)`,
   };
 
-  const state: ColorSliderState = {
-    shape,
+  const state: ColorSliderBaseState = {
     vertical,
     channel,
     components: {
@@ -153,5 +154,30 @@ export const useColorSlider_unstable = (
   // Input Props
   state.input.value = clampedValue;
   state.input.onChange = _onChange;
+  return state;
+};
+
+/**
+ * Create the state required to render ColorSlider.
+ *
+ * The returned state can be modified with hooks such as useColorSliderStyles_unstable,
+ * before being passed to renderColorSlider_unstable.
+ *
+ * @param props - props from this instance of ColorSlider
+ * @param ref - reference to root HTMLInputElement of ColorSlider
+ */
+export const useColorSlider_unstable = (
+  props: ColorSliderProps,
+  ref: React.Ref<HTMLInputElement>,
+): ColorSliderState => {
+  const shapeFromContext = useColorPickerContextValue_unstable(ctx => ctx.shape);
+
+  const { shape = shapeFromContext, ...baseProps } = props;
+
+  const state: ColorSliderState = {
+    ...useColorSliderBase_unstable(baseProps, ref),
+    shape,
+  };
+
   return state;
 };

--- a/packages/react-components/react-color-picker/library/src/index.ts
+++ b/packages/react-components/react-color-picker/library/src/index.ts
@@ -1,32 +1,64 @@
-export type { ColorSliderProps, ColorSliderSlots, ColorSliderState } from './ColorSlider';
+export type {
+  ColorChannel,
+  ColorSliderBaseProps,
+  ColorSliderBaseState,
+  ColorSliderProps,
+  ColorSliderSlots,
+  ColorSliderState,
+} from './ColorSlider';
 export {
   ColorSlider,
   colorSliderClassNames,
   renderColorSlider_unstable,
+  useColorSliderBase_unstable,
   useColorSliderStyles_unstable,
   useColorSlider_unstable,
 } from './ColorSlider';
-export type { ColorPickerProps, ColorPickerSlots, ColorPickerState } from './ColorPicker';
+export type {
+  ColorPickerBaseProps,
+  ColorPickerBaseState,
+  ColorPickerProps,
+  ColorPickerSlots,
+  ColorPickerState,
+} from './ColorPicker';
 export {
   ColorPicker,
   colorPickerClassNames,
   renderColorPicker_unstable,
+  useColorPickerBase_unstable,
+  useColorPickerContextValues,
   useColorPickerStyles_unstable,
   useColorPicker_unstable,
 } from './ColorPicker';
-export type { ColorAreaProps, ColorAreaSlots, ColorAreaState } from './ColorArea';
+export type {
+  ColorAreaBaseProps,
+  ColorAreaBaseState,
+  ColorAreaProps,
+  ColorAreaSlots,
+  ColorAreaState,
+} from './ColorArea';
 export {
   ColorArea,
   colorAreaClassNames,
   renderColorArea_unstable,
+  useColorAreaBase_unstable,
   useColorAreaStyles_unstable,
   useColorArea_unstable,
 } from './ColorArea';
-export type { AlphaSliderProps, AlphaSliderSlots, AlphaSliderState } from './AlphaSlider';
+export type {
+  AlphaSliderBaseProps,
+  AlphaSliderBaseState,
+  AlphaSliderProps,
+  AlphaSliderSlots,
+  AlphaSliderState,
+} from './AlphaSlider';
 export {
   AlphaSlider,
   alphaSliderClassNames,
   renderAlphaSlider_unstable,
+  useAlphaSliderBase_unstable,
   useAlphaSliderStyles_unstable,
   useAlphaSlider_unstable,
 } from './AlphaSlider';
+export type { ColorPickerContextValue, ColorPickerContextValues } from './contexts/colorPicker';
+export { useColorPickerContextValue_unstable } from './contexts/colorPicker';


### PR DESCRIPTION
## Motivation

`@fluentui/react-headless-components-preview` needs the color-picker behavior and slot state without applying the styled components’ visual-only state. This PR separates that reusable behavior from the styled wrappers so the follow-up PR can compose headless controls without duplicating interaction logic.

No visual or behavioral change is intended for the existing `@fluentui/react-color-picker` components.

## Changes

- add base props and state types for `ColorPicker`, `ColorArea`, `ColorSlider`, and `AlphaSlider`
- extract and export `use*Base_unstable` hooks containing shared slot, input, color, orientation, and change-handling behavior
- keep the existing styled hooks as thin wrappers that add visual-only state such as `shape`
- allow existing render functions to consume base state
- add a base `ColorPicker` context-values hook for headless composition
- expose supporting public types and APIs, including `ColorChannel`
- update the API report and add a minor changefile for `@fluentui/react-color-picker`

## Review guidance

Review this PR relative to `test/react-color-picker-hooks`. The key boundary is that base hooks own reusable behavior, while existing component hooks continue to add styled-only state.

## Validation

- `yarn nx build react-color-picker`
- the hook tests pass in #36527
- the dependent headless implementation passes in #36518

## PR stack

1. #36527: add hook state coverage
2. **This PR:** expose reusable color-picker base APIs
3. #36518: add headless color-picker controls

Depends on #36527 and should be merged after it.