### PR TITLE
fix: align react peerDependencies across react-components packages

### DIFF
--- a/change/@fluentui-react-calendar-compat-25031152-3f2f-498b-87b1-6be678cf09b7.json
+++ b/change/@fluentui-react-calendar-compat-25031152-3f2f-498b-87b1-6be678cf09b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-4210bc32-eb8c-4fee-a455-9e9d11c6e3ac.json
+++ b/change/@fluentui-react-datepicker-compat-4210bc32-eb8c-4fee-a455-9e9d11c6e3ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-compat-99ab4ccd-a0a4-491e-9a10-2ca1d53293bd.json
+++ b/change/@fluentui-react-icons-compat-99ab4ccd-a0a4-491e-9a10-2ca1d53293bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-f02577ac-913f-4ed1-aac8-5f307f228cd1.json
+++ b/change/@fluentui-react-infolabel-f02577ac-913f-4ed1-aac8-5f307f228cd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-6eb5d551-5f64-4f24-bb6d-b10489732089.json
+++ b/change/@fluentui-react-list-6eb5d551-5f64-4f24-bb6d-b10489732089.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-list",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-54930096-3ea9-4baa-8b33-679925651403.json
+++ b/change/@fluentui-react-message-bar-54930096-3ea9-4baa-8b33-679925651403.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-cf2ba3fb-7d37-4d0a-8105-9940c72ccc19.json
+++ b/change/@fluentui-react-migration-v8-v9-cf2ba3fb-7d37-4d0a-8105-9940c72ccc19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-7f7c3881-f1a9-4fe3-bbda-a9ecb0df4076.json
+++ b/change/@fluentui-react-motion-7f7c3881-f1a9-4fe3-bbda-a9ecb0df4076.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-6b5a0004-4b31-41da-bc93-16cf12c97dd5.json
+++ b/change/@fluentui-react-rating-6b5a0004-4b31-41da-bc93-16cf12c97dd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-ff10de4e-2836-4f56-8cf2-a5e8bef29b4d.json
+++ b/change/@fluentui-react-swatch-picker-ff10de4e-2836-4f56-8cf2-a5e8bef29b4d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-95c14e7f-f226-48a2-94e6-27c2e7cb89a8.json
+++ b/change/@fluentui-react-teaching-popover-95c14e7f-f226-48a2-94e6-27c2e7cb89a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-f96b242c-6379-4d5b-908e-e30185ee30a2.json
+++ b/change/@fluentui-react-timepicker-compat-f96b242c-6379-4d5b-908e-e30185ee30a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: align react/react-dom/@types peerDependencies with the react/jsx-runtime 16.14.0 floor",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -25,10 +25,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
     "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -26,10 +26,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -24,10 +24,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-list/library/package.json
