### PR TITLE
Fix/message bar max width

### DIFF
--- a/change/@fluentui-web-components-ef486754-179a-49e3-869f-855e51d3ee7e.json
+++ b/change/@fluentui-web-components-ef486754-179a-49e3-869f-855e51d3ee7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Remove max-width from MessageBar component",
+  "packageName": "@fluentui/web-components",
+  "email": "jolud@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/message-bar/message-bar.styles.css
+++ b/packages/web-components/src/message-bar/message-bar.styles.css
@@ -47,7 +47,6 @@
 
 .content {
   grid-area: body;
-  max-width: 520px;
   padding-block: var(--spacingVerticalMNudge);
   padding-inline: 0;
 }

--- a/packages/web-components/src/message-bar/message-bar.styles.ts
+++ b/packages/web-components/src/message-bar/message-bar.styles.ts
@@ -75,7 +75,6 @@ export const styles: ElementStyles = css`
 
   .content {
     grid-area: body;
-    max-width: 520px;
     padding-block: ${spacingVerticalMNudge};
     padding-inline: 0;
   }


### PR DESCRIPTION
## Previous Behavior

`<fluent-message-bar>` capped its content at a hardcoded `max-width: 520px`. Per current Fabric design guidance that cap is no longer desired, and it doesn't match Fluent UI React v9 (whose `MessageBarBody` has no `max-width`).

## New Behavior

The MessageBar content is no longer capped by default — it fills its container, matching React v9.

## Notes for the reviewer

I chose not to introduce a unit test specifically for this, it felt unnecessary to test that a specific css style was *not* present. Arguably there should have been an existing test for max-width that I would have removed here.

## Related Issue(s)

- Fixes #36365
