### PR TITLE
test(react-button): add CompoundButton regression coverage

### DIFF
--- a/change/@fluentui-react-button-88cb120c-7476-4f57-86d8-5563916a4fa8.json
+++ b/change/@fluentui-react-button-88cb120c-7476-4f57-86d8-5563916a4fa8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "test(react-button): add CompoundButton regression coverage before base-hook extraction",
+  "packageName": "@fluentui/react-button",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-d96e31a7-a0b1-4f49-976b-8b0dea86ed51.json
+++ b/change/@fluentui-react-button-d96e31a7-a0b1-4f49-976b-8b0dea86ed51.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "test(react-button): add CompoundButton regression coverage before base-hook extraction",
   "packageName": "@fluentui/react-button",
   "email": "vgenaev@gmail.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@fluentui-react-button-d96e31a7-a0b1-4f49-976b-8b0dea86ed51.json
+++ b/change/@fluentui-react-button-d96e31a7-a0b1-4f49-976b-8b0dea86ed51.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "test(react-button): add CompoundButton regression coverage before base-hook extraction",
+  "comment": "Add CompoundButton regression coverage before base-hook extraction",
   "packageName": "@fluentui/react-button",
   "email": "vgenaev@gmail.com",
   "dependentChangeType": "none"

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
@@ -5,11 +5,11 @@ import type { ButtonContextValue } from '../../contexts/ButtonContext';
 import { useCompoundButton_unstable } from './useCompoundButton';
 
 const wrap = (contextValue: ButtonContextValue = {}): React.ComponentType<{ children?: React.ReactNode }> => {
-  function Wrapper({ children }: { children?: React.ReactNode }) {
-    return <ButtonContextProvider value={contextValue}>{children}</ButtonContextProvider>;
-  }
+  const wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <ButtonContextProvider value={contextValue}>{children}</ButtonContextProvider>
+  );
 
-  return Wrapper;
+  return wrapper;
 };
 
 describe('useCompoundButton_unstable', () => {
@@ -25,16 +25,18 @@ describe('useCompoundButton_unstable', () => {
     });
   });
 
-  it('uses the default root element and icon position and normalizes content slots', () => {
-    const { result } = renderHook(() =>
-      useCompoundButton_unstable({ children: 'Primary', secondaryContent: 'Secondary' }, React.createRef()),
-    );
+  it('uses the default root element and icon position', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()));
 
     expect(result.current.root.type).toBe('button');
     expect(result.current.iconPosition).toBe('before');
+  });
+
+  it('normalizes the contentContainer slot', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({ children: 'Primary' }, React.createRef()));
+
     expect(result.current.contentContainer).toBeDefined();
     expect(result.current.contentContainer.children).toBeUndefined();
