### PR TITLE
fix(drawer): tolerate fractional scroll metrics

### DIFF
--- a/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
+++ b/packages/react-components/react-drawer/library/src/components/DrawerBody/useDrawerBody.ts
@@ -23,6 +23,7 @@ import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts
  * @param element - HTMLElement to check scroll state of
  */
 const getScrollState = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement): DrawerScrollState => {
+  const epsilon = 1;
   if (scrollHeight <= clientHeight) {
     return 'none';
   }
@@ -31,7 +32,7 @@ const getScrollState = ({ scrollTop, scrollHeight, clientHeight }: HTMLElement):
     return 'top';
   }
 
-  if (scrollTop + clientHeight === scrollHeight) {
+  if (scrollTop + clientHeight >= scrollHeight - epsilon) {
     return 'bottom';
   }
 


### PR DESCRIPTION
## Description

This PR fixes the scroll-bottom detection in `DrawerBody`.

Previously, the component checked whether the drawer had reached the bottom using an exact equality comparison:

```ts
scrollTop + clientHeight === scrollHeight