### PR TITLE
feat(react-button): expose CompoundButton headless base APIs

### DIFF
--- a/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
+++ b/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(react-button): expose CompoundButton headless base APIs",
+  "packageName": "@fluentui/react-button",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
+++ b/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Expose CompoundButton headless base APIs",
+  "comment": "feat: expose CompoundButton base hook",
   "packageName": "@fluentui/react-button",
   "email": "vgenaev@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
+++ b/change/@fluentui-react-button-8e57e713-d9fe-4164-af33-bc75bc62190f.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "feat(react-button): expose CompoundButton headless base APIs",
+  "comment": "Expose CompoundButton headless base APIs",
   "packageName": "@fluentui/react-button",
   "email": "vgenaev@gmail.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-button/library/bundle-size/useCompoundButtonBase.fixture.js
+++ b/packages/react-components/react-button/library/bundle-size/useCompoundButtonBase.fixture.js
@@ -1,0 +1,7 @@
+import { renderCompoundButton_unstable, useCompoundButtonBase_unstable } from '@fluentui/react-button';
+
+console.log(renderCompoundButton_unstable, useCompoundButtonBase_unstable);
+
+export default {
+  name: 'useCompoundButtonBase',
+};

--- a/packages/react-components/react-button/library/bundle-size/useCompoundButtonBase.fixture.js
+++ b/packages/react-components/react-button/library/bundle-size/useCompoundButtonBase.fixture.js
@@ -1,7 +1,0 @@
-import { renderCompoundButton_unstable, useCompoundButtonBase_unstable } from '@fluentui/react-button';
-
-console.log(renderCompoundButton_unstable, useCompoundButtonBase_unstable);
-
-export default {
-  name: 'useCompoundButtonBase',
-};

--- a/packages/react-components/react-button/library/etc/react-button.api.md
+++ b/packages/react-components/react-button/library/etc/react-button.api.md
@@ -60,10 +60,16 @@ export type ButtonState = ComponentState<ButtonSlots> & Required<Pick<ButtonProp
 export const CompoundButton: ForwardRefComponent<CompoundButtonProps>;
 
 // @public (undocumented)
+export type CompoundButtonBaseProps = ComponentProps<Partial<CompoundButtonSlots>> & Pick<ButtonBaseProps, 'disabledFocusable' | 'disabled' | 'iconPosition'>;
+
+// @public (undocumented)
+export type CompoundButtonBaseState = ComponentState<CompoundButtonSlots> & Omit<ButtonBaseState, keyof ButtonSlots | 'components'>;
+
+// @public (undocumented)
 export const compoundButtonClassNames: SlotClassNames<CompoundButtonSlots>;
 
 // @public (undocumented)