+++ b/packages/react-components/react-list/library/package.json
@@ -30,10 +30,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -25,10 +25,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
     "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
   "beachball": {

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -23,10 +23,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -22,10 +22,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -24,10 +24,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -33,10 +33,10 @@
     "use-sync-external-store": "^1.2.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -29,10 +29,10 @@
     "@swc/helpers": "^0.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <20.0.0",
-    "@types/react-dom": ">=16.8.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
-    "react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -27,10 +27,10 @@
     "@swc/helpers": ""
   },
   "peerDependencies": {
-    "@types/react": ">=16.14.0 <19.0.0",
-    "@types/react-dom": ">=16.9.0 <19.0.0",
-    "react": ">=16.14.0 <19.0.0",
-    "react-dom": ">=16.14.0 <19.0.0"
+    "@types/react": ">=16.14.0 <20.0.0",
+    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react": ">=16.14.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,10 +3559,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
-    react: ">=16.8.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
+    react: ">=16.14.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4064,7 +4064,7 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     "@types/react-dom": ">=16.9.0 <20.0.0"
-    react: ">=16.8.0 <20.0.0"
+    react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
@@ -4425,10 +4425,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
-    react: ">=16.8.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
+    react: ">=16.14.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4555,10 +4555,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4682,10 +4682,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4773,10 +4773,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4831,7 +4831,7 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     "@types/react-dom": ">=16.9.0 <20.0.0"
-    react: ">=16.8.0 <20.0.0"
+    react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
@@ -4900,10 +4900,10 @@ __metadata:
     "@fluentui/react-utilities": "npm:^9.26.5"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5278,10 +5278,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5525,10 +5525,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5725,10 +5725,10 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5824,10 +5824,10 @@ __metadata:
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
-    "@types/react": ">=16.8.0 <20.0.0"
-    "@types/react-dom": ">=16.8.0 <20.0.0"
-    react: ">=16.8.0 <20.0.0"
-    react-dom: ">=16.8.0 <20.0.0"
+    "@types/react": ">=16.14.0 <20.0.0"
+    "@types/react-dom": ">=16.9.0 <20.0.0"
+    react: ">=16.14.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Previous Behavior

Peer dependency ranges for `react`, `react-dom`, `@types/react` and `@types/react-dom` had drifted into **5 different signatures** across publishable `packages/react-components/**` packages, 12 of which were internally incoherent:

| Count | `react` | `react-dom` | `@types/react` | `@types/react-dom` | |
| --- | --- | --- | --- | --- | --- |
| 58 | `>=16.14.0` | `>=16.14.0` | `>=16.14.0` | `>=16.9.0` | ✅ canonical |
| 5 | `>=16.14.0` | — | `>=16.14.0` | — | ✅ non-DOM packages |
| 7 | `>=16.14.0` | `>=16.8.0` | `>=16.8.0` | `>=16.8.0` | ❌ |
| 2 | `>=16.8.0` | `>=16.14.0` | `>=16.14.0` | `>=16.9.0` | ❌ |
| 3 | `>=16.8.0` | `>=16.8.0` | `>=16.8.0` | `>=16.8.0` | ❌ transitively unsatisfiable |

Every v9 package depends on `@fluentui/react-jsx-runtime`, which does a hard module import of `react/jsx-runtime`:

```ts
// packages/react-components/react-jsx-runtime/src/utils/Runtime.ts
import * as ReactRuntime from 'react/jsx-runtime';
```

That entry point was only backported to the 16.x line in **react@16.14.0** — verified by unpacking both tarballs:

```
react@16.13.1 -> 0 jsx-runtime files
react@16.14.0 -> package/jsx-runtime.js
                 package/cjs/react-jsx-runtime.development.js
                 package/cjs/react-jsx-runtime.production.min.js
```

So `react >=16.14.0` is a **hard floor**. Any package advertising `>=16.8.0` lets a consumer on React 16.8–16.13 install cleanly and then fail to resolve `react/jsx-runtime` at build/runtime.

### How the skew happened

1. `400cd5a243` — a bad release run wrote the package's own version into peers: `"react": "^8.119.0"`, across ~97 `package.json` files.
2. #31937 (`4edb54ea6e`) reverted it — but **restored only the `react` key**, hand-assigning `>=16.14.0` to 63 entries and `>=16.8.0` to the rest. `react-dom`, `@types/react` and `@types/react-dom` were left untouched at whatever they had. **This is the origin of the mismatch.**
3. #35145 (`eb7f6d51c2`) added React 19 support via a mechanical `<19.0.0` → `<20.0.0` sweep. It preserved lower bounds verbatim, freezing the skew in place — and it never touched `tools/`, leaving the generator template stale.

## New Behavior

All publishable `packages/react-components/**` packages collapse to **one** signature:

```json
"@types/react":     ">=16.14.0 <20.0.0",
"@types/react-dom": ">=16.9.0 <20.0.0",
"react":            ">=16.14.0 <20.0.0",
"react-dom":        ">=16.14.0 <20.0.0"
```

`@types/react-dom` intentionally stays at `>=16.9.0`: no `16.14.x` was ever published for it (16.x ends at `16.9.25`), which is exactly what #30259 fixed. Every other package keeps `>=16.14.0`.

**12 packages normalized:** `react-infolabel`, `react-list`, `react-message-bar`, `react-motion`, `react-rating`, `react-swatch-picker`, `react-teaching-popover`, `react-datepicker-compat`, `react-migration-v8-v9`, `react-calendar-compat`, `react-icons-compat`, `react-timepicker-compat`

The 5 non-DOM packages (`react-utilities`, `react-jsx-runtime`, `react-shared-contexts`, `react-portal-compat`, `react-portal-compat-context`) correctly declare no `react-dom` peer and were already canonical — untouched.

**Generator template fixed:** `tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__` still emitted `<19.0.0`, so every package scaffolded since #35145 started life with a stale upper bound.

This is metadata-only — no source, build output or runtime behavior changes. It narrows an advertised range that was never actually supported, so no consumer on a working configuration is affected.

## Validation

- `beachball check` → clean (12 `patch` change files, one per changed package)
- `nx run workspace-plugin:test --testPathPatterns=react-library` → 3 tests, 10 snapshots passed
- `prettier --check` → clean

## Follow-up (not in this PR)

Nothing prevents this from drifting again — `normalize-package-dependencies` only validates *internal* workspace deps and deliberately skips external peers. A coherence check for the four react peers would make this regression-proof. Happy to add it here or in a separate PR.

## Related Issue(s)

- Follows up on #31937, #35145, #30259
