### PR TITLE
fix(react-color-picker): use valid modern HSL syntax

### DIFF
--- a/change/@fluentui-react-color-picker-0f7a1c2d-63fb-4f72-baa1-8ae6f4dd49c7.json
+++ b/change/@fluentui-react-color-picker-0f7a1c2d-63fb-4f72-baa1-8ae6f4dd49c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use valid HSL syntax for color slider styles",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/AlphaSlider.test.tsx
@@ -30,7 +30,7 @@ describe('AlphaSlider', () => {
       <div>
         <div
           class="fui-ColorSlider fui-AlphaSlider"
-          style="--fui-AlphaSlider--direction: 90deg; --fui-AlphaSlider--progress: 100%; --fui-AlphaSlider__thumb--color: hsla(0 100%, 50%, 1); --fui-AlphaSlider__rail--color: hsl(0 100%, 50%);"
+          style="--fui-AlphaSlider--direction: 90deg; --fui-AlphaSlider--progress: 100%; --fui-AlphaSlider__thumb--color: hsla(0, 100%, 50%, 1); --fui-AlphaSlider__rail--color: hsl(0, 100%, 50%);"
         >
           <input
             class="fui-ColorSlider__input fui-AlphaSlider__input"

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSlider.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useAlphaSlider_unstable } from './useAlphaSlider';
 import { ColorPickerProvider } from '../../contexts/colorPicker';
+import { alphaSliderCSSVars } from './AlphaSlider.constants';
 
 describe('useAlphaSlider', () => {
   it('uses the default shape', () => {
@@ -42,5 +43,15 @@ describe('useAlphaSlider', () => {
     const { result } = renderHook(() => useAlphaSlider_unstable({ shape: 'square' }, ref));
 
     expect(result.current.shape).toBe('square');
+  });
+
+  it('uses valid HSL syntax for slider colors', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useAlphaSlider_unstable({ color: { h: 0, s: 1, v: 1, a: 0.5 } }, ref));
+
+    expect(result.current.root.style).toMatchObject({
+      [alphaSliderCSSVars.thumbColorVar]: 'hsla(0, 100%, 50%, 0.5)',
+      [alphaSliderCSSVars.railColorVar]: 'hsl(0, 100%, 50%)',
+    });
   });
 });

--- a/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
+++ b/packages/react-components/react-color-picker/library/src/components/AlphaSlider/useAlphaSliderState.ts
@@ -44,8 +44,10 @@ export const useAlphaSliderState_unstable = (state: AlphaSliderState, props: Alp
   const rootVariables = {
     [alphaSliderCSSVars.sliderDirectionVar]: sliderDirection,
     [alphaSliderCSSVars.sliderProgressVar]: `${valuePercent}%`,
-    [alphaSliderCSSVars.thumbColorVar]: `hsla(${hslColor.h} ${hslColor.s * 100}%, ${hslColor.l * 100}%, ${hslColor.a})`,
-    [alphaSliderCSSVars.railColorVar]: `hsl(${hslColor.h} ${hslColor.s * 100}%, ${hslColor.l * 100}%)`,
+    [alphaSliderCSSVars.thumbColorVar]: `hsla(${hslColor.h}, ${hslColor.s * 100}%, ${hslColor.l * 100}%, ${
+      hslColor.a
+    })`,
+    [alphaSliderCSSVars.railColorVar]: `hsl(${hslColor.h}, ${hslColor.s * 100}%, ${hslColor.l * 100}%)`,
   };
 
   // Root props

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/ColorSlider.test.tsx
@@ -17,7 +17,7 @@ describe('ColorSlider', () => {
         <div
           class="fui-ColorSlider"
           role="group"
-          style="--fui-Slider--direction: -90deg; --fui-Slider--progress: 0%; --fui-Slider__thumb--color: hsl(0, 100%, 50%); --fui-Slider__rail--color: hsl(0 0%, 0%);"
+          style="--fui-Slider--direction: -90deg; --fui-Slider--progress: 0%; --fui-Slider__thumb--color: hsl(0, 100%, 50%); --fui-Slider__rail--color: hsl(0, 0%, 0%);"
         >
           <input
             aria-orientation="horizontal"

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.test.tsx
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { ColorPickerProvider } from '../../contexts/colorPicker';
 import { useColorSlider_unstable } from './useColorSlider';
+import { colorSliderCSSVars } from './ColorSlider.constants';
 
 describe('useColorSlider', () => {
   it('uses the default shape', () => {
@@ -42,5 +43,15 @@ describe('useColorSlider', () => {
     const { result } = renderHook(() => useColorSlider_unstable({ shape: 'square' }, ref));
 
     expect(result.current.shape).toBe('square');
+  });
+
+  it.each(['hue', 'saturation'] as const)('uses valid HSL syntax for the %s channel', channel => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { result } = renderHook(() => useColorSlider_unstable({ channel, color: { h: 0, s: 1, v: 1, a: 1 } }, ref));
+
+    expect(result.current.root.style).toMatchObject({
+      [colorSliderCSSVars.thumbColorVar]: channel === 'hue' ? 'hsl(0, 100%, 50%)' : 'hsla(0, 100%, 50%, 1)',
+      [colorSliderCSSVars.railColorVar]: 'hsl(0, 100%, 50%)',
+    });
   });
 });

--- a/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
+++ b/packages/react-components/react-color-picker/library/src/components/ColorSlider/useColorSlider.ts
@@ -108,8 +108,8 @@ export const useColorSliderBase_unstable = (
       channel === 'hue' ? `hsl(${clampedValue}, 100%, 50%)` : createHslColorString(hsvColor),
     [colorSliderCSSVars.railColorVar]:
       channel === 'hue'
-        ? `hsl(${hslColor.h} ${hslColor.s * 100}%, ${hslColor.l * 100}%)`
-        : `hsl(${hslColor.h} 100%, 50%)`,
+        ? `hsl(${hslColor.h}, ${hslColor.s * 100}%, ${hslColor.l * 100}%)`
+        : `hsl(${hslColor.h}, 100%, 50%)`,
   };
 
   const state: ColorSliderBaseState = {


### PR DESCRIPTION
## Previous Behavior

Color slider CSS variables mixed space-separated and comma-separated HSL components, producing invalid color values


https://github.com/user-attachments/assets/63f38b3e-d9bf-44b0-beae-4f88dc2bf55f

## New Behavior

Color and alpha sliders use valid HSL syntax with coma-separated components. Regression tests cover the generated CSS variables, and inline snapshots are updated.

## Related Issue(s)

- None

## Validation

- `yarn nx run react-color-picker:test --runInBand` (140 tests passed)
- `yarn nx run react-color-picker:lint`

A patch change file for `@fluentui/react-color-picker` is included.