### PR TITLE
perf(workspace-plugin): reuse a single api-extractor compiler state in generate-api

### DIFF
--- a/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
@@ -1,6 +1,8 @@
 import { type ExecutorContext, serializeJson } from '@nx/devkit';
 import {
+  CompilerState,
   Extractor,
+  type ICompilerStateCreateOptions,
   type IExtractorInvokeOptions,
   type ExtractorConfig,
   type ExtractorResult,
@@ -39,6 +41,14 @@ const _context: ExecutorContext = {
 };
 
 const execSyncMock = execSync as jest.Mock;
+
+// The real thing would build a TS program over the fixtures, which the mocked `Extractor.invoke` never reads.
+const compilerStateStub = { program: {} } as unknown as CompilerState;
+let compilerStateCreateSpy: jest.SpyInstance<CompilerState, [ExtractorConfig, ICompilerStateCreateOptions?]>;
+
+beforeEach(() => {
+  compilerStateCreateSpy = jest.spyOn(CompilerState, 'create').mockReturnValue(compilerStateStub);
+});
 
 function cleanup() {
   // Remove all contents of the fixtures directory but keep the directory itself
@@ -192,6 +202,7 @@ describe('GenerateApi Executor', () => {
     const actualLocalBuildValue = isCI() ? false : true;
 
     expect(extractorArgs).toEqual({
+      compilerState: compilerStateStub,
       localBuild: actualLocalBuildValue,
       showDiagnostics: false,
       showVerboseMessages: true,
@@ -224,6 +235,7 @@ describe('GenerateApi Executor', () => {
 
     expect(extractorConfig).toEqual(expect.any(Object));
     expect(extractorArgs).toEqual({
+      compilerState: compilerStateStub,
       localBuild: false,
       showDiagnostics: true,
       showVerboseMessages: true,
@@ -490,6 +502,32 @@ describe('GenerateApi Executor – export subpath resolution', () => {
 
     // primary (1) + utils (1) + wildcard sub-dirs (2)
     expect(ExtractorInvokeSpy).toHaveBeenCalledTimes(1 + 1 + subDirs.length);
+    expect(output.success).toBe(true);
+  });
+
+  it('creates one compiler state for all entry points and reuses it for every invocation', async () => {
+    const subDirs = ['alpha', 'beta'];
+    const { context } = prepareExportFixture({ wildcardSubDirs: subDirs, namedExports: ['utils'] });
+
+    const capturedConfigs: ExtractorConfig[] = [];
+    const capturedStates: (CompilerState | undefined)[] = [];
+    jest.spyOn(Extractor, 'invoke').mockImplementation((cfg, invokeOptions) => {
+      capturedConfigs.push(cfg);
+      capturedStates.push(invokeOptions?.compilerState);
+      return { succeeded: true } as ExtractorResult;
+    });
+
+    const output = await executor({ ...options, exportSubpaths: true }, context);
+
+    expect(compilerStateCreateSpy).toHaveBeenCalledTimes(1);
+
+    const [primaryConfig, createOptions] = compilerStateCreateSpy.mock.calls[0];
+    expect(primaryConfig).toBe(capturedConfigs[0]);
+    expect(createOptions?.additionalEntryPoints).toEqual(
+      capturedConfigs.slice(1).map(cfg => cfg.mainEntryPointFilePath),
+    );
+
+    expect(capturedStates).toEqual(new Array(1 + 1 + subDirs.length).fill(compilerStateStub));
     expect(output.success).toBe(true);
   });
 });

--- a/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
@@ -1,10 +1,12 @@
 import { type ExecutorContext, serializeJson } from '@nx/devkit';
 import {
   CompilerState,
+  ConsoleMessageId,
   Extractor,
   type ICompilerStateCreateOptions,
   type IExtractorInvokeOptions,
   type ExtractorConfig,
+  type ExtractorMessage,
   type ExtractorResult,
 } from '@microsoft/api-extractor';
 import { basename, join } from 'node:path';
@@ -203,6 +205,7 @@ describe('GenerateApi Executor', () => {
 
     expect(extractorArgs).toEqual({
       compilerState: compilerStateStub,
+      messageCallback: expect.any(Function),
       localBuild: actualLocalBuildValue,
       showDiagnostics: false,
       showVerboseMessages: true,
@@ -236,6 +239,7 @@ describe('GenerateApi Executor', () => {
     expect(extractorConfig).toEqual(expect.any(Object));
     expect(extractorArgs).toEqual({
       compilerState: compilerStateStub,
+      messageCallback: expect.any(Function),
       localBuild: false,
       showDiagnostics: true,
       showVerboseMessages: true,
@@ -529,5 +533,35 @@ describe('GenerateApi Executor – export subpath resolution', () => {
 
     expect(capturedStates).toEqual(new Array(1 + 1 + subDirs.length).fill(compilerStateStub));
     expect(output.success).toBe(true);
+  });
+
+  it('reports repeated api-extractor console notices only once across invocations', async () => {
+    const { context } = prepareExportFixture({ namedExports: ['utils'] });
+
+    const capturedCallbacks: NonNullable<IExtractorInvokeOptions['messageCallback']>[] = [];
+    jest.spyOn(Extractor, 'invoke').mockImplementation((_config, invokeOptions) => {
+      capturedCallbacks.push(invokeOptions!.messageCallback!);
+      return { succeeded: true } as ExtractorResult;
+    });
+
+    await executor({ ...options, exportSubpaths: true }, context);
+
+    expect(capturedCallbacks).toHaveLength(2);
+    expect(capturedCallbacks[0]).toBe(capturedCallbacks[1]);
+
+    const messages = {
+      firstPreamble: { messageId: ConsoleMessageId.Preamble, handled: false } as ExtractorMessage,
+      secondPreamble: { messageId: ConsoleMessageId.Preamble, handled: false } as ExtractorMessage,
+      apiReport: { messageId: ConsoleMessageId.ApiReportCopied, handled: false } as ExtractorMessage,
+    };
+
+    capturedCallbacks[0](messages.firstPreamble);
+    capturedCallbacks[1](messages.secondPreamble);
+    capturedCallbacks[1](messages.apiReport);
+
+    expect(messages.firstPreamble.handled).toBe(false);
+    expect(messages.secondPreamble.handled).toBe(true);
+    // unrelated console messages keep api-extractor's default handling
+    expect(messages.apiReport.handled).toBe(false);
   });
 });

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -1,8 +1,15 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { execSync } from 'node:child_process';
 import { type ExecutorContext, type PromiseExecutor, logger, parseJson } from '@nx/devkit';
-import { CompilerState, Extractor, ExtractorConfig, type IConfigFile } from '@microsoft/api-extractor';
+import {
+  CompilerState,
+  ConsoleMessageId,
+  Extractor,
+  ExtractorConfig,
+  type ExtractorMessage,
+  type IConfigFile,
+} from '@microsoft/api-extractor';
 
 import type { GenerateApiExecutorSchema } from './schema';
 import type { PackageJson, TsConfig } from '../../types';
@@ -47,14 +54,47 @@ async function runGenerateApi(options: NormalizedOptions, context: ExecutorConte
 
   const extractorConfigs = configSources.map(configSource => prepareExtractorConfig(configSource, options));
   const compilerState = createCompilerState(extractorConfigs);
+  const messageCallback = createConsoleMessageDeduper();
 
-  for (const extractorConfig of extractorConfigs) {
-    if (!invokeExtractor(extractorConfig, compilerState, options, context)) {
+  for (const [index, extractorConfig] of extractorConfigs.entries()) {
+    const invoked = invokeExtractor(
+      {
+        extractorConfig,
+        compilerState,
+        messageCallback,
+        progress: { current: index + 1, total: extractorConfigs.length },
+      },
+      options,
+      context,
+    );
+
+    if (!invoked) {
       return false;
     }
   }
 
   return true;
+}
+
+/**
+ * api-extractor repeats its compiler version notices on every invocation, so keep only the first of each.
+ */
+function createConsoleMessageDeduper() {
+  const dedupedMessageIds: string[] = [ConsoleMessageId.Preamble, ConsoleMessageId.CompilerVersionNotice];
+  const alreadyReported = new Set<string>();
+
+  return (message: ExtractorMessage) => {
+    if (!dedupedMessageIds.includes(message.messageId)) {
+      return;
+    }
+
+    if (alreadyReported.has(message.messageId)) {
+      message.handled = true;
+      return;
+    }
+
+    alreadyReported.add(message.messageId);
+  };
 }
 
 /**
@@ -180,15 +220,22 @@ function prepareExtractorConfig(configSource: ConfigSource, options: NormalizedO
 }
 
 function invokeExtractor(
-  extractorConfig: ExtractorConfig,
-  compilerState: CompilerState,
+  params: {
+    extractorConfig: ExtractorConfig;
+    compilerState: CompilerState;
+    messageCallback: (message: ExtractorMessage) => void;
+    progress: { current: number; total: number };
+  },
   options: NormalizedOptions,
   context: ExecutorContext,
 ) {
-  verboseLog(`Running api-extractor for entry point: ${extractorConfig.mainEntryPointFilePath}`);
+  const { extractorConfig, compilerState, messageCallback, progress } = params;
+
+  logEntryPoint();
 
   const extractorResult = Extractor.invoke(extractorConfig, {
     compilerState,
+    messageCallback,
 
     // Equivalent to the "--local" command-line parameter
     localBuild: options.local,
@@ -208,6 +255,18 @@ function invokeExtractor(
       ` and ${extractorResult.warningCount} warnings`,
   );
   return false;
+
+  function logEntryPoint() {
+    const outputPath = extractorConfig.untrimmedFilePath || extractorConfig.mainEntryPointFilePath;
+    const label = relative(options.projectAbsolutePath, outputPath);
+
+    if (progress.total === 1) {
+      verboseLog(`Generating API for ${label}`);
+      return;
+    }
+
+    logger.info(`[${progress.current}/${progress.total}] Generating API for ${label}`);
+  }
 }
 
 function getTsConfigForApiExtractor(options: {

--- a/tools/workspace-plugin/src/executors/generate-api/executor.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import { type ExecutorContext, type PromiseExecutor, logger, parseJson } from '@nx/devkit';
-import { Extractor, ExtractorConfig, type IConfigFile } from '@microsoft/api-extractor';
+import { CompilerState, Extractor, ExtractorConfig, type IConfigFile } from '@microsoft/api-extractor';
 
 import type { GenerateApiExecutorSchema } from './schema';
 import type { PackageJson, TsConfig } from '../../types';
@@ -28,28 +28,47 @@ export default runExecutor;
 
 export interface NormalizedOptions extends ReturnType<typeof normalizeOptions> {}
 
+type ConfigSource = { configPath: string } | { configObject: IConfigFile };
+
 async function runGenerateApi(options: NormalizedOptions, context: ExecutorContext): Promise<boolean> {
   if (!generateTypeDeclarations(options)) {
     return false;
   }
 
-  // Run primary api-extractor config
-  if (!apiExtractor({ configPath: options.config }, options, context)) {
-    return false;
+  const configSources: ConfigSource[] = [{ configPath: options.config }];
+
+  // Expand export subpaths into one api-extractor config per resolved entry
+  if (options.exportSubpaths.enabled) {
+    for (const configObject of getExportSubpathConfigs(options)) {
+      verboseLog(`Resolved api-extractor config for export subpath entry: ${configObject.mainEntryPointFilePath}`);
+      configSources.push({ configObject });
+    }
   }
 
-  // Expand export subpaths and run api-extractor for each resolved entry
-  if (options.exportSubpaths.enabled) {
-    const subpathConfigs = getExportSubpathConfigs(options);
-    for (const configObject of subpathConfigs) {
-      verboseLog(`Running api-extractor for export subpath entry: ${configObject.mainEntryPointFilePath}`);
-      if (!apiExtractor({ configObject }, options, context)) {
-        return false;
-      }
+  const extractorConfigs = configSources.map(configSource => prepareExtractorConfig(configSource, options));
+  const compilerState = createCompilerState(extractorConfigs);
+
+  for (const extractorConfig of extractorConfigs) {
+    if (!invokeExtractor(extractorConfig, compilerState, options, context)) {
+      return false;
     }
   }
 
   return true;
+}
+
+/**
+ * Every config compiles with the same tsconfig, so one TS program can serve all entry points
+ * instead of api-extractor creating a new one per invocation.
+ */
+function createCompilerState(extractorConfigs: ExtractorConfig[]): CompilerState {
+  const [primaryConfig, ...subpathConfigs] = extractorConfigs;
+
+  verboseLog(`Creating shared api-extractor compiler state for ${extractorConfigs.length} entry point(s)`);
+
+  return CompilerState.create(primaryConfig, {
+    additionalEntryPoints: subpathConfigs.map(config => config.mainEntryPointFilePath),
+  });
 }
 
 function normalizeOptions(schema: GenerateApiExecutorSchema, context: ExecutorContext) {
@@ -116,41 +135,19 @@ function generateTypeDeclarations(options: NormalizedOptions) {
   }
 }
 
-function apiExtractor(
-  configSource: { configPath: string } | { configObject: IConfigFile },
-  options: NormalizedOptions,
-  context: ExecutorContext,
-) {
+/**
+ * Loads, parses, customizes and prepares the api-extractor config for the API Extractor API.
+ */
+function prepareExtractorConfig(configSource: ConfigSource, options: NormalizedOptions): ExtractorConfig {
   const { rawConfig, fullPath } = resolveConfigSource();
 
-  // Load,parse,customize and prepare the api-extractor.json file for API Extractor API
   customizeExtractorConfig(rawConfig);
-  const extractorConfig = ExtractorConfig.prepare({
+
+  return ExtractorConfig.prepare({
     configObject: rawConfig,
     configObjectFullPath: fullPath,
     packageJsonFullPath: options.packageJsonPath,
   });
-
-  // Invoke API Extractor
-  const extractorResult = Extractor.invoke(extractorConfig, {
-    // Equivalent to the "--local" command-line parameter
-    localBuild: options.local,
-
-    // Equivalent to the "--verbose" command-line parameter
-    showVerboseMessages: context.isVerbose,
-    showDiagnostics: options.diagnostics,
-  });
-
-  if (extractorResult.succeeded) {
-    verboseLog(`API Extractor completed successfully`);
-    return true;
-  }
-
-  logger.error(
-    `API Extractor completed with ${extractorResult.errorCount} errors` +
-      ` and ${extractorResult.warningCount} warnings`,
-  );
-  return false;
 
   /**
    * Resolves the config source into a raw IConfigFile and the full path used for token resolution.
@@ -180,6 +177,37 @@ function apiExtractor(
 
     return apiExtractorConfig;
   }
+}
+
+function invokeExtractor(
+  extractorConfig: ExtractorConfig,
+  compilerState: CompilerState,
+  options: NormalizedOptions,
+  context: ExecutorContext,
+) {
+  verboseLog(`Running api-extractor for entry point: ${extractorConfig.mainEntryPointFilePath}`);
+
+  const extractorResult = Extractor.invoke(extractorConfig, {
+    compilerState,
+
+    // Equivalent to the "--local" command-line parameter
+    localBuild: options.local,
+
+    // Equivalent to the "--verbose" command-line parameter
+    showVerboseMessages: context.isVerbose,
+    showDiagnostics: options.diagnostics,
+  });
+
+  if (extractorResult.succeeded) {
+    verboseLog(`API Extractor completed successfully`);
+    return true;
+  }
+
+  logger.error(
+    `API Extractor completed with ${extractorResult.errorCount} errors` +
+      ` and ${extractorResult.warningCount} warnings`,
+  );
+  return false;
 }
 
 function getTsConfigForApiExtractor(options: {


### PR DESCRIPTION
## Previous Behavior

The `generate-api` executor invoked API Extractor once per api-extractor config **without** passing a `compilerState`. API Extractor therefore created a brand new `ts.Program` internally on every invocation.

With `exportSubpaths` enabled this scales linearly with the number of export subpaths. `react-headless-components-preview/library` has 50 named subpaths + 1 primary entry point, so a single `generate-api` run built **51 TypeScript programs** over the same declaration graph — ~40s for that one target.

On top of that, API Extractor prints its version preamble on every invocation, so the console was flooded with 51 identical, useless lines that gave no indication of which entry point was being processed:

```
Analysis will use the bundled TypeScript version 5.7.3
Analysis will use the bundled TypeScript version 5.7.3
Analysis will use the bundled TypeScript version 5.7.3
... (×51)
```

## New Behavior

### 1. One shared TypeScript program

All api-extractor configs are now prepared up front, a **single** `CompilerState` is created from the primary config with every subpath entry passed via `additionalEntryPoints`, and that state is reused for all `Extractor.invoke` calls.

This is viable because every config already compiles with the identical `overrideTsconfig` produced by `getTsConfigForApiExtractor`, so the extra programs were genuinely redundant work. Only public API Extractor API is used (`CompilerState.create` / `IExtractorInvokeOptions.compilerState`) — no internals, no fork.

#### Results — `react-headless-components-preview` (51 entry points)

| | Before | After |
| --- | --- | --- |
| `generate-api` executor duration | 40.56 s | **5.26 s** (~7.7×) |
| `ts.createProgram` calls | 51 | 1 |

A secondary win: `Collector.analyze()` calls `program.getSemanticDiagnostics()` on each invocation, and TypeScript caches those per file on a `Program` instance — so calls 2..51 are now near-free instead of re-checking a fresh program each time.

### 2. Readable console output

The repeated version preamble is deduplicated via a shared `messageCallback`, and each entry point now logs what it is actually generating:

```
[1/51] Generating API for dist/index.d.ts
Analysis will use the bundled TypeScript version 5.7.3
[2/51] Generating API for dist/accordion.d.ts
[3/51] Generating API for dist/avatar.d.ts
[4/51] Generating API for dist/avatar-group.d.ts
[5/51] Generating API for dist/badge.d.ts
...
[51/51] Generating API for dist/tooltip.d.ts
```

Packages with a single entry point stay as quiet as before (the label drops to verbose level).

This also makes CI failures far easier to diagnose — the failing entry point is now obvious instead of being buried in 51 identical lines:

```
[11/51] Generating API for dist/dialog.d.ts
Warning: You have changed the API signature for this project. Please copy the file
"temp/dialog.api.md" to "etc/dialog.api.md", or perform a local build (which does
this automatically). See the Git repo documentation for more info.
API Extractor completed with 0 errors and 1 warnings

 NX   Running target generate-api for project react-headless-components-preview failed
```

### Implementation notes

- `apiExtractor()` was split into `prepareExtractorConfig()` and `invokeExtractor()`; `createCompilerState()` and `createConsoleMessageDeduper()` were added.
- Export subpath expansion now runs *before* the primary extraction (still after the `tsc --emitDeclarationOnly` step, which wildcard expansion depends on).
- The shared compiler state is created even for single-config packages, keeping one code path. Behaviour is identical since no `typescriptCompilerFolder` is passed.
- Invocation count is unchanged (still one `Extractor.invoke` per entry point) — only program construction is deduplicated.
- The `messageCallback` only marks `console-preamble` and `console-compiler-version-notice` as handled after their first occurrence. Every other message returns early untouched, so default console output and the `errorCount`/`warningCount` tally are unaffected.

### Verification

- **Output parity is byte-for-byte**: all 51 `etc/*.api.md` and 104 `dist/**/*.d.ts` rollups are identical to a pre-change baseline snapshot; `git status` is clean.
- **Error reporting is unaffected**: deliberately drifted `etc/dialog.api.md` (entry 11 of 51) and ran with `CI=true` (forcing `local: false`) — the `ApiReportNotCopied` warning is still printed and still fails the target with exit code 1 (output above). This is expected from the code path too: the callback runs before the tally in `MessageRouter._handleMessage`, and non-local builds fail on `errorCount + warningCount > 0`.
- `react-button:generate-api` (no export subpaths) is unaffected; repo-wide `*.api.md` diff is empty.
- Unit tests updated — new coverage asserts `CompilerState.create` is called exactly once, that `additionalEntryPoints` matches the resolved subpath entry points, that every invocation receives the same instance, and that the deduper suppresses only repeated preambles while leaving unrelated console messages (e.g. `ApiReportCopied`) alone. 13/13 pass.
- `workspace-plugin:lint` passes.

No change file — `@fluentui/workspace-plugin` is private.

## Related Issue(s)

<!-- n/a -->
