### PR TITLE
fix(react-message-bar): keep motion ref out of base hook

### DIFF
--- a/change/@fluentui-react-message-bar-b83be573-581c-4db1-ae97-4e375b123a7d.json
+++ b/change/@fluentui-react-message-bar-b83be573-581c-4db1-ae97-4e375b123a7d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep motion ref handling out of the headless MessageBar base hook.",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
+++ b/packages/react-components/react-message-bar/library/src/components/MessageBar/useMessageBar.ts
@@ -27,7 +27,6 @@ export const useMessageBarBase_unstable = (
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { className: transitionClassName, nodeRef } = useMessageBarTransitionContext();
-  const motionRef = useMotionForwardedRef();
 
   const actionsRef = React.useRef<HTMLDivElement | null>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
@@ -50,7 +49,7 @@ export const useMessageBarBase_unstable = (
     },
     root: slot.always(
       getIntrinsicElementProps('div', {
-        ref: useMergedRefs(ref, reflowRef, nodeRef, motionRef),
+        ref: useMergedRefs(ref, reflowRef, nodeRef),
         role: 'group',
         'aria-labelledby': titleId,
         ...props,
@@ -86,7 +85,8 @@ export const useMessageBarBase_unstable = (
 export const useMessageBar_unstable = (props: MessageBarProps, ref: React.Ref<HTMLDivElement>): MessageBarState => {
   const { shape = 'rounded', ...baseProps } = props;
 
-  const state = useMessageBarBase_unstable(baseProps, ref);
+  const motionRef = useMotionForwardedRef();
+  const state = useMessageBarBase_unstable(baseProps, useMergedRefs(ref, motionRef));
 
   return {
     ...state,


### PR DESCRIPTION
Fixes issue discovered in https://github.com/microsoft/fluentui/pull/36544

## Summary

- remove motion-specific ref handling from the headless MessageBar base hook
- merge the motion ref in the styled MessageBar hook instead

## Validation

- `yarn nx run react-message-bar:build --skipNxCache`