-    expect(result.current.secondaryContent).toMatchObject({ children: 'Secondary' });
   });
 
   it('normalizes secondaryContent string shorthand', () => {

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ButtonContextProvider } from '../../contexts/ButtonContext';
+import type { ButtonContextValue } from '../../contexts/ButtonContext';
+import { useCompoundButton_unstable } from './useCompoundButton';
+
+const wrap = (contextValue: ButtonContextValue = {}): React.ComponentType<{ children?: React.ReactNode }> => {
+  function Wrapper({ children }: { children?: React.ReactNode }) {
+    return <ButtonContextProvider value={contextValue}>{children}</ButtonContextProvider>;
+  }
+
+  return Wrapper;
+};
+
+describe('useCompoundButton_unstable', () => {
+  it('returns the resolved CompoundButton components shape', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()));
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components).toEqual({
+      root: 'button',
+      icon: 'span',
+      contentContainer: 'span',
+      secondaryContent: 'span',
+    });
+  });
+
+  it('uses the default root element and icon position and normalizes content slots', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ children: 'Primary', secondaryContent: 'Secondary' }, React.createRef()),
+    );
+
+    expect(result.current.root.type).toBe('button');
+    expect(result.current.iconPosition).toBe('before');
+    expect(result.current.contentContainer).toBeDefined();
+    expect(result.current.contentContainer.children).toBeUndefined();
+    expect(result.current.secondaryContent).toMatchObject({ children: 'Secondary' });
+  });
+
+  it('normalizes secondaryContent string shorthand', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ secondaryContent: 'Secondary' }, React.createRef()),
+    );
+
+    expect(result.current.secondaryContent).toMatchObject({ children: 'Secondary' });
+  });
+
+  it('normalizes secondaryContent React element shorthand', () => {
+    const secondaryContent = <strong>Secondary</strong>;
+    const { result } = renderHook(() => useCompoundButton_unstable({ secondaryContent }, React.createRef()));
+
+    expect(result.current.secondaryContent).toMatchObject({ children: secondaryContent });
+  });
+
+  it('normalizes secondaryContent slot-object shorthand', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable(
+        { secondaryContent: { children: 'Secondary', className: 'custom-secondary' } },
+        React.createRef(),
+      ),
+    );
+
+    expect(result.current.secondaryContent).toMatchObject({
+      children: 'Secondary',
+      className: 'custom-secondary',
+    });
+  });
+
+  it('sets iconOnly true when an icon has no primary or secondary content', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({ icon: <span /> }, React.createRef()));
+
+    expect(result.current.iconOnly).toBe(true);
+  });
+
+  it('sets iconOnly false when primary children exist', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ icon: <span />, children: 'Primary' }, React.createRef()),
+    );
+
+    expect(result.current.iconOnly).toBe(false);
+  });
+
+  it('sets iconOnly false when secondary content has children but primary children do not', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ icon: <span />, secondaryContent: { children: 'Secondary' } }, React.createRef()),
+    );
+
+    expect(result.current.iconOnly).toBe(false);
+  });
+
+  it('keeps iconOnly true for an icon with an empty secondary content slot', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ icon: <span />, secondaryContent: {} }, React.createRef()),
+    );
+
+    expect(result.current.secondaryContent).toBeDefined();
+    expect(result.current.secondaryContent?.children).toBeUndefined();
+    expect(result.current.iconOnly).toBe(true);
+  });
+
+  it('applies default styled values inherited from Button', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()));
+
+    expect(result.current.appearance).toBe('secondary');
+    expect(result.current.shape).toBe('rounded');
+    expect(result.current.size).toBe('medium');
+  });
+
+  it('honors explicit styled values and icon position', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable(
+        { appearance: 'primary', shape: 'circular', size: 'large', iconPosition: 'after' },
+        React.createRef(),
+      ),
+    );
+
+    expect(result.current.appearance).toBe('primary');
+    expect(result.current.shape).toBe('circular');
+    expect(result.current.size).toBe('large');
+    expect(result.current.iconPosition).toBe('after');
+  });
+
+  it('inherits size from ButtonContext when no size prop is supplied', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()), {
+      wrapper: wrap({ size: 'small' }),
+    });
+
+    expect(result.current.size).toBe('small');
+  });
+
+  it('allows explicit size to override ButtonContext', () => {
+    const { result } = renderHook(() => useCompoundButton_unstable({ size: 'large' }, React.createRef()), {
+      wrapper: wrap({ size: 'small' }),
+    });
+
+    expect(result.current.size).toBe('large');
+  });
+
+  it('returns disabled and disabledFocusable state', () => {
+    const { result } = renderHook(() =>
+      useCompoundButton_unstable({ disabled: true, disabledFocusable: true }, React.createRef()),
+    );
+
+    expect(result.current.disabled).toBe(true);
+    expect(result.current.disabledFocusable).toBe(true);
+  });
+
+  it('places the provided ref on the resolved root slot', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { result } = renderHook(() => useCompoundButton_unstable({}, ref));
+
+    expect(result.current.root.ref).toBe(ref);
+  });
+});

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.test.tsx
@@ -13,61 +13,6 @@ const wrap = (contextValue: ButtonContextValue = {}): React.ComponentType<{ chil
 };
 
 describe('useCompoundButton_unstable', () => {
-  it('returns the resolved CompoundButton components shape', () => {
-    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()));
-
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    expect(result.current.components).toEqual({
-      root: 'button',
-      icon: 'span',
-      contentContainer: 'span',
-      secondaryContent: 'span',
-    });
-  });
-
-  it('uses the default root element and icon position', () => {
-    const { result } = renderHook(() => useCompoundButton_unstable({}, React.createRef()));
-
-    expect(result.current.root.type).toBe('button');
-    expect(result.current.iconPosition).toBe('before');
-  });
-
-  it('normalizes the contentContainer slot', () => {
-    const { result } = renderHook(() => useCompoundButton_unstable({ children: 'Primary' }, React.createRef()));
-
-    expect(result.current.contentContainer).toBeDefined();
-    expect(result.current.contentContainer.children).toBeUndefined();
-  });
-
-  it('normalizes secondaryContent string shorthand', () => {
-    const { result } = renderHook(() =>
-      useCompoundButton_unstable({ secondaryContent: 'Secondary' }, React.createRef()),
-    );
-
-    expect(result.current.secondaryContent).toMatchObject({ children: 'Secondary' });
-  });
-
-  it('normalizes secondaryContent React element shorthand', () => {
-    const secondaryContent = <strong>Secondary</strong>;
-    const { result } = renderHook(() => useCompoundButton_unstable({ secondaryContent }, React.createRef()));
-
-    expect(result.current.secondaryContent).toMatchObject({ children: secondaryContent });
-  });
-
-  it('normalizes secondaryContent slot-object shorthand', () => {
-    const { result } = renderHook(() =>
-      useCompoundButton_unstable(
-        { secondaryContent: { children: 'Secondary', className: 'custom-secondary' } },
-        React.createRef(),
-      ),
-    );
-
-    expect(result.current.secondaryContent).toMatchObject({
-      children: 'Secondary',
-      className: 'custom-secondary',
-    });
-  });
-
   it('sets iconOnly true when an icon has no primary or secondary content', () => {
     const { result } = renderHook(() => useCompoundButton_unstable({ icon: <span /> }, React.createRef()));
 
@@ -136,21 +81,5 @@ describe('useCompoundButton_unstable', () => {
     });
 
     expect(result.current.size).toBe('large');
-  });
-
-  it('returns disabled and disabledFocusable state', () => {
-    const { result } = renderHook(() =>
-      useCompoundButton_unstable({ disabled: true, disabledFocusable: true }, React.createRef()),
-    );
-
-    expect(result.current.disabled).toBe(true);
-    expect(result.current.disabledFocusable).toBe(true);
-  });
-
-  it('places the provided ref on the resolved root slot', () => {
-    const ref = React.createRef<HTMLButtonElement>();
-    const { result } = renderHook(() => useCompoundButton_unstable({}, ref));
-
-    expect(result.current.root.ref).toBe(ref);
   });
 });


### PR DESCRIPTION
## Previous Behavior

`useCompoundButton_unstable` did not have hook-level regression coverage for the state and defaults that must remain stable during base-hook extraction.

## New Behavior

- Locks CompoundButton slot normalization, icon-only behavior, visual defaults, Button context sizing, disabled state, and ref placement.
- Adds a package-owned `none` change file because the PR changes tests only.
- Contains no production code changes.

## Validation

- `react-button` lint and type-check
- CompoundButton hook and component tests

## Stack

1. This PR
2. #36530 — expose CompoundButton base APIs
3. #36531 — add the headless CompoundButton primitive
