### PR TITLE
refactor(react-swatch-picker): move styles out of base hook

### DIFF
--- a/change/@fluentui-react-swatch-picker-29cb736f-3997-4405-aad2-ec8d968a0b8b.json
+++ b/change/@fluentui-react-swatch-picker-29cb736f-3997-4405-aad2-ec8d968a0b8b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Move ColorSwatch styling out of the headless base hook.",
+  "comment": "fix: Move ColorSwatch styling out of the headless base hook.",
   "packageName": "@fluentui/react-swatch-picker",
   "email": "dmytrokirpa@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-swatch-picker-29cb736f-3997-4405-aad2-ec8d968a0b8b.json
+++ b/change/@fluentui-react-swatch-picker-29cb736f-3997-4405-aad2-ec8d968a0b8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move ColorSwatch styling out of the headless base hook.",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.constants.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.constants.ts
@@ -1,0 +1,4 @@
+export const swatchCSSVars = {
+  color: `--fui-SwatchPicker--color`,
+  borderColor: `--fui-SwatchPicker--borderColor`,
+};

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.test.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.test.tsx
@@ -29,7 +29,6 @@ describe('ColorSwatch', () => {
           aria-checked="false"
           class="fui-ColorSwatch"
           role="radio"
-          style="--fui-SwatchPicker--color: #f09; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
           type="button"
         />
       </div>

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.test.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/ColorSwatch.test.tsx
@@ -29,6 +29,7 @@ describe('ColorSwatch', () => {
           aria-checked="false"
           class="fui-ColorSwatch"
           role="radio"
+          style="--fui-SwatchPicker--color: #f09;"
           type="button"
         />
       </div>

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/index.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/index.ts
@@ -8,4 +8,5 @@ export type {
 } from './ColorSwatch.types';
 export { renderColorSwatch_unstable } from './renderColorSwatch';
 export { useColorSwatch_unstable, useColorSwatchBase_unstable } from './useColorSwatch';
-export { colorSwatchClassNames, swatchCSSVars, useColorSwatchStyles_unstable } from './useColorSwatchStyles.styles';
+export { colorSwatchClassNames, useColorSwatchStyles_unstable } from './useColorSwatchStyles.styles';
+export { swatchCSSVars } from './ColorSwatch.constants';

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatch.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatch.tsx
@@ -10,6 +10,7 @@ import type {
 } from './ColorSwatch.types';
 import { useSwatchPickerContextValue_unstable } from '../../contexts/swatchPicker';
 import { ProhibitedFilled } from '@fluentui/react-icons';
+import { swatchCSSVars } from './ColorSwatch.constants';
 
 /**
  * Create the basee state required to render unstyled ColorSwatch.
@@ -23,7 +24,7 @@ export const useColorSwatchBase_unstable = (
   props: ColorSwatchBaseProps,
   ref: React.Ref<HTMLButtonElement>,
 ): ColorSwatchBaseState => {
-  const { borderColor, color, disabled, disabledIcon, icon, value, onClick, ...rest } = props;
+  const { borderColor, color, disabled, disabledIcon, icon, value, onClick, style, ...rest } = props;
   const isGrid = useSwatchPickerContextValue_unstable(ctx => ctx.isGrid);
 
   const requestSelectionChange = useSwatchPickerContextValue_unstable(ctx => ctx.requestSelectionChange);
@@ -37,6 +38,11 @@ export const useColorSwatchBase_unstable = (
       }),
     ),
   );
+
+  const rootVariables = {
+    [swatchCSSVars.color]: color,
+    [swatchCSSVars.borderColor]: borderColor,
+  };
 
   const role = isGrid ? 'gridcell' : 'radio';
   const ariaSelected = isGrid
@@ -65,6 +71,10 @@ export const useColorSwatchBase_unstable = (
         type: 'button',
         disabled,
         ...rest,
+        style: {
+          ...rootVariables,
+          ...style,
+        },
       }),
       { elementType: 'button' },
     ),

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatch.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatch.tsx
@@ -9,9 +9,7 @@ import type {
   ColorSwatchState,
 } from './ColorSwatch.types';
 import { useSwatchPickerContextValue_unstable } from '../../contexts/swatchPicker';
-import { swatchCSSVars } from './useColorSwatchStyles.styles';
 import { ProhibitedFilled } from '@fluentui/react-icons';
-import { tokens } from '@fluentui/react-theme';
 
 /**
  * Create the basee state required to render unstyled ColorSwatch.
@@ -25,7 +23,7 @@ export const useColorSwatchBase_unstable = (
   props: ColorSwatchBaseProps,
   ref: React.Ref<HTMLButtonElement>,
 ): ColorSwatchBaseState => {
-  const { borderColor, color, disabled, disabledIcon, icon, value, onClick, style, ...rest } = props;
+  const { borderColor, color, disabled, disabledIcon, icon, value, onClick, ...rest } = props;
   const isGrid = useSwatchPickerContextValue_unstable(ctx => ctx.isGrid);
 
   const requestSelectionChange = useSwatchPickerContextValue_unstable(ctx => ctx.requestSelectionChange);
@@ -39,11 +37,6 @@ export const useColorSwatchBase_unstable = (
       }),
     ),
   );
-
-  const rootVariables = {
-    [swatchCSSVars.color]: color,
-    [swatchCSSVars.borderColor]: borderColor ?? tokens.colorTransparentStroke,
-  };
 
   const role = isGrid ? 'gridcell' : 'radio';
   const ariaSelected = isGrid
@@ -72,10 +65,6 @@ export const useColorSwatchBase_unstable = (
         type: 'button',
         disabled,
         ...rest,
-        style: {
-          ...rootVariables,
-          ...style,
-        },
       }),
       { elementType: 'button' },
     ),

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -5,16 +5,12 @@ import type { SlotClassNames } from '@fluentui/react-utilities';
 import type { ColorSwatchSlots, ColorSwatchState } from './ColorSwatch.types';
 import { tokens } from '@fluentui/react-theme';
 import { createCustomFocusIndicatorStyle } from '@fluentui/react-tabster';
+import { swatchCSSVars } from './ColorSwatch.constants';
 
 export const colorSwatchClassNames: SlotClassNames<ColorSwatchSlots> = {
   root: 'fui-ColorSwatch',
   icon: 'fui-ColorSwatch__icon',
   disabledIcon: 'fui-ColorSwatch__disabledIcon',
-};
-
-export const swatchCSSVars = {
-  color: `--fui-SwatchPicker--color`,
-  borderColor: `--fui-SwatchPicker--borderColor`,
 };
 
 const { color, borderColor } = swatchCSSVars;
@@ -28,7 +24,7 @@ const useResetStyles = makeResetStyles({
   alignItems: 'center',
   justifyContent: 'center',
   boxSizing: 'border-box',
-  border: `1px solid var(${borderColor})`,
+  border: `1px solid var(${borderColor}, ${tokens.colorTransparentStroke})`,
   background: `var(${color})`,
   overflow: 'hidden',
   padding: '0',
@@ -67,10 +63,6 @@ const useResetStyles = makeResetStyles({
 });
 
 const useStyles = makeStyles({
-  root: {
-    [swatchCSSVars.color]: color,
-    [swatchCSSVars.borderColor]: borderColor ?? tokens.colorTransparentStroke,
-  },
   disabled: {
     ':hover': {
       cursor: 'not-allowed',
@@ -195,7 +187,6 @@ export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwa
   state.root.className = mergeClasses(
     colorSwatchClassNames.root,
     resetStyles,
-    styles.root,
     sizeStyles[size],
     shapeStyles[shape],
     state.selected && styles.selected,

--- a/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
+++ b/packages/react-components/react-swatch-picker/library/src/components/ColorSwatch/useColorSwatchStyles.styles.ts
@@ -67,6 +67,10 @@ const useResetStyles = makeResetStyles({
 });
 
 const useStyles = makeStyles({
+  root: {
+    [swatchCSSVars.color]: color,
+    [swatchCSSVars.borderColor]: borderColor ?? tokens.colorTransparentStroke,
+  },
   disabled: {
     ':hover': {
       cursor: 'not-allowed',
@@ -191,6 +195,7 @@ export const useColorSwatchStyles_unstable = (state: ColorSwatchState): ColorSwa
   state.root.className = mergeClasses(
     colorSwatchClassNames.root,
     resetStyles,
+    styles.root,
     sizeStyles[size],
     shapeStyles[shape],
     state.selected && styles.selected,

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.test.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.test.tsx
@@ -32,6 +32,7 @@ describe('SwatchPicker', () => {
             aria-checked="false"
             class="fui-ColorSwatch"
             role="radio"
+            style="--fui-SwatchPicker--color: #f09;"
             type="button"
           />
           <button
@@ -39,6 +40,7 @@ describe('SwatchPicker', () => {
             class="fui-ColorSwatch"
             disabled=""
             role="radio"
+            style="--fui-SwatchPicker--color: #0f0;"
             type="button"
           >
             <span

--- a/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.test.tsx
+++ b/packages/react-components/react-swatch-picker/library/src/components/SwatchPicker/SwatchPicker.test.tsx
@@ -32,7 +32,6 @@ describe('SwatchPicker', () => {
             aria-checked="false"
             class="fui-ColorSwatch"
             role="radio"
-            style="--fui-SwatchPicker--color: #f09; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
             type="button"
           />
           <button
@@ -40,7 +39,6 @@ describe('SwatchPicker', () => {
             class="fui-ColorSwatch"
             disabled=""
             role="radio"
-            style="--fui-SwatchPicker--color: #0f0; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
             type="button"
           >
             <span

--- a/packages/react-components/react-swatch-picker/library/src/utils/__snapshots__/renderUtils.test.tsx.snap
+++ b/packages/react-components/react-swatch-picker/library/src/utils/__snapshots__/renderUtils.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF1921; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -25,7 +24,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF7A00; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -33,7 +31,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #90D057; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>
@@ -46,7 +43,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00B053; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -54,7 +50,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00AFED; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -62,7 +57,6 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #006EBD; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>
@@ -113,7 +107,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF1921; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -121,7 +114,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF7A00; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -129,7 +121,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #90D057; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>
@@ -142,7 +133,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00B053; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -150,7 +140,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00AFED; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -158,7 +147,6 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #006EBD; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>
@@ -183,7 +171,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF1921; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -191,7 +178,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #FF7A00; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -199,7 +185,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #90D057; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>
@@ -212,7 +197,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00B053; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -220,7 +204,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #00AFED; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
       <button
@@ -228,7 +211,6 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
-        style="--fui-SwatchPicker--color: #006EBD; --fui-SwatchPicker--borderColor: var(--colorTransparentStroke);"
         type="button"
       />
     </div>

--- a/packages/react-components/react-swatch-picker/library/src/utils/__snapshots__/renderUtils.test.tsx.snap
+++ b/packages/react-components/react-swatch-picker/library/src/utils/__snapshots__/renderUtils.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF1921;"
         type="button"
       />
       <button
@@ -24,6 +25,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF7A00;"
         type="button"
       />
       <button
@@ -31,6 +33,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #90D057;"
         type="button"
       />
     </div>
@@ -43,6 +46,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00B053;"
         type="button"
       />
       <button
@@ -50,6 +54,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00AFED;"
         type="button"
       />
       <button
@@ -57,6 +62,7 @@ exports[`Render utils of SwatchPicker renders custom row 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #006EBD;"
         type="button"
       />
     </div>
@@ -107,6 +113,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF1921;"
         type="button"
       />
       <button
@@ -114,6 +121,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF7A00;"
         type="button"
       />
       <button
@@ -121,6 +129,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #90D057;"
         type="button"
       />
     </div>
@@ -133,6 +142,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00B053;"
         type="button"
       />
       <button
@@ -140,6 +150,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00AFED;"
         type="button"
       />
       <button
@@ -147,6 +158,7 @@ exports[`Render utils of SwatchPicker renders custom swatch 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch custom-swatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #006EBD;"
         type="button"
       />
     </div>
@@ -171,6 +183,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF1921;"
         type="button"
       />
       <button
@@ -178,6 +191,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #FF7A00;"
         type="button"
       />
       <button
@@ -185,6 +199,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #90D057;"
         type="button"
       />
     </div>
@@ -197,6 +212,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00B053;"
         type="button"
       />
       <button
@@ -204,6 +220,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #00AFED;"
         type="button"
       />
       <button
@@ -211,6 +228,7 @@ exports[`Render utils of SwatchPicker renders default grid layout 1`] = `
         aria-selected="false"
         class="fui-ColorSwatch"
         role="gridcell"
+        style="--fui-SwatchPicker--color: #006EBD;"
         type="button"
       />
     </div>


### PR DESCRIPTION
## Summary

- remove CSS-variable style construction from the headless ColorSwatch base hook
- apply color and border variables through the styled hook instead

## Validation

- `yarn nx run react-swatch-picker:build --skipNxCache`