### PR TITLE
test(react-color-picker): add hook state coverage

### DIFF
--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useAlphaSlider_unstable } from './useAlphaSlider';
+import { ColorPickerProvider } from '../../contexts/colorPicker';
+
+describe('useAlphaSlider', () => {
+  it('uses the default shape', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useAlphaSlider_unstable({}, ref));
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape from context', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useAlphaSlider_unstable({}, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('square');
+  });
+
+  it('prefers the shape prop over context', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useAlphaSlider_unstable({ shape: 'rounded' }, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape prop', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useAlphaSlider_unstable({ shape: 'square' }, ref));
+
+    expect(result.current.shape).toBe('square');
+  });
+});

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ColorPickerProvider } from '../../contexts/colorPicker';
+import { useColorArea_unstable } from './useColorArea';
+
+describe('useColorArea', () => {
+  it('uses the default shape', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorArea_unstable({}, ref));
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape from context', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorArea_unstable({}, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('square');
+  });
+
+  it('prefers the shape prop over context', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorArea_unstable({ shape: 'rounded' }, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape prop', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorArea_unstable({ shape: 'square' }, ref));
+
+    expect(result.current.shape).toBe('square');
+  });
+});

--- a/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorPicker/useColorPicker.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useColorPicker_unstable } from './useColorPicker';
+
+describe('useColorPicker', () => {
+  it('returns state based on props', () => {
+    const color = { h: 120, s: 0.5, v: 0.75 };
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorPicker_unstable({ color, shape: 'square' }, ref));
+
+    expect(result.current.color).toBe(color);
+    expect(result.current.shape).toBe('square');
+  });
+
+  it('forwards requested color changes', () => {
+    const onColorChange = jest.fn();
+    const color = { h: 240, s: 0.25, v: 0.5 };
+    const event = {} as React.ChangeEvent<HTMLInputElement>;
+    const ref = React.createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useColorPicker_unstable({ onColorChange }, ref));
+
+    act(() => result.current.requestChange(event, { color }));
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+    expect(onColorChange).toHaveBeenCalledWith(event, {
+      type: 'change',
+      event,
+      color,
+    });
+  });
+});

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ColorPickerProvider } from '../../contexts/colorPicker';
+import { useColorSlider_unstable } from './useColorSlider';
+
+describe('useColorSlider', () => {
+  it('uses the default shape', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useColorSlider_unstable({}, ref));
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape from context', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useColorSlider_unstable({}, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('square');
+  });
+
+  it('prefers the shape prop over context', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useColorSlider_unstable({ shape: 'rounded' }, ref), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ColorPickerProvider value={{ color: undefined, shape: 'square', requestChange: jest.fn() }}>
+          {children}
+        </ColorPickerProvider>
+      ),
+    });
+
+    expect(result.current.shape).toBe('rounded');
+  });
+
+  it('uses the shape prop', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useColorSlider_unstable({ shape: 'square' }, ref));
+
+    expect(result.current.shape).toBe('square');
+  });
+});


### PR DESCRIPTION
## Motivation

Lock down the existing color-picker hook behavior before the reusable base-hook extraction in the next PR. Keeping this coverage in a separate bottom PR makes the behavioral expectations reviewable independently from the API refactor.

## Changes

- add hook-level tests for `useAlphaSlider_unstable`
- add hook-level tests for `useColorArea_unstable`
- add hook-level tests for `useColorSlider_unstable`
- add hook-level tests for `useColorPicker_unstable`
- cover default shape, context inheritance, prop precedence, state from props, and color-change forwarding

## Validation

- `yarn nx test react-color-picker` (13 suites, 132 tests, 4 snapshots)
- `yarn nx lint react-color-picker`

## PR stack

1. **This PR:** add hook state coverage
2. #36517: expose reusable color-picker base APIs
3. #36518: add headless color-picker controls

Please review and merge the stack in this order.