### PR TITLE
refactor(react-color-picker): remove tinycolor dependency

### DIFF
--- a/change/@fluentui-react-color-picker-244d4727-8a5d-4863-94f9-545b45df99d3.json
+++ b/change/@fluentui-react-color-picker-244d4727-8a5d-4863-94f9-545b45df99d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace the tinycolor dependency with internal HSV-to-HSL conversion utilities.",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-244d4727-8a5d-4863-94f9-545b45df99d3.json
+++ b/change/@fluentui-react-color-picker-244d4727-8a5d-4863-94f9-545b45df99d3.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Replace the tinycolor dependency with internal HSV-to-HSL conversion utilities.",
+  "comment": "refactor: Replace the tinycolor dependency with internal utilities.",
   "packageName": "@fluentui/react-color-picker",
   "email": "dmytrokirpa@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-color-picker/library/package.json
+++ b/packages/react-components/react-color-picker/library/package.json
@@ -18,7 +18,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@ctrl/tinycolor": "^3.3.4",
     "@fluentui/react-context-selector": "^9.2.18",
     "@fluentui/react-jsx-runtime": "^9.4.4",
     "@fluentui/react-shared-contexts": "^9.26.2",

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import type * as React from 'react';
-import { tinycolor } from '@ctrl/tinycolor';
 import { clamp, useControllableState, useEventCallback } from '@fluentui/react-utilities';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { alphaSliderCSSVars } from './useAlphaSliderStyles.styles';
@@ -11,6 +10,7 @@ import { MIN, MAX } from '../../utils/constants';
 import { getPercent } from '../../utils/getPercent';
 import { adjustToTransparency, calculateTransparencyValue, getSliderDirection } from './alphaSliderUtils';
 import { createHsvColor } from '../../utils/createHsvColor';
