### PR TITLE
fix(bundle-size): correct non-existent named imports in fixtures + surface compare-reports failures

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -50,9 +50,19 @@ jobs:
         if: ${{ github.event.pull_request.base.ref != 'master' }}
         run: echo "::warning::Bundle size comparison skipped — base reports are only produced for the default branch (master). PR targets '${{ github.event.pull_request.base.ref }}'."
 
+      # `compare-reports` exits 1 when an entry exceeds the size threshold, but its stdout is the
+      # markdown report - without echoing it the job fails with a bare "exit code 1" and no reason.
       - name: Compare bundle size with base
         if: ${{ github.event.pull_request.base.ref == 'master' }}
-        run: npx monosize compare-reports --branch=${{ github.event.pull_request.base.ref }} --output=markdown --quiet > ./monosize-report.md
+        run: |
+          exit_code=0
+          npx monosize compare-reports --branch=${{ github.event.pull_request.base.ref }} --output=markdown --quiet > ./monosize-report.md || exit_code=$?
+          cat ./monosize-report.md >> "$GITHUB_STEP_SUMMARY"
+          if [ "$exit_code" -ne 0 ]; then
+            echo "::error::Bundle size threshold exceeded - see the job summary for the full report."
+            cat ./monosize-report.md
+          fi
+          exit "$exit_code"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.nxignore
+++ b/.nxignore
@@ -5,7 +5,6 @@ tmp
 ; known directories to not incorporate into the workspace graph creation
 **/fixtures/**
 **/**fixtures**/**
-**/bundle-size/**
 **/fake_node_modules/**
 
 ; scaffolding templates

--- a/nx.json
+++ b/nx.json
@@ -129,7 +129,8 @@
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/jest.config.[jt]s",
-      "!{projectRoot}/src/test-setup.[jt]s"
+      "!{projectRoot}/src/test-setup.[jt]s",
+      "!{projectRoot}/bundle-size/**"
     ]
   },
   "release": {

--- a/packages/react-components/react-message-bar/library/bundle-size/Default.fixture.js
+++ b/packages/react-components/react-message-bar/library/bundle-size/Default.fixture.js
@@ -3,10 +3,10 @@ import {
   MessageBar,
   MessageBarBody,
   MessageBarTitle,
-  MessagebarActions,
+  MessageBarActions,
 } from '@fluentui/react-message-bar';
 
-console.log(MessageBar, MessageBarBody, MessageBar, MessageBarBody, MessageBarTitle, MessagebarActions);
+console.log(MessageBar, MessageBarBody, MessageBar, MessageBarBody, MessageBarTitle, MessageBarActions);
 
 export default {
   name: 'MessageBar (all components)',

--- a/packages/react-components/react-table/library/bundle-size/DataGrid.fixture.js
+++ b/packages/react-components/react-table/library/bundle-size/DataGrid.fixture.js
@@ -5,10 +5,10 @@ import {
   DataGridHeader,
   DataGridHeaderCell,
   DataGridCell,
-  createColumn,
+  createTableColumn,
 } from '@fluentui/react-table';
 
-console.log(DataGridBody, DataGridRow, DataGrid, DataGridHeader, DataGridHeaderCell, DataGridCell, createColumn);
+console.log(DataGridBody, DataGridRow, DataGrid, DataGridHeader, DataGridHeaderCell, DataGridCell, createTableColumn);
 
 export default {
   name: 'DataGrid',

--- a/packages/react-components/react-table/library/bundle-size/TableAsDataGrid.fixture.js
+++ b/packages/react-components/react-table/library/bundle-size/TableAsDataGrid.fixture.js
@@ -11,7 +11,7 @@ import {
   useTableFeatures,
   useTableSelection,
   useTableSort,
-  createColumn,
+  createTableColumn,
 } from '@fluentui/react-table';
 
 console.log(
@@ -27,7 +27,7 @@ console.log(
   useTableFeatures,
   useTableSelection,
   useTableSort,
-  createColumn,
+  createTableColumn,
 );
 
 export default {

--- a/packages/react-components/react-table/library/bundle-size/TableSelectionOnly.fixture.js
+++ b/packages/react-components/react-table/library/bundle-size/TableSelectionOnly.fixture.js
@@ -9,7 +9,7 @@ import {
   TableCellLayout,
   useTableFeatures,
   useTableSelection,
-  createColumn,
+  createTableColumn,
 } from '@fluentui/react-table';
 
 console.log(
@@ -23,7 +23,7 @@ console.log(
   TableCellLayout,
   useTableFeatures,
   useTableSelection,
-  createColumn,
+  createTableColumn,
 );
 
 export default {

--- a/packages/react-components/react-table/library/bundle-size/TableSortOnly.fixture.js
+++ b/packages/react-components/react-table/library/bundle-size/TableSortOnly.fixture.js
@@ -9,7 +9,7 @@ import {
   TableCellLayout,
   useTableFeatures,
   useTableSort,
-  createColumn,
+  createTableColumn,
 } from '@fluentui/react-table';
 
 console.log(
@@ -23,7 +23,7 @@ console.log(
   TableCellLayout,
   useTableFeatures,
   useTableSort,
-  createColumn,
+  createTableColumn,
 );
 
 export default {


### PR DESCRIPTION
Split out of #36327 so the ESM migration's bundle-size diff reflects only the ESM delta.

## Previous Behavior

**1. Two bundle-size fixtures imported named exports that do not exist:**

| Fixture | Imported | Actual export |
| --- | --- | --- |
| `react-message-bar/bundle-size/Default.fixture.js` | `MessagebarActions` | `MessageBarActions` |
| `react-table/bundle-size/{DataGrid,TableAsDataGrid,TableSelectionOnly,TableSortOnly}.fixture.js` | `createColumn` | `createTableColumn` |

CommonJS interop resolves a missing named export to `undefined` rather than failing, so webpack tree-shook those components out and the fixtures measured **less than they claimed**. `MessageBar (all components)` was under-reporting by ~1.8KB — it never included `MessageBarActions`.

**2. When a bundle-size threshold is breached, the job gives no diagnosis.** `monosize compare-reports` writes its markdown report to stdout (redirected to `monosize-report.md`) and `--quiet` suppresses the reason, so `process.exit(1)` surfaces only as:

```
##[error]Process completed with exit code 1
```

with no indication of which entry grew or by how much.

## New Behavior

1. Fixtures import the real exports, so the affected fixtures measure what their names claim.
2. The compare step echoes the report to the job summary and stdout and emits an `::error::` annotation, while preserving the exit code so the gate still fails.

## Notes for reviewers

- **Expect a one-off baseline increase** on `MessageBar (all components)` and the four `react-table` fixtures. This is a measurement correction, not a size regression — those components were always meant to be in the bundle.
- No change files: `**/bundle-size/**` is in beachball's `ignorePatterns` and no shipped code is touched.
- These typos were surfaced by #36327, where strict ESM turns the same import into a hard `ModuleDependencyError` instead of silently yielding `undefined`.

## Related Issue(s)

- Split out of #36327