-export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> & Pick<ButtonProps, 'appearance' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>;
+export type CompoundButtonProps = CompoundButtonBaseProps & Pick<ButtonProps, 'appearance' | 'shape' | 'size'>;
 
 // @public (undocumented)
 export type CompoundButtonSlots = ButtonSlots & {
@@ -72,7 +78,7 @@ export type CompoundButtonSlots = ButtonSlots & {
 };
 
 // @public (undocumented)
-export type CompoundButtonState = ComponentState<CompoundButtonSlots> & Omit<ButtonState, keyof ButtonSlots | 'components'>;
+export type CompoundButtonState = CompoundButtonBaseState & Pick<ButtonState, 'appearance' | 'shape' | 'size'>;
 
 // @public
 export const MenuButton: ForwardRefComponent<MenuButtonProps>;
@@ -103,7 +109,7 @@ export { renderButton_unstable }
 export { renderButton_unstable as renderToggleButton_unstable }
 
 // @public
-export const renderCompoundButton_unstable: (state: CompoundButtonState) => JSXElement;
+export const renderCompoundButton_unstable: (state: CompoundButtonBaseState) => JSXElement;
 
 // @public
 export const renderMenuButton_unstable: (state: MenuButtonBaseState) => JSXElement;
@@ -166,6 +172,9 @@ export const useButtonStyles_unstable: (state: ButtonState) => ButtonState;
 
 // @public
 export const useCompoundButton_unstable: (props: CompoundButtonProps, ref: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => CompoundButtonState;
+
+// @public
+export const useCompoundButtonBase_unstable: (props: CompoundButtonBaseProps, ref?: React_2.Ref<HTMLButtonElement | HTMLAnchorElement>) => CompoundButtonBaseState;
 
 // @public (undocumented)
 export const useCompoundButtonStyles_unstable: (state: CompoundButtonState) => CompoundButtonState;

--- a/packages/react-components/react-button/library/src/CompoundButton.ts
+++ b/packages/react-components/react-button/library/src/CompoundButton.ts
@@ -1,8 +1,15 @@
-export type { CompoundButtonProps, CompoundButtonSlots, CompoundButtonState } from './components/CompoundButton/index';
+export type {
+  CompoundButtonBaseProps,
+  CompoundButtonBaseState,
+  CompoundButtonProps,
+  CompoundButtonSlots,
+  CompoundButtonState,
+} from './components/CompoundButton/index';
 export {
   CompoundButton,
   compoundButtonClassNames,
   renderCompoundButton_unstable,
+  useCompoundButtonBase_unstable,
   useCompoundButtonStyles_unstable,
   useCompoundButton_unstable,
 } from './components/CompoundButton/index';

--- a/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/CompoundButton.types.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps, ComponentState, Slot } from '@fluentui/react-utilities';
-import type { ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
+import type { ButtonBaseProps, ButtonBaseState, ButtonProps, ButtonSlots, ButtonState } from '../Button/Button.types';
 
 export type CompoundButtonSlots = ButtonSlots & {
   /**
@@ -13,8 +13,12 @@ export type CompoundButtonSlots = ButtonSlots & {
   contentContainer: NonNullable<Slot<'span'>>;
 };
 
-export type CompoundButtonProps = ComponentProps<Partial<CompoundButtonSlots>> &
-  Pick<ButtonProps, 'appearance' | 'disabledFocusable' | 'disabled' | 'iconPosition' | 'shape' | 'size'>;
+export type CompoundButtonBaseProps = ComponentProps<Partial<CompoundButtonSlots>> &
+  Pick<ButtonBaseProps, 'disabledFocusable' | 'disabled' | 'iconPosition'>;
 
-export type CompoundButtonState = ComponentState<CompoundButtonSlots> &
-  Omit<ButtonState, keyof ButtonSlots | 'components'>;
+export type CompoundButtonProps = CompoundButtonBaseProps & Pick<ButtonProps, 'appearance' | 'shape' | 'size'>;
+
+export type CompoundButtonBaseState = ComponentState<CompoundButtonSlots> &
+  Omit<ButtonBaseState, keyof ButtonSlots | 'components'>;
+
+export type CompoundButtonState = CompoundButtonBaseState & Pick<ButtonState, 'appearance' | 'shape' | 'size'>;

--- a/packages/react-components/react-button/library/src/components/CompoundButton/index.ts
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/index.ts
@@ -1,5 +1,11 @@
 export { CompoundButton } from './CompoundButton';
-export type { CompoundButtonProps, CompoundButtonSlots, CompoundButtonState } from './CompoundButton.types';
+export type {
+  CompoundButtonBaseProps,
+  CompoundButtonBaseState,
+  CompoundButtonProps,
+  CompoundButtonSlots,
+  CompoundButtonState,
+} from './CompoundButton.types';
 export { renderCompoundButton_unstable } from './renderCompoundButton';
-export { useCompoundButton_unstable } from './useCompoundButton';
+export { useCompoundButtonBase_unstable, useCompoundButton_unstable } from './useCompoundButton';
 export { compoundButtonClassNames, useCompoundButtonStyles_unstable } from './useCompoundButtonStyles.styles';

--- a/packages/react-components/react-button/library/src/components/CompoundButton/renderCompoundButton.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/renderCompoundButton.tsx
@@ -4,12 +4,12 @@
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 
-import type { CompoundButtonSlots, CompoundButtonState } from './CompoundButton.types';
+import type { CompoundButtonBaseState, CompoundButtonSlots } from './CompoundButton.types';
 
 /**
  * Renders a CompoundButton component by passing the state defined props to the appropriate slots.
  */
-export const renderCompoundButton_unstable = (state: CompoundButtonState): JSXElement => {
+export const renderCompoundButton_unstable = (state: CompoundButtonBaseState): JSXElement => {
   assertSlots<CompoundButtonSlots>(state);
   const { iconOnly, iconPosition } = state;
 

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.ts
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButton.ts
@@ -2,25 +2,28 @@
 
 import type * as React from 'react';
 import { slot } from '@fluentui/react-utilities';
-import { useButton_unstable } from '../Button/index';
-import type { CompoundButtonProps, CompoundButtonState } from './CompoundButton.types';
+import { useButtonContext } from '../../contexts/ButtonContext';
+import { useButtonBase_unstable } from '../Button/index';
+import type {
+  CompoundButtonBaseProps,
+  CompoundButtonBaseState,
+  CompoundButtonProps,
+  CompoundButtonState,
+} from './CompoundButton.types';
 
 /**
- * Given user props, defines default props for the CompoundButton, calls useButtonState, and returns processed state.
+ * Base hook for CompoundButton, which manages state related to slots structure and ARIA attributes.
+ *
  * @param props - User provided props to the CompoundButton component.
  * @param ref - User provided ref to be passed to the CompoundButton component.
  */
-export const useCompoundButton_unstable = (
-  props: CompoundButtonProps,
-  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
-): CompoundButtonState => {
+export const useCompoundButtonBase_unstable = (
+  props: CompoundButtonBaseProps,
+  ref?: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): CompoundButtonBaseState => {
   const { contentContainer, secondaryContent, ...buttonProps } = props;
-
-  const state: CompoundButtonState = {
-    // Button state
-    ...useButton_unstable(buttonProps, ref),
-
-    // Slots definition
+  const state: CompoundButtonBaseState = {
+    ...useButtonBase_unstable(buttonProps, ref),
     components: {
       root: 'button',
       icon: 'span',
@@ -31,8 +34,27 @@ export const useCompoundButton_unstable = (
     secondaryContent: slot.optional(secondaryContent, { elementType: 'span' }),
   };
 
-  // Recalculate iconOnly to take into account secondaryContent.
   state.iconOnly = Boolean(state.icon?.children && !props.children && !state.secondaryContent?.children);
-
   return state;
+};
+
+/**
+ * Given user props, defines default props for the CompoundButton, calls useButtonState, and returns processed state.
+ * @param props - User provided props to the CompoundButton component.
+ * @param ref - User provided ref to be passed to the CompoundButton component.
+ */
+export const useCompoundButton_unstable = (
+  props: CompoundButtonProps,
+  ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
+): CompoundButtonState => {
+  const { size: contextSize } = useButtonContext();
+  const { appearance = 'secondary', shape = 'rounded', size = contextSize ?? 'medium', ...buttonProps } = props;
+  const state = useCompoundButtonBase_unstable(buttonProps, ref);
+
+  return {
+    appearance,
+    shape,
+    size,
+    ...state,
+  };
 };

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonBase.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonBase.test.tsx
@@ -3,14 +3,14 @@ import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import '@testing-library/jest-dom';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
-import type { CompoundButtonBaseProps, CompoundButtonState } from './CompoundButton.types';
+import type { CompoundButtonBaseProps } from './CompoundButton.types';
 import { renderCompoundButton_unstable } from './renderCompoundButton';
 import { useCompoundButtonBase_unstable } from './useCompoundButton';
 
 const TestCompoundButtonBase: ForwardRefComponent<CompoundButtonBaseProps> = React.forwardRef((props, ref) => {
   const state = useCompoundButtonBase_unstable(props, ref);
 
-  return renderCompoundButton_unstable(state as CompoundButtonState);
+  return renderCompoundButton_unstable(state);
 });
 
 describe('useCompoundButtonBase_unstable', () => {

--- a/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonBase.test.tsx
+++ b/packages/react-components/react-button/library/src/components/CompoundButton/useCompoundButtonBase.test.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom';
+import type { ForwardRefComponent } from '@fluentui/react-utilities';
+import type { CompoundButtonBaseProps, CompoundButtonState } from './CompoundButton.types';
+import { renderCompoundButton_unstable } from './renderCompoundButton';
+import { useCompoundButtonBase_unstable } from './useCompoundButton';
+
+const TestCompoundButtonBase: ForwardRefComponent<CompoundButtonBaseProps> = React.forwardRef((props, ref) => {
+  const state = useCompoundButtonBase_unstable(props, ref);
+
+  return renderCompoundButton_unstable(state as CompoundButtonState);
+});
+
+describe('useCompoundButtonBase_unstable', () => {
+  it('uses a button root with type button by default', () => {
+    const { getByRole } = render(<TestCompoundButtonBase />);
+
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('supports anchor polymorphism and href', () => {
+    const { getByRole } = render(<TestCompoundButtonBase as="a" href="#compound-button" />);
+
+    expect(getByRole('link')).toHaveAttribute('href', '#compound-button');
+  });
+
+  it('returns disabled and disabledFocusable state', () => {
+    const { result } = renderHook(() =>
+      useCompoundButtonBase_unstable({ disabled: true, disabledFocusable: true }, React.createRef()),
+    );
+
+    expect(result.current.disabled).toBe(true);
+    expect(result.current.disabledFocusable).toBe(true);
+  });
+
+  it.each(['before', 'after'] as const)('supports %s icon position', iconPosition => {
+    const { result } = renderHook(() => useCompoundButtonBase_unstable({ iconPosition }, React.createRef()));
+
+    expect(result.current.iconPosition).toBe(iconPosition);
+  });
+
+  it('creates and normalizes content slots', () => {
+    const { result } = renderHook(() =>
+      useCompoundButtonBase_unstable(
+        {
+          contentContainer: { className: 'content-container' },
+          secondaryContent: { children: 'Secondary', className: 'secondary-content' },
+        },
+        React.createRef(),
+      ),
+    );
+
+    expect(result.current.contentContainer).toMatchObject({ className: 'content-container' });
+    expect(result.current.secondaryContent).toMatchObject({
+      children: 'Secondary',
+      className: 'secondary-content',
+    });
+  });
+
+  it('sets iconOnly false when secondary content has children without primary children', () => {
+    const { result } = renderHook(() =>
+      useCompoundButtonBase_unstable({ icon: <span />, secondaryContent: 'Secondary' }, React.createRef()),
+    );
+
+    expect(result.current.iconOnly).toBe(false);
+  });
+
+  it('sets iconOnly true only when an icon has no primary or secondary children', () => {
+    const { result } = renderHook(() => useCompoundButtonBase_unstable({ icon: <span /> }, React.createRef()));
+
+    expect(result.current.iconOnly).toBe(true);
+  });
+
+  it('keeps iconOnly true when the secondary content slot is empty', () => {
+    const { result } = renderHook(() =>
+      useCompoundButtonBase_unstable({ icon: <span />, secondaryContent: {} }, React.createRef()),
+    );
+
+    expect(result.current.secondaryContent).toBeDefined();
+    expect(result.current.secondaryContent?.children).toBeUndefined();
+    expect(result.current.iconOnly).toBe(true);
+  });
+
+  it('sets iconOnly false when the icon slot is empty', () => {
+    const { result } = renderHook(() => useCompoundButtonBase_unstable({ icon: {} }, React.createRef()));
+
+    expect(result.current.icon).toBeDefined();
+    expect(result.current.icon?.children).toBeUndefined();
+    expect(result.current.iconOnly).toBe(false);
+  });
+
+  it('places the provided ref on the root slot', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const { result } = renderHook(() => useCompoundButtonBase_unstable({}, ref));
+
+    expect(result.current.root.ref).toBe(ref);
+  });
+
+  it('does not include visual fields in base state', () => {
+    const { result } = renderHook(() => useCompoundButtonBase_unstable({}, React.createRef()));
+
+    expect(result.current).not.toHaveProperty('appearance');
+    expect(result.current).not.toHaveProperty('shape');
+    expect(result.current).not.toHaveProperty('size');
+  });
+});

--- a/packages/react-components/react-button/library/src/index.ts
+++ b/packages/react-components/react-button/library/src/index.ts
@@ -11,10 +11,17 @@ export {
   CompoundButton,
   compoundButtonClassNames,
   renderCompoundButton_unstable,
+  useCompoundButtonBase_unstable,
   useCompoundButtonStyles_unstable,
   useCompoundButton_unstable,
 } from './CompoundButton';
-export type { CompoundButtonProps, CompoundButtonSlots, CompoundButtonState } from './CompoundButton';
+export type {
+  CompoundButtonBaseProps,
+  CompoundButtonBaseState,
+  CompoundButtonProps,
+  CompoundButtonSlots,
+  CompoundButtonState,
+} from './CompoundButton';
 export {
   MenuButton,
   menuButtonClassNames,


### PR DESCRIPTION
## Previous Behavior

`CompoundButton` exposed only its styled hook and visual props/state, so the headless package could not reuse a design-agnostic implementation.

## New Behavior

- Adds `CompoundButtonBaseProps`, `CompoundButtonBaseState`, and `useCompoundButtonBase_unstable`.
- Keeps styled defaults and context behavior in `useCompoundButton_unstable`.
- Generalizes the renderer for base state and publishes the base surface.
- Adds focused base tests, API docs, bundle-size coverage, and a minor change file.

## Validation

- `react-button` test, lint, type-check, build, generate-api, and bundle-size
- Existing hook regression coverage remains passing

## Stack

1. #36529 — regression coverage
2. This PR
3. #36531 — add the headless CompoundButton primitive