+import { createHslColor } from '../../utils/createHslColor';
 
 export const useAlphaSliderState_unstable = (state: AlphaSliderState, props: AlphaSliderProps): AlphaSliderState => {
   const { dir } = useFluent();
@@ -18,7 +18,7 @@ export const useAlphaSliderState_unstable = (state: AlphaSliderState, props: Alp
   const colorFromContext = useColorPickerContextValue_unstable(ctx => ctx.color);
   const { color, onChange = onChangeFromContext, transparency = false, vertical = false } = props;
   const hsvColor = color || colorFromContext;
-  const hslColor = tinycolor(hsvColor).toHsl();
+  const hslColor = createHslColor(hsvColor);
 
   const [currentValue, setCurrentValue] = useControllableState({
     defaultState: calculateTransparencyValue(transparency, props.defaultColor?.a),

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/ColorArea.test.tsx
@@ -15,7 +15,7 @@ describe('ColorArea', () => {
       <div>
         <div
           class="fui-ColorArea"
-          style="--fui-AreaX--progress: 100%; --fui-AreaY--progress: 50%; --fui-Area__thumb--color: rgb(128, 0, 76); --fui-Area--main-color: hsl(324, 100%, 50%);"
+          style="--fui-AreaX--progress: 100%; --fui-AreaY--progress: 50%; --fui-Area__thumb--color: hsla(324, 100%, 25%, 1); --fui-Area--main-color: hsl(324, 100%, 50%);"
         >
           <div
             class="fui-ColorArea__thumb"

--- a/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorArea/useColorArea.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { tinycolor } from '@ctrl/tinycolor';
 import { useId, slot, useMergedRefs, mergeCallbacks, getIntrinsicElementProps } from '@fluentui/react-utilities';
 import type { ColorAreaBaseProps, ColorAreaBaseState, ColorAreaProps, ColorAreaState } from './ColorArea.types';
 import type { HsvColor } from '../../types/color';
@@ -12,6 +11,7 @@ import { useFocusWithin } from '@fluentui/react-tabster';
 import { INITIAL_COLOR_HSV } from '../../utils/constants';
 import { getCoordinates } from '../../utils/getCoordinates';
 import { useColorPickerContextValue_unstable } from '../../contexts/colorPicker';
+import { createHslColorString } from '../../utils/createHslColor';
 
 /**
  * Create the state required to render unstyled ColorArea.
@@ -161,7 +161,7 @@ export const useColorAreaBase_unstable = (
   const rootVariables = {
     [colorAreaCSSVars.areaXProgressVar]: `${saturation}%`,
     [colorAreaCSSVars.areaYProgressVar]: `${value}%`,
-    [colorAreaCSSVars.thumbColorVar]: tinycolor(hsvColor).toRgbString(),
+    [colorAreaCSSVars.thumbColorVar]: createHslColorString(hsvColor),
     [colorAreaCSSVars.mainColorVar]: `hsl(${hsvColor.h}, 100%, 50%)`,
   };
   const state: ColorAreaBaseState = {

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import type * as React from 'react';
-import { tinycolor } from '@ctrl/tinycolor';
 import {
   getPartitionedNativeProps,
   useId,
@@ -24,6 +23,7 @@ import { createHsvColor } from '../../utils/createHsvColor';
 import { clampValue, type ChannelActions, adjustChannel } from '../../utils/adjustChannel';
 import type { HsvColor } from '../../types/color';
 import { INITIAL_COLOR_HSV } from '../../utils/constants';
+import { createHslColor, createHslColorString } from '../../utils/createHslColor';
 
 /**
  * Create the base state required to render unstyled ColorSlider.
@@ -61,7 +61,7 @@ export const useColorSliderBase_unstable = (
   } = props;
 
   const hsvColor = color || colorFromContext;
-  const hslColor = tinycolor(hsvColor).toHsl();
+  const hslColor = createHslColor(hsvColor);
 
   const [currentColor, setCurrentColor] = useControllableState<HsvColor>({
     defaultState: props.defaultColor,
@@ -105,7 +105,7 @@ export const useColorSliderBase_unstable = (
     [colorSliderCSSVars.sliderDirectionVar]: vertical ? '180deg' : dir === 'ltr' ? '-90deg' : '90deg',
     [colorSliderCSSVars.sliderProgressVar]: `${valuePercent}%`,
     [colorSliderCSSVars.thumbColorVar]:
-      channel === 'hue' ? `hsl(${clampedValue}, 100%, 50%)` : tinycolor(hsvColor).toRgbString(),
+      channel === 'hue' ? `hsl(${clampedValue}, 100%, 50%)` : createHslColorString(hsvColor),
     [colorSliderCSSVars.railColorVar]:
       channel === 'hue'
         ? `hsl(${hslColor.h} ${hslColor.s * 100}%, ${hslColor.l * 100}%)`

--- a/packages/react-components/react-color-picker/library/src/types/color.ts
+++ b/packages/react-components/react-color-picker/library/src/types/color.ts
@@ -4,3 +4,10 @@ export type HsvColor = {
   v: number;
   a?: number;
 };
+
+export type HslColor = {
+  h: number;
+  s: number;
+  l: number;
+  a?: number;
+};

--- a/packages/react-components/react-color-picker/library/src/utils/constants.ts
+++ b/packages/react-components/react-color-picker/library/src/utils/constants.ts
@@ -1,7 +1,5 @@
-import { tinycolor } from '@ctrl/tinycolor';
-
 export const MIN = 0;
 export const MAX = 100;
 export const HUE_MAX = 360;
 export const INITIAL_COLOR = '#FFF';
-export const INITIAL_COLOR_HSV = tinycolor(INITIAL_COLOR).toHsv();
+export const INITIAL_COLOR_HSV = { h: 0, s: 0, v: 1, a: 1 };

--- a/packages/react-components/react-color-picker/library/src/utils/createHslColor.test.ts
+++ b/packages/react-components/react-color-picker/library/src/utils/createHslColor.test.ts
@@ -1,0 +1,28 @@
+import { createHslColor, createHslColorString } from './createHslColor';
+
+describe('createHslColor', () => {
+  it('should create a black HSL color with default values', () => {
+    expect(createHslColor({})).toEqual({ h: 0, s: 0, l: 0, a: 1 });
+  });
+
+  it('should convert an HSV color to HSL', () => {
+    expect(createHslColor({ h: 0, s: 1, v: 1 })).toEqual({ h: 0, s: 1, l: 0.5, a: 1 });
+  });
+
+  it('should preserve hue and alpha', () => {
+    const color = createHslColor({ h: 210, s: 0.5, v: 0.8, a: 0.4 });
+
+    expect(color.h).toBe(210);
+    expect(color.s).toBeCloseTo(0.5);
+    expect(color.l).toBeCloseTo(0.6);
+    expect(color.a).toBe(0.4);
+  });
+
+  it('should create an achromatic HSL color from white', () => {
+    expect(createHslColor({ h: 120, s: 0, v: 1 })).toEqual({ h: 120, s: 0, l: 1, a: 1 });
+  });
+
+  it('should create an HSLA color string', () => {
+    expect(createHslColorString({ h: 210, s: 0.5, v: 0.8, a: 0.4 })).toBe('hsla(210, 50%, 60%, 0.4)');
+  });
+});

--- a/packages/react-components/react-color-picker/library/src/utils/createHslColor.ts
+++ b/packages/react-components/react-color-picker/library/src/utils/createHslColor.ts
@@ -1,0 +1,30 @@
+import type { HslColor, HsvColor } from '../types/color';
+
+/**
+ *
+ * Creates an HSL color object from a given HSV color object.
+ *
+ * @param color - HSV color object to convert to HSL.
+ * @returns HSL color object with the same hue and alpha values, and converted saturation and lightness values.
+ */
+export function createHslColor(color: Partial<HsvColor> = {}): HslColor {
+  const { h = 0, s = 0, v = 0, a = 1 } = color;
+  const l = v * (1 - s / 2);
+  const hslSaturation = l === 0 || l === 1 ? 0 : (v - l) / Math.min(l, 1 - l);
+
+  return { h, s: hslSaturation, l, a };
+}
+
+/**
+ * Creates an HSL color string from a given HSV color object.
+ *
+ * @param color - HSV color object to convert to HSL string.
+ * @returns - HSL color string in the format of "hsla(h, s%, l%, a)".
+ */
+export function createHslColorString(color: Partial<HsvColor> = {}): string {
+  const hslColor = createHslColor(color);
+  const saturation = Number((hslColor.s * 100).toFixed(2));
+  const lightness = Number((hslColor.l * 100).toFixed(2));
+
+  return `hsla(${hslColor.h}, ${saturation}%, ${lightness}%, ${hslColor.a})`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3778,7 +3778,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fluentui/react-color-picker@workspace:packages/react-components/react-color-picker/library"
   dependencies:
-    "@ctrl/tinycolor": "npm:^3.3.4"
     "@fluentui/react-context-selector": "npm:^9.2.18"
     "@fluentui/react-jsx-runtime": "npm:^9.4.4"
     "@fluentui/react-shared-contexts": "npm:^9.26.2"


### PR DESCRIPTION
## Summary

- replace tinycolor usage with internal HSV-to-HSL conversion utilities
- add conversion unit coverage and remove the package dependency

## Validation

- `yarn nx run react-color-picker:build --skipNxCache`