### PR TITLE
docs: fix v9 migration table rendering

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/AvatarGroup.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/AvatarGroup.mdx
@@ -79,20 +79,20 @@ const AvatarGroupV9BasicExample = () => {
 
 This table maps `Facepile` v8 props to the v9's `AvatarGroup` equivalent.
 
-| v8 \`Facepile\`            | v9 \`AvatarGroup\`                                             |
-| -------------------------- | -------------------------------------------------------------- |
-| \`personas\`               | \`children\`                                                   |
-| \`addButtonProps\`         | \-                                                             |
-| \`className\`              | \`className\`                                                  |
-| \`getPersonaProps\`        | \`AvatarGroupItem\`'s props                                    |
-| \`maxDisplayablePersonas\` | \`maxAvatars\` option in \`partitionAvatarGroupItems\`         |
-| \`onRenderPersona\`        | Render function for the \`AvatarGroupItem\`                    |
-| \`onRenderPersonaCoin\`    | Render function for the \`avatar\` slot in \`AvatarGroupItem\` |
-| \`onRenderPersonaWrapper\` | \-                                                             |
-| \`overflowButtonProps\`    | \`AvatarGroupPopover\`'s props                                 |
-| \`overflowButtonType\`     | \`AvatarGroupPopover\`'s \`indicator\` prop                    |
-| \`overflowPersonas\`       | \`AvatarGroupPopover\`'s children                              |
-| \`personaSize\`            | \`size\`                                                       |
-| \`showAddButton\`          | \-                                                             |
-| \`showTooltip\`            | \-                                                             |
-| \`styles\`                 | (theme)                                                        |
+| v8 `Facepile`            | v9 `AvatarGroup`                                           |
+| ------------------------ | ---------------------------------------------------------- |
+| `personas`               | `children`                                                 |
+| `addButtonProps`         | -                                                          |
+| `className`              | `className`                                                |
+| `getPersonaProps`        | `AvatarGroupItem`'s props                                  |
+| `maxDisplayablePersonas` | `maxAvatars` option in `partitionAvatarGroupItems`         |
+| `onRenderPersona`        | Render function for the `AvatarGroupItem`                  |
+| `onRenderPersonaCoin`    | Render function for the `avatar` slot in `AvatarGroupItem` |
+| `onRenderPersonaWrapper` | -                                                          |
+| `overflowButtonProps`    | `AvatarGroupPopover`'s props                               |
+| `overflowButtonType`     | `AvatarGroupPopover`'s `indicator` prop                    |
+| `overflowPersonas`       | `AvatarGroupPopover`'s children                            |
+| `personaSize`            | `size`                                                     |
+| `showAddButton`          | -                                                          |
+| `showTooltip`            | -                                                          |
+| `styles`                 | (theme)                                                    |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Card/CardPreview.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Card/CardPreview.mdx
@@ -8,15 +8,15 @@ Fluent UI v8 provides the `DocumentCardPreview` component. Fluent UI v9 provides
 
 This table maps `DocumentCardPreview` v8 props to the `Card` v9 equivalent.
 
-| v8                           | v9        | Notes                                                              |
-| ---------------------------- | --------- | ------------------------------------------------------------------ |
-| className                    | className |                                                                    |
-| componentRef                 | ref       |                                                                    |
-| previewImages                | n/a       | see Migrate \`previewImages\` prop in this document                |
-| getOverflowDocumentCountText | n/a       | see Migrate \`getOverflowDocumentCountText\` prop in this document |
-| maxDisplayCount              | n/a       | see Migrate \`getOverflowDocumentCountText\` prop in this document |
-| styles                       | className |                                                                    |
-| theme                        | n/a       | Use \`FluentProvider\` to customize themes                         |
+| v8                           | v9        | Notes                                                            |
+| ---------------------------- | --------- | ---------------------------------------------------------------- |
+| className                    | className |                                                                  |
+| componentRef                 | ref       |                                                                  |
+| previewImages                | n/a       | see Migrate `previewImages` prop in this document                |
+| getOverflowDocumentCountText | n/a       | see Migrate `getOverflowDocumentCountText` prop in this document |
+| maxDisplayCount              | n/a       | see Migrate `getOverflowDocumentCountText` prop in this document |
+| styles                       | className |                                                                  |
+| theme                        | n/a       | Use `FluentProvider` to customize themes                         |
 
 ## Migrate `previewImages` prop
 

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Checkbox.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Checkbox.mdx
@@ -70,29 +70,29 @@ const CheckboxShimBasicExample = () => {
 
 This table maps `Checkbox` v8 props to the `Checkbox` v9 equivalent and `CheckboxShim`.
 
-| v8                       | v9                   | shim                | Notes                                      |
-| ------------------------ | -------------------- | ------------------- | ------------------------------------------ |
-| \`ariaDescribedBy\`      | \`aria-describedby\` | \`ariaDescribedBy\` |                                            |
-| \`ariaLabel\`            | \`aria-label\`       | \`ariaLabel\`       |                                            |
-| \`ariaLabelledBy\`       | \`aria-labelledby\`  | \`ariaLabelledBy\`  |                                            |
-| \`ariaPositionInSet\`    | \`aria-posinset\`    | \`aria-posinset\`   |                                            |
-| \`ariaSetSize\`          | \`aria-setsize\`     | \`aria-setsize\`    |                                            |
-| \`boxSide\`              | \`labelPosition\`    | n/a                 |                                            |
-| \`checked\`              | \`checked\`          | \`checked\`         | Mutually exclusive with \`defaultChecked\` |
-| \`checkmarkIconProps\`   | \`indicator\`        | n/a                 |                                            |
-| \`className\`            | \`className\`        | \`className\`       |                                            |
-| \`componentRef\`         | \`ref\`              | \`componentRef\`    |                                            |
-| \`defaultChecked\`       | \`defaultChecked\`   | \`defaultChecked\`  | Mutually exclusive with \`checked\`        |
-| \`defaultIndeterminate\` | \`defaultChecked\`   | n/a                 |                                            |
-| \`disabled\`             | \`disabled\`         | \`disabled\`        |                                            |
-| \`id\`                   | \`id\`               | \`id\`              |                                            |
-| \`indeterminate\`        | \`checked\`          | n/a                 |                                            |
-| \`inputProps\`           | n/a                  | n/a                 | Props go directly to the \`input\` slot    |
-| \`label\`                | \`label\`            | \`label\`           |                                            |
-| \`name\`                 | \`name\`             | \`name\`            |                                            |
-| \`onChange\`             | \`onChange\`         | \`onChange\`        |                                            |
-| \`onRenderLabel\`        | n/a                  | \`onRenderLabel\`   |                                            |
-| \`required\`             | \`required\`         | \`required\`        |                                            |
-| \`styles\`               | \`className\`        | \`className\`       |                                            |
-| \`theme\`                | n/a                  | \`theme\`           | Use \`FluentProvider\` to customize themes |
-| \`title\`                | n/a                  | \`title\`           |                                            |
+| v8                     | v9                 | shim              | Notes                                    |
+| ---------------------- | ------------------ | ----------------- | ---------------------------------------- |
+| `ariaDescribedBy`      | `aria-describedby` | `ariaDescribedBy` |                                          |
+| `ariaLabel`            | `aria-label`       | `ariaLabel`       |                                          |
+| `ariaLabelledBy`       | `aria-labelledby`  | `ariaLabelledBy`  |                                          |
+| `ariaPositionInSet`    | `aria-posinset`    | `aria-posinset`   |                                          |
+| `ariaSetSize`          | `aria-setsize`     | `aria-setsize`    |                                          |
+| `boxSide`              | `labelPosition`    | n/a               |                                          |
+| `checked`              | `checked`          | `checked`         | Mutually exclusive with `defaultChecked` |
+| `checkmarkIconProps`   | `indicator`        | n/a               |                                          |
+| `className`            | `className`        | `className`       |                                          |
+| `componentRef`         | `ref`              | `componentRef`    |                                          |
+| `defaultChecked`       | `defaultChecked`   | `defaultChecked`  | Mutually exclusive with `checked`        |
+| `defaultIndeterminate` | `defaultChecked`   | n/a               |                                          |
+| `disabled`             | `disabled`         | `disabled`        |                                          |
+| `id`                   | `id`               | `id`              |                                          |
+| `indeterminate`        | `checked`          | n/a               |                                          |
+| `inputProps`           | n/a                | n/a               | Props go directly to the `input` slot    |
+| `label`                | `label`            | `label`           |                                          |
+| `name`                 | `name`             | `name`            |                                          |
+| `onChange`             | `onChange`         | `onChange`        |                                          |
+| `onRenderLabel`        | n/a                | `onRenderLabel`   |                                          |
+| `required`             | `required`         | `required`        |                                          |
+| `styles`               | `className`        | `className`       |                                          |
+| `theme`                | n/a                | `theme`           | Use `FluentProvider` to customize themes |
+| `title`                | n/a                | `title`           |                                          |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/ColorPicker.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/ColorPicker.mdx
@@ -81,65 +81,65 @@ export const Default = () => {
 
 This table maps v8 `ColorPicker` component props to their v9 equivalents.
 
-| v8                    | v9                | Notes                                                                                            |
-| --------------------- | ----------------- | ------------------------------------------------------------------------------------------------ |
-| \`alphaType\`         | \`not supported\` | Use \`AlphaSlider\` component.                                                                   |
-| \`alphaSliderHidden\` | \`not supported\` |                                                                                                  |
-| \`color\`             | \`color\`         | Type changed \`IColor, string\`->\`HSV\`                                                         |
-| \`className\`         | \`not supported\` | Slot system supports it by default. We don't need to provide it explicitly.                      |
-| \`componentRef\`      | \`not supported\` |                                                                                                  |
-| \`hexLabel\`          | \`not supported\` |                                                                                                  |
-| \`redLabel\`          | \`not supported\` |                                                                                                  |
-| \`greenLabel\`        | \`not supported\` |                                                                                                  |
-| \`blueLabel\`         | \`not supported\` |                                                                                                  |
-| \`alphaLabel\`        | \`not supported\` |                                                                                                  |
-| \`onChange\`          | \`onColorChange\` | Renamed. Type changed \`(ev: React.SyntheticEvent, color: IColor) => void;\` => \`EventHandler\` |
-| \`no equivalent\`     | \`shape\`         | New prop, \`shape\` of the ColorPicker.                                                          |
-| \`showPreview\`       | \`not supported\` | Use \`ColorSwatch\` instead.                                                                     |
-| \`strings\`           | \`not supported\` |                                                                                                  |
-| \`styles\`            | \`not supported\` | Use style customization through \`className\` instead.                                           |
-| \`theme\`             | \`not supported\` |                                                                                                  |
-| \`tooltipProps\`      | \`not supported\` | Use \`Tooltip\` component instead.                                                               |
+| v8                  | v9              | Notes                                                                                                                              |
+| ------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `alphaType`         | `not supported` | Use `AlphaSlider` component.                                                                                                       |
+| `alphaSliderHidden` | `not supported` |                                                                                                                                    |
+| `color`             | `color`         | Type changed `IColor, string`->`HSV`                                                                                               |
+| `className`         | `not supported` | Slot system supports it by default. We don't need to provide it explicitly.                                                        |
+| `componentRef`      | `not supported` |                                                                                                                                    |
+| `hexLabel`          | `not supported` |                                                                                                                                    |
+| `redLabel`          | `not supported` |                                                                                                                                    |
+| `greenLabel`        | `not supported` |                                                                                                                                    |
+| `blueLabel`         | `not supported` |                                                                                                                                    |
+| `alphaLabel`        | `not supported` |                                                                                                                                    |
+| `onChange`          | `onColorChange` | Renamed. Type changed `(ev: React.SyntheticEvent<HTMLElement>, color: IColor) => void;` => `EventHandler<ColorPickerOnChangeData>` |
+| `no equivalent`     | `shape`         | New prop, `shape` of the ColorPicker.                                                                                              |
+| `showPreview`       | `not supported` | Use `ColorSwatch` instead.                                                                                                         |
+| `strings`           | `not supported` |                                                                                                                                    |
+| `styles`            | `not supported` | Use style customization through `className` instead.                                                                               |
+| `theme`             | `not supported` |                                                                                                                                    |
+| `tooltipProps`      | `not supported` | Use `Tooltip` component instead.                                                                                                   |
 
 ### ColorRectangle -> ColorArea
 
 This table maps changes between `ColorRectangle` and `ColorArea` equivalent in v9.
 
-| v8                  | v9                | Notes                                                                                            |
-| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------ |
-| \`ariaLabel\`       | \`not supported\` | Use native \`aria-attributes\`                                                                   |
-| \`ariaValueFormat\` | \`not supported\` |                                                                                                  |
-| \`ariaDescription\` | \`not supported\` |                                                                                                  |
-| \`color\`           | \`color\`         | Type changed \`IColor\`->\`HSV\`                                                                 |
-| \`no equivalent\`   | \`defaultColor\`  | Default color for uncontrollable ColorArea                                                       |
-| \`minSize\`         | \`not supported\` |                                                                                                  |
-| \`onChange\`        | \`onColorChange\` | Renamed. Type changed \`(ev: React.SyntheticEvent, color: IColor) => void;\` => \`EventHandler\` |
-| \`no equivalent\`   | \`shape\`         | New prop, \`shape\` of the ColorPicker.                                                          |
+| v8                | v9              | Notes                                                                                                                              |
+| ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `ariaLabel`       | `not supported` | Use native `aria-attributes`                                                                                                       |
+| `ariaValueFormat` | `not supported` |                                                                                                                                    |
+| `ariaDescription` | `not supported` |                                                                                                                                    |
+| `color`           | `color`         | Type changed `IColor`->`HSV`                                                                                                       |
+| `no equivalent`   | `defaultColor`  | Default color for uncontrollable ColorArea                                                                                         |
+| `minSize`         | `not supported` |                                                                                                                                    |
+| `onChange`        | `onColorChange` | Renamed. Type changed `(ev: React.SyntheticEvent<HTMLElement>, color: IColor) => void;` => `EventHandler<ColorPickerOnChangeData>` |
+| `no equivalent`   | `shape`         | New prop, `shape` of the ColorPicker.                                                                                              |
 
 ### ColorSlider
 
-| v8                | v9                | Notes                                                                                                                |
-| ----------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
-| \`type\`          | \`channel\`       | Color channel. Currently supported \`hue\`, \`saturation\` and \`brightness\`. For alpha channel use \`AlphaSlider\` |
-| \`color\`         | \`color\`         | Type changed \`IColor\`->\`HSV\`                                                                                     |
-| \`no equivalent\` | \`defaultColor\`  | Default color for uncontrollable ColorArea                                                                           |
-| \`minValue\`      | \`not supported\` | Use native input \`min\` prop                                                                                        |
-| \`maxValue\`      | \`not supported\` | Use native input \`max\` prop                                                                                        |
-| \`isAlpha\`       | \`not supported\` |                                                                                                                      |
-| \`overlayColor\`  | \`not supported\` |                                                                                                                      |
-| \`thumbColor\`    | \`not supported\` | Use native input \`max\` prop                                                                                        |
-| \`overlayStyle\`  | \`not supported\` | Use native input \`max\` prop                                                                                        |
-| \`onChange\`      | \`onColorChange\` | Renamed. Type changed \`(ev: React.SyntheticEvent, color: IColor) => void;\` => \`EventHandler\`                     |
-| \`no equivalent\` | \`shape\`         | New prop, \`shape\` of the ColorPicker.                                                                              |
-| \`no equivalent\` | \`vertical\`      | Vertical slider.                                                                                                     |
+| v8              | v9              | Notes                                                                                                                              |
+| --------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `type`          | `channel`       | Color channel. Currently supported `hue`, `saturation` and `brightness`. For alpha channel use `AlphaSlider`                       |
+| `color`         | `color`         | Type changed `IColor`->`HSV`                                                                                                       |
+| `no equivalent` | `defaultColor`  | Default color for uncontrollable ColorArea                                                                                         |
+| `minValue`      | `not supported` | Use native input `min` prop                                                                                                        |
+| `maxValue`      | `not supported` | Use native input `max` prop                                                                                                        |
+| `isAlpha`       | `not supported` |                                                                                                                                    |
+| `overlayColor`  | `not supported` |                                                                                                                                    |
+| `thumbColor`    | `not supported` | Use native input `max` prop                                                                                                        |
+| `overlayStyle`  | `not supported` | Use native input `max` prop                                                                                                        |
+| `onChange`      | `onColorChange` | Renamed. Type changed `(ev: React.SyntheticEvent<HTMLElement>, color: IColor) => void;` => `EventHandler<ColorPickerOnChangeData>` |
+| `no equivalent` | `shape`         | New prop, `shape` of the ColorPicker.                                                                                              |
+| `no equivalent` | `vertical`      | Vertical slider.                                                                                                                   |
 
 ### No equivalent in V8 -> AlphaSlider
 
 For aplha channel, use `AlphaSlider` component.
 It has all the props of the `ColorSlider`.
 
-| v8                | v9               | Notes                                                                          |
-| ----------------- | ---------------- | ------------------------------------------------------------------------------ |
-| \`no equivalent\` | \`transparency\` | The \`transparency\` property determines how the alpha channel is interpreted. |
+| v8              | v9             | Notes                                                                        |
+| --------------- | -------------- | ---------------------------------------------------------------------------- |
+| `no equivalent` | `transparency` | The `transparency` property determines how the alpha channel is interpreted. |
 
 For more examples, please refer to the [ColorPicker documentation](https://react.fluentui.dev/?path=/docs/preview-components-colorpicker--docs).

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Flex/Flex.Stack.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Flex/Flex.Stack.mdx
@@ -313,10 +313,10 @@ horizontalAlign/verticalAlign change which props they affect depending on your `
 
 Here is a table you can follow for which prop to use for alignment:
 
-| Direction  | \`flex-direction\` | Horizontal alignment | Vertical alignment |
-| ---------- | ------------------ | -------------------- | ------------------ |
-| default    | column             | align-items          | justify-content    |
-| horizontal | row                | justify-content      | align-items        |
+| Direction  | `flex-direction` | Horizontal alignment | Vertical alignment |
+| ---------- | ---------------- | -------------------- | ------------------ |
+| default    | column           | align-items          | justify-content    |
+| horizontal | row              | justify-content      | align-items        |
 
 You can also refer to [this MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container) for a great in depth explanation about how alignment works in flex container.
 
@@ -435,10 +435,10 @@ MDN documentation:
 
 `reversed` will append "reverse" to your `flex-direction` CSS prop. Below is a table to reflect what you should use:
 
-| Alignment  | CSS    | With \`reversed\` prop |
-| ---------- | ------ | ---------------------- |
-| default    | column | column-reverse         |
-| horizontal | row    | row-reverse            |
+| Alignment  | CSS    | With `reversed` prop |
+| ---------- | ------ | -------------------- |
+| default    | column | column-reverse       |
+| horizontal | row    | row-reverse          |
 
 Example usage for an horizontal layout:
 

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Image/Image.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Image/Image.mdx
@@ -163,20 +163,20 @@ const Component = () => {
 
 The table below presents a mapping of props between the v8 and v9 `Image` components in order to clarify which properties require changes.
 
-| v8                       | v9                                                                         |
-| ------------------------ | -------------------------------------------------------------------------- |
-| \`height\`               | \`height\`                                                                 |
-| \`width\`                | \`width\`                                                                  |
-| \`className\`            | \`className\`                                                              |
-| \`coverStyle\`           | \`fit="cover"\`                                                            |
-| \`imageFit\`             | \`fit\`                                                                    |
-| \`maximizeFrame\`        | \`block\`.                                                                 |
-| \`styles\`               | \`className\`                                                              |
-| \`loading\`              | Not supported -> use onLoad and onError events                             |
-| \`onLoadingStateChange\` | Not supported -> use onLoad and onError events                             |
-| \`shouldFadeIn\`         | Not supported -> implement animation via makeStyles and className + onLoad |
-| \`shouldStartVisible\`   | Not supported -> use onLoad and onError events                             |
-| \`theme\`                | Use \`FluentProvider\` to customize the theme                              |
+| v8                     | v9                                                                         |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `height`               | `height`                                                                   |
+| `width`                | `width`                                                                    |
+| `className`            | `className`                                                                |
+| `coverStyle`           | `fit="cover"`                                                              |
+| `imageFit`             | `fit`                                                                      |
+| `maximizeFrame`        | `block`.                                                                   |
+| `styles`               | `className`                                                                |
+| `loading`              | Not supported -> use onLoad and onError events                             |
+| `onLoadingStateChange` | Not supported -> use onLoad and onError events                             |
+| `shouldFadeIn`         | Not supported -> implement animation via makeStyles and className + onLoad |
+| `shouldStartVisible`   | Not supported -> use onLoad and onError events                             |
+| `theme`                | Use `FluentProvider` to customize the theme                                |
 
 In v9, the boolean props from [IImageStyleProps](https://developer.microsoft.com/en-us/fluentui#/controls/web/image#IImageStyleProps)
 — such as `isCenter`, `isCenterCover`, `isCenterContain`, `isContain`, `isLandscape`, `isNone`, `isError`, `isLoaded`, and `isNotImageFit` — are no longer supported.

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Input.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Input.mdx
@@ -115,43 +115,43 @@ const InputV9BasicExample = () => {
 
 This table maps v8 `TextField` props to the v9 `Input` equivalent.
 
-| v8                           | v9                                             | Notes                                                                                      |
-| ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| \`componentRef\`             | \`ref\`                                        | v9 provides access to the underlyig DOM node, not ITextField                               |
-| \`elementRef\`               | \`ref\`                                        |                                                                                            |
-| \`multiline\`                | n/a                                            | Use \`Textarea\`                                                                           |
-| \`resizable\`                | n/a                                            |                                                                                            |
-| \`autoAjustHeight\`          | n/a                                            | See \`Textarea\` docs                                                                      |
-| \`underlined\`               | \`appearance\`                                 |                                                                                            |
-| \`borderless\`               | \`appearance\`                                 |                                                                                            |
-| \`label\`                    | Use \`Label\` component                        | Be sure to associate \`Label\` with \`Input\` via \`htmlFor\`                              |
-| \`onRenderLabel\`            | n/a                                            | Use slots to customize \`Input\`                                                           |
-| \`description\`              | n/a                                            | Use another element like \`Text\` and associate it with \`Input\` via \`aria-describedby\` |
-| \`onRenderDescription\`      | n/a                                            |                                                                                            |
-| \`onRenderInput\`            | n/a                                            | Use slots to customize \`Input\`                                                           |
-| \`prefix\`                   | \`contentBefore\`                              | This is a slot not a \`string\`                                                            |
-| \`suffix\`                   | \`contentAfter\`                               | This is a slot not a \`string\`                                                            |
-| \`onRenderPrefix\`           | n/a                                            | Use slots to customize \`Input\`                                                           |
-| \`onRenderSuffix\`           | n/a                                            | Use slots to customize \`Input\`                                                           |
-| \`iconProps\`                | Use \`contentBefore\` or \`contentAfter\` slot |                                                                                            |
-| \`defaultValue\`             | \`defaultValue\`                               | Mutually exclusive with \`value\`                                                          |
-| \`value\`                    | \`value\`                                      | Mutually exclusive with \`defaultValue\`                                                   |
-| \`disabled\`                 | \`disabled\`                                   |                                                                                            |
-| \`readOnly\`                 | \`readOnly\`                                   | In v9 this is the native HTML prop                                                         |
-| \`invalid\`                  | n/a                                            | v9 \`Input\` does not handle validation states                                             |
-| \`errorMessage\`             | n/a                                            | Use another element like \`Text\` and associate it with \`Input\` via \`aria-describedby\` |
-| \`onChange\`                 | \`onChange\`                                   | Typescript types have changed                                                              |
-| \`onNotifyValidationResult\` | n/a                                            | v9 \`Input\` does not handle validation                                                    |
-| \`onGetErrorMessage\`        | n/a                                            | v9 \`Input\` does not handle error states                                                  |
-| \`deferredValidationTime\`   | n/a                                            | v9 \`Input\` does not handle validation                                                    |
-| \`className\`                | \`className\`                                  |                                                                                            |
-| \`inputClassName\`           | Use \`input\` slot                             |                                                                                            |
-| \`ariaLabel\`                | \`aria-label\`                                 |                                                                                            |
-| \`validateOnFocusIn\`        | n/a                                            | v9 \`Input\` does not handle validation                                                    |
-| \`validateOnFocusOut\`       | n/a                                            | v9 \`Input\` does not handle validation                                                    |
-| \`validateOnLoad\`           | n/a                                            | v9 \`Input\` does not handle validation                                                    |
-| \`theme\`                    | n/a                                            | Use \`FluentProvider\` to customize themes                                                 |
-| \`styles\`                   | \`className\`                                  |                                                                                            |
-| \`autoComplete\`             | \`autoComplete\`                               | In v9 this is the native HTML prop                                                         |
-| \`canRevealPassword\`        | n/a                                            | v9 \`Input\` does not provide built in password reveal behavior                            |
-| \`revealPasswordAriaLabel\`  | n/a                                            | v9 \`Input\` does not provide built in password reveal behavior                            |
+| v8                         | v9                                         | Notes                                                                                |
+| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `componentRef`             | `ref`                                      | v9 provides access to the underlyig DOM node, not ITextField                         |
+| `elementRef`               | `ref`                                      |                                                                                      |
+| `multiline`                | n/a                                        | Use `Textarea`                                                                       |
+| `resizable`                | n/a                                        |                                                                                      |
+| `autoAjustHeight`          | n/a                                        | See `Textarea` docs                                                                  |
+| `underlined`               | `appearance`                               |                                                                                      |
+| `borderless`               | `appearance`                               |                                                                                      |
+| `label`                    | Use `Label` component                      | Be sure to associate `Label` with `Input` via `htmlFor`                              |
+| `onRenderLabel`            | n/a                                        | Use slots to customize `Input`                                                       |
+| `description`              | n/a                                        | Use another element like `Text` and associate it with `Input` via `aria-describedby` |
+| `onRenderDescription`      | n/a                                        |                                                                                      |
+| `onRenderInput`            | n/a                                        | Use slots to customize `Input`                                                       |
+| `prefix`                   | `contentBefore`                            | This is a slot not a `string`                                                        |
+| `suffix`                   | `contentAfter`                             | This is a slot not a `string`                                                        |
+| `onRenderPrefix`           | n/a                                        | Use slots to customize `Input`                                                       |
+| `onRenderSuffix`           | n/a                                        | Use slots to customize `Input`                                                       |
+| `iconProps`                | Use `contentBefore` or `contentAfter` slot |                                                                                      |
+| `defaultValue`             | `defaultValue`                             | Mutually exclusive with `value`                                                      |
+| `value`                    | `value`                                    | Mutually exclusive with `defaultValue`                                               |
+| `disabled`                 | `disabled`                                 |                                                                                      |
+| `readOnly`                 | `readOnly`                                 | In v9 this is the native HTML prop                                                   |
+| `invalid`                  | n/a                                        | v9 `Input` does not handle validation states                                         |
+| `errorMessage`             | n/a                                        | Use another element like `Text` and associate it with `Input` via `aria-describedby` |
+| `onChange`                 | `onChange`                                 | Typescript types have changed                                                        |
+| `onNotifyValidationResult` | n/a                                        | v9 `Input` does not handle validation                                                |
+| `onGetErrorMessage`        | n/a                                        | v9 `Input` does not handle error states                                              |
+| `deferredValidationTime`   | n/a                                        | v9 `Input` does not handle validation                                                |
+| `className`                | `className`                                |                                                                                      |
+| `inputClassName`           | Use `input` slot                           |                                                                                      |
+| `ariaLabel`                | `aria-label`                               |                                                                                      |
+| `validateOnFocusIn`        | n/a                                        | v9 `Input` does not handle validation                                                |
+| `validateOnFocusOut`       | n/a                                        | v9 `Input` does not handle validation                                                |
+| `validateOnLoad`           | n/a                                        | v9 `Input` does not handle validation                                                |
+| `theme`                    | n/a                                        | Use `FluentProvider` to customize themes                                             |
+| `styles`                   | `className`                                |                                                                                      |
+| `autoComplete`             | `autoComplete`                             | In v9 this is the native HTML prop                                                   |
+| `canRevealPassword`        | n/a                                        | v9 `Input` does not provide built in password reveal behavior                        |
+| `revealPasswordAriaLabel`  | n/a                                        | v9 `Input` does not provide built in password reveal behavior                        |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Keytips.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Keytips.mdx
@@ -13,46 +13,46 @@ However, the v9 version has changes in the API and is now part of [Fluent UI con
 
 This table maps v8 `KeytipLayer` component props to their v9 `Keytips` equivalents.
 
-| v8                       | v9                     | Notes                                                                                                                    |
-| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
-| \`keytipExitSequence\`   | \`exitSequence\`       | Renamed. Type changed \`IKeytipTransitionKey\[\]\` to \`string\`. Specify single hotkey or combination separated by '+'. |
-| \`keytipStartSequence\`  | \`startSequence\`      | Renamed. Type changed \`IKeytipTransitionKey\[\]\` to \`string\`. Specify single hotkey or combination separated by '+'. |
-| \`keytipReturnSequence\` | \`returnSequence\`     | Renamed. Type changed \`IKeytipTransitionKey\[\]\` to \`string\`. Specify single hotkey or combination separated by '+'. |
-| \`onExitKeytipMode\`     | \`onExitKeytipsMode\`  | Renamed. Type changed \`(ev?: React.KeyboardEvent\` \`\\                                                                 | React.MouseEvent) => void\` to \`EventHandler\` |
-| \`onEnterKeytipMode\`    | \`onEnterKeytipsMode\` | Renamed. Type changed \`(ev?: React.KeyboardEvent\` \`\\                                                                 | React.MouseEvent) => void\` to \`EventHandler\` |
-| \`content\`              | \`content\`            | Unchanged.                                                                                                               |
-| \`styles\`               | \`not supported\`      | The component holds only logic and does not require styles.                                                              |
-| \`componentRef\`         | \`not supported\`      |                                                                                                                          |
-| \`no equivalent\`        | \`invokeEvent\`        | New prop, specifies the event that triggers the keytips.                                                                 |
-| \`no equivalent\`        | \`startDelay\`         | New prop, adds delay before entering keytip mode by holding start sequence.                                              |
+| v8                     | v9                   | Notes                                                                                                                                              |
+| ---------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keytipExitSequence`   | `exitSequence`       | Renamed. Type changed `IKeytipTransitionKey[]` to `string`. Specify single hotkey or combination separated by '+'.                                 |
+| `keytipStartSequence`  | `startSequence`      | Renamed. Type changed `IKeytipTransitionKey[]` to `string`. Specify single hotkey or combination separated by '+'.                                 |
+| `keytipReturnSequence` | `returnSequence`     | Renamed. Type changed `IKeytipTransitionKey[]` to `string`. Specify single hotkey or combination separated by '+'.                                 |
+| `onExitKeytipMode`     | `onExitKeytipsMode`  | Renamed. Type changed `(ev?: React.KeyboardEvent<HTMLElement> \| React.MouseEvent<HTMLElement>) => void` to `EventHandler<OnExitKeytipsModeData>`  |
+| `onEnterKeytipMode`    | `onEnterKeytipsMode` | Renamed. Type changed `(ev?: React.KeyboardEvent<HTMLElement> \| React.MouseEvent<HTMLElement>) => void` to `EventHandler<OnEnterKeytipsModeData>` |
+| `content`              | `content`            | Unchanged.                                                                                                                                         |
+| `styles`               | `not supported`      | The component holds only logic and does not require styles.                                                                                        |
+| `componentRef`         | `not supported`      |                                                                                                                                                    |
+| `no equivalent`        | `invokeEvent`        | New prop, specifies the event that triggers the keytips.                                                                                           |
+| `no equivalent`        | `startDelay`         | New prop, adds delay before entering keytip mode by holding start sequence.                                                                        |
 
 ### IKeytipProps -> KeytipProps
 
 This table maps changes between `IKeytipProps` and `KeytipProps` type equivalent in v9.
 
-| v8                      | v9                   | v8 type                          | v9 type                          | Notes                                                                                                                           |
-| ----------------------- | -------------------- | -------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------ |
-| \`content\`             | \`content\`          | \`string\`                       | \`NonNullable\>\`                | Unchanged.                                                                                                                      |
-| \`visible\`             | \`visible\`          | \`boolean\`                      | \`boolean\`                      | Unchanged.                                                                                                                      |
-| \`keySequences\`        | \`keySequences\`     | \`string\[\]\`                   | \`string\[\]\`                   | Unchanged.                                                                                                                      |
-| \`hasMenu\`             | \`hasMenu\`          | \`boolean\`                      | \`boolean\`                      | Unchanged.                                                                                                                      |
-| \`hasDynamicChildren\`  | \`dynamic\`          | \`boolean\`                      | \`boolean\`                      | Renamed.                                                                                                                        |
-| \`hasOverflowSubMenu\`  | \`no equivalent\`    | \`boolean\`                      |                                  | Use \`hasMenu\` instead.                                                                                                        |
-| \`theme\`               | \`no equivalent\`    |                                  |                                  | Not supported.                                                                                                                  |
-| \`overflowSetSequence\` | \`overflowSequence\` | \`string\[\]\`                   | \`string\[\]\`                   |                                                                                                                                 |
-| \`disabled\`            | \`no equivalent\`    | \`boolean\`                      |                                  | Not supported. v9 keytips do not appear for disabled elements.                                                                  |
-| \`callOutProps\`        | \`positioning\`      | \`ICalloutProps\`                | \`PositioningProps\`             | Read more about our \[positioning API\](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--docs) |
-| \`styles\`              | \`no equivalent\`    |                                  |                                  |                                                                                                                                 |
-| \`onExecute\`           | \`onExecute\`        | \`(executeTarget: HTMLElement \\ | null\`, \`target: HTMLElement \\ | null) => void\`                                                                                                                 | \`ExecuteKeytipEventHandler\` | Type changed to match v9 callback typings. |
-| \`onReturn\`            | \`onReturn\`         | \`(executeTarget: HTMLElement \\ | null\`, \`target: HTMLElement \\ | null) => void\`                                                                                                                 | \`ReturnKeytipEventHandler\`  | Type changed to match v9 callback typings. |
+| v8                    | v9                 | v8 type                                                                     | v9 type                     | Notes                                                                                                                         |
+| --------------------- | ------------------ | --------------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `content`             | `content`          | `string`                                                                    | `NonNullable<Slot<'div'>>`  | Unchanged.                                                                                                                    |
+| `visible`             | `visible`          | `boolean`                                                                   | `boolean`                   | Unchanged.                                                                                                                    |
+| `keySequences`        | `keySequences`     | `string[]`                                                                  | `string[]`                  | Unchanged.                                                                                                                    |
+| `hasMenu`             | `hasMenu`          | `boolean`                                                                   | `boolean`                   | Unchanged.                                                                                                                    |
+| `hasDynamicChildren`  | `dynamic`          | `boolean`                                                                   | `boolean`                   | Renamed.                                                                                                                      |
+| `hasOverflowSubMenu`  | `no equivalent`    | `boolean`                                                                   |                             | Use `hasMenu` instead.                                                                                                        |
+| `theme`               | `no equivalent`    |                                                                             |                             | Not supported.                                                                                                                |
+| `overflowSetSequence` | `overflowSequence` | `string[]`                                                                  | `string[]`                  |                                                                                                                               |
+| `disabled`            | `no equivalent`    | `boolean`                                                                   |                             | Not supported. v9 keytips do not appear for disabled elements.                                                                |
+| `callOutProps`        | `positioning`      | `ICalloutProps`                                                             | `PositioningProps`          | Read more about our [positioning API](https://react.fluentui.dev/?path=/docs/concepts-developer-positioning-components--docs) |
+| `styles`              | `no equivalent`    |                                                                             |                             |                                                                                                                               |
+| `onExecute`           | `onExecute`        | `(executeTarget: HTMLElement \| null, target: HTMLElement \| null) => void` | `ExecuteKeytipEventHandler` | Type changed to match v9 callback typings.                                                                                    |
+| `onReturn`            | `onReturn`         | `(executeTarget: HTMLElement \| null, target: HTMLElement \| null) => void` | `ReturnKeytipEventHandler`  | Type changed to match v9 callback typings.                                                                                    |
 
 ### useKeytipRef -> useKeytipRef
 
-| v8                  | v9                | Notes                                                           |
-| ------------------- | ----------------- | --------------------------------------------------------------- |
-| \`keytipProps\`     | \`no equivalent\` | Not supported. Use individual props (see \`KeytipProps\` type). |
-| \`ariaDescribedBy\` | \`no equivalent\` | Not supported.                                                  |
-| \`disabled\`        | \`no equivalent\` | Not supported. Keytips are not shown for disabled elements.     |
+| v8                | v9              | Notes                                                         |
+| ----------------- | --------------- | ------------------------------------------------------------- |
+| `keytipProps`     | `no equivalent` | Not supported. Use individual props (see `KeytipProps` type). |
+| `ariaDescribedBy` | `no equivalent` | Not supported.                                                |
+| `disabled`        | `no equivalent` | Not supported. Keytips are not shown for disabled elements.   |
 
 ### KeytipData -> no equivalent
 

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Label.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Label.mdx
@@ -54,11 +54,11 @@ const LabelV9BasicExample = () => {
 
 This table maps `Label` v8 props to the `Label` v9 equivalent.
 
-| v8               | v9            | Notes                                      |
-| ---------------- | ------------- | ------------------------------------------ |
-| \`as\`           | n/a           |                                            |
-| \`componentRef\` | \`ref\`       |                                            |
-| \`disabled\`     | \`disabled\`  |                                            |
-| \`required\`     | \`required\`  |                                            |
-| \`styles\`       | \`className\` |                                            |
-| \`theme\`        | n/a           | use \`FluentProvider\` to customize themes |
+| v8             | v9          | Notes                                    |
+| -------------- | ----------- | ---------------------------------------- |
+| `as`           | n/a         |                                          |
+| `componentRef` | `ref`       |                                          |
+| `disabled`     | `disabled`  |                                          |
+| `required`     | `required`  |                                          |
+| `styles`       | `className` |                                          |
+| `theme`        | n/a         | use `FluentProvider` to customize themes |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/RadioGroup.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/RadioGroup.mdx
@@ -165,42 +165,42 @@ const RadioGroupCustomOptionExample = () => {
 
 This table maps v8 `ChoiceGroup` props to the v9 `RadioGroup` equivalent.
 
-| v8                     | v9                      | Notes                                                                      |
-| ---------------------- | ----------------------- | -------------------------------------------------------------------------- |
-| \`componentRef\`       | \`ref\`                 | v9 provides access to the underlyig DOM node, not IChoiceGroup             |
-| \`options\`            | \`children\`            | v9 uses React \`children\` rather than data props                          |
-| \`defaultSelectedKey\` | \`defaultValue\`        | Mutually exclusive with \`value\`                                          |
-| \`selectedKey\`        | \`value\`               | Mutually exclusive with \`defaultValue\`                                   |
-| \`onChange\`           | \`onChange\`            | The Typescript types have changed in v9                                    |
-| \`label\`              | Use \`Label\` component | Be sure to associate \`Label\` with \`RadioGroup\` via \`aria-labelledby\` |
-| \`theme\`              | n/a                     | Use \`FluentProvider\` to customize themes                                 |
-| \`styles\`             | \`className\`           |                                                                            |
-| \`ariaLabelledBy\`     | \`aria-labelledby\`     | In v9 this is the intrinsic HTML prop                                      |
+| v8                   | v9                    | Notes                                                                |
+| -------------------- | --------------------- | -------------------------------------------------------------------- |
+| `componentRef`       | `ref`                 | v9 provides access to the underlyig DOM node, not IChoiceGroup       |
+| `options`            | `children`            | v9 uses React `children` rather than data props                      |
+| `defaultSelectedKey` | `defaultValue`        | Mutually exclusive with `value`                                      |
+| `selectedKey`        | `value`               | Mutually exclusive with `defaultValue`                               |
+| `onChange`           | `onChange`            | The Typescript types have changed in v9                              |
+| `label`              | Use `Label` component | Be sure to associate `Label` with `RadioGroup` via `aria-labelledby` |
+| `theme`              | n/a                   | Use `FluentProvider` to customize themes                             |
+| `styles`             | `className`           |                                                                      |
+| `ariaLabelledBy`     | `aria-labelledby`     | In v9 this is the intrinsic HTML prop                                |
 
 This table maps v8 `IChoiceGroupOption` props to the v9 `Radio` equivalent.
 
-| v8                   | v9             | Notes                                                                                                              |
-| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------ |
-| \`key\`              | \`key\`        | This is only necessary if you \`.map()\` an array to generate the list of \`Radio\`s.                              |
-| \`text\`             | \`label\`      | In v9 this is a slot so this prop can be a string, a component or a shorthand object                               |
-| \`onRenderField\`    | n/a            | Provide a custom child to \`RadioGroup\`                                                                           |
-| \`onRenderLabel\`    | \`label\`      | Provide a custom component to the \`label\` slot                                                                   |
-| \`iconProps\`        | n/a            | Use slots to customize \`Radio\`                                                                                   |
-| \`imageSrc\`         | n/a            | Use slots to customize \`Radio\`                                                                                   |
-| \`imageAlt\`         | n/a            | Use slots to customize \`Radio\`                                                                                   |
-| \`selectedImageSrc\` | n/a            | Use slots to customize \`Radio\`                                                                                   |
-| \`imageSize\`        | n/a            | Use slots to customize \`Radio\`                                                                                   |
-| \`disabled\`         | \`disabled\`   |                                                                                                                    |
-| \`id\`               | \`id\`         | In v9 this is the intrinsic HTML prop                                                                              |
-| \`labeldId\`         | n/a            | Provide an id to the \`label\` slot via shorthand props or a custom component                                      |
-| \`ariaLabel\`        | \`aria-label\` | In v9 this is the intrinsic HTML prop                                                                              |
-| \`styles\`           | \`className\`  |                                                                                                                    |
-| \`itemKey\`          | n/a            |                                                                                                                    |
-| \`checked\`          | \`checked\`    | When used in a \`RadioGroup\` use the \`value\` prop on \`RadioGroup\` instead                                     |
-| \`onChange\`         | \`onChange\`   | Typescript types have changed                                                                                      |
-| \`onFocus\`          | \`onFocus\`    | v9 uses native \`onFocus\`                                                                                         |
-| \`onBlur\`           | \`onBlur\`     | v9 uses native \`onBlur\`                                                                                          |
-| \`focused\`          | n/a            |                                                                                                                    |
-| \`theme\`            | n/a            | Use \`FluentProvider\` to customize themes                                                                         |
-| \`required\`         | \`required\`   |                                                                                                                    |
-| \`name\`             | \`name\`       | v9 uses native HTML prop. When used in a \`RadioGroup\` this prop is inherited from the \`RadioGroup\` by default. |
+| v8                 | v9           | Notes                                                                                                          |
+| ------------------ | ------------ | -------------------------------------------------------------------------------------------------------------- |
+| `key`              | `key`        | This is only necessary if you `.map()` an array to generate the list of `Radio`s.                              |
+| `text`             | `label`      | In v9 this is a slot so this prop can be a string, a component or a shorthand object                           |
+| `onRenderField`    | n/a          | Provide a custom child to `RadioGroup`                                                                         |
+| `onRenderLabel`    | `label`      | Provide a custom component to the `label` slot                                                                 |
+| `iconProps`        | n/a          | Use slots to customize `Radio`                                                                                 |
+| `imageSrc`         | n/a          | Use slots to customize `Radio`                                                                                 |
+| `imageAlt`         | n/a          | Use slots to customize `Radio`                                                                                 |
+| `selectedImageSrc` | n/a          | Use slots to customize `Radio`                                                                                 |
+| `imageSize`        | n/a          | Use slots to customize `Radio`                                                                                 |
+| `disabled`         | `disabled`   |                                                                                                                |
+| `id`               | `id`         | In v9 this is the intrinsic HTML prop                                                                          |
+| `labeldId`         | n/a          | Provide an id to the `label` slot via shorthand props or a custom component                                    |
+| `ariaLabel`        | `aria-label` | In v9 this is the intrinsic HTML prop                                                                          |
+| `styles`           | `className`  |                                                                                                                |
+| `itemKey`          | n/a          |                                                                                                                |
+| `checked`          | `checked`    | When used in a `RadioGroup` use the `value` prop on `RadioGroup` instead                                       |
+| `onChange`         | `onChange`   | Typescript types have changed                                                                                  |
+| `onFocus`          | `onFocus`    | v9 uses native `onFocus`                                                                                       |
+| `onBlur`           | `onBlur`     | v9 uses native `onBlur`                                                                                        |
+| `focused`          | n/a          |                                                                                                                |
+| `theme`            | n/a          | Use `FluentProvider` to customize themes                                                                       |
+| `required`         | `required`   |                                                                                                                |
+| `name`             | `name`       | v9 uses native HTML prop. When used in a `RadioGroup` this prop is inherited from the `RadioGroup` by default. |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Slider/Slider.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Slider/Slider.mdx
@@ -137,24 +137,24 @@ export const V9FormattedValueExample = () => {
 
 ## Property mapping
 
-| v8 \`Slider\`         | v9 \`Slider\`      |
-| --------------------- | ------------------ |
-|                       |                    |
-| \`ariaLabel\`         | \`aria-label\`     |
-| \`ariaValueText\`     | \`aria-valuetext\` |
-| \`buttonProps\`       |                    |
-| \`componentRef\`      | \`ref\`            |
-| \`defaultLowerValue\` |                    |
-| \`inline\`            |                    |
-| \`input\`             | \`input\`          |
-| \`label\`             |                    |
-| \`lowerValue\`        |                    |
-| \`onChanged\`         | \`onChange\`       |
-| \`origin\`            |                    |
-| \`originFromZero\`    |                    |
-| \`ranged\`            |                    |
-| \`showValue\`         |                    |
-| \`snapToStep\`        | \`step\`           |
-| \`styles\`            | \`className\`      |
-| \`theme\`             |                    |
-| \`valueFormat\`       |                    |
+| v8 `Slider`         | v9 `Slider`      |
+| ------------------- | ---------------- |
+|                     |                  |
+| `ariaLabel`         | `aria-label`     |
+| `ariaValueText`     | `aria-valuetext` |
+| `buttonProps`       |                  |
+| `componentRef`      | `ref`            |
+| `defaultLowerValue` |                  |
+| `inline`            |                  |
+| `input`             | `input`          |
+| `label`             |                  |
+| `lowerValue`        |                  |
+| `onChanged`         | `onChange`       |
+| `origin`            |                  |
+| `originFromZero`    |                  |
+| `ranged`            |                  |
+| `showValue`         |                  |
+| `snapToStep`        | `step`           |
+| `styles`            | `className`      |
+| `theme`             |                  |
+| `valueFormat`       |                  |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/SpinButton.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/SpinButton.mdx
@@ -260,25 +260,25 @@ const SpinButtonV9CustomSuffixBasicExample = () => {
 
 This table maps v8 `SpinButton` props to the v9 `SpinButton` equivalent.
 
-| v8                    | v9                      | Notes                                                                                                          |
-| --------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
-| \`componentRef\`      | \`ref\`                 | v9 provides access to the underlyig DOM node, not ISpinButton                                                  |
-| \`defaultValue\`      | \`defaultValue\`        | v9 uses \`number\` rather than \`string\` for the type of this prop. Mutually exclusive with \`value\`.        |
-| \`value\`             | \`value\`               | v9 uses \`number\` rather than \`string\` for the type of this prop. Mutually exclusive with \`defaultValue\`. |
-| \`min\`               | \`min\`                 |                                                                                                                |
-| \`max\`               | \`max\`                 |                                                                                                                |
-| \`step\`              | \`step\`                |                                                                                                                |
-| \`precision\`         | \`precision\`           |                                                                                                                |
-| \`onChange\`          | \`onChange\`            | Typescript types have changed                                                                                  |
-| \`onValidate\`        | n/a                     |                                                                                                                |
-| \`onIncrement\`       | \`onChange\`            | See example above                                                                                              |
-| \`onDecrement\`       | \`onChange\`            | See example above                                                                                              |
-| \`label\`             | Use \`Label\` component | Be sure to associate \`Label\` with \`SpinButton\` via \`htmlFor\`                                             |
-| \`labelPosition\`     | Use \`Label\` component |                                                                                                                |
-| \`ariaLabel\`         | \`aria-label\`          |                                                                                                                |
-| \`ariaDescribedBy\`   | \`aria-describedby\`    |                                                                                                                |
-| \`ariaPositionInSet\` | \`aria-posinset\`       | You probably don't need this for \`SpinButton\`                                                                |
-| \`ariaSetSize\`       | \`aria-setsize\`        | You probably don't need this for \`SpinButton\`                                                                |
-| \`ariaValueNow\`      | n/a                     | Set internally by \`SpinButton\`                                                                               |
-| \`ariaValueText\`     | \`aria-valuetext\`      | Set internally by \`SpinButton\` but can be overridden by setting this prop                                    |
-| \`iconProps\`         | Use \`Icon\` component  |                                                                                                                |
+| v8                  | v9                    | Notes                                                                                                    |
+| ------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `componentRef`      | `ref`                 | v9 provides access to the underlyig DOM node, not ISpinButton                                            |
+| `defaultValue`      | `defaultValue`        | v9 uses `number` rather than `string` for the type of this prop. Mutually exclusive with `value`.        |
+| `value`             | `value`               | v9 uses `number` rather than `string` for the type of this prop. Mutually exclusive with `defaultValue`. |
+| `min`               | `min`                 |                                                                                                          |
+| `max`               | `max`                 |                                                                                                          |
+| `step`              | `step`                |                                                                                                          |
+| `precision`         | `precision`           |                                                                                                          |
+| `onChange`          | `onChange`            | Typescript types have changed                                                                            |
+| `onValidate`        | n/a                   |                                                                                                          |
+| `onIncrement`       | `onChange`            | See example above                                                                                        |
+| `onDecrement`       | `onChange`            | See example above                                                                                        |
+| `label`             | Use `Label` component | Be sure to associate `Label` with `SpinButton` via `htmlFor`                                             |
+| `labelPosition`     | Use `Label` component |                                                                                                          |
+| `ariaLabel`         | `aria-label`          |                                                                                                          |
+| `ariaDescribedBy`   | `aria-describedby`    |                                                                                                          |
+| `ariaPositionInSet` | `aria-posinset`       | You probably don't need this for `SpinButton`                                                            |
+| `ariaSetSize`       | `aria-setsize`        | You probably don't need this for `SpinButton`                                                            |
+| `ariaValueNow`      | n/a                   | Set internally by `SpinButton`                                                                           |
+| `ariaValueText`     | `aria-valuetext`      | Set internally by `SpinButton` but can be overridden by setting this prop                                |
+| `iconProps`         | Use `Icon` component  |                                                                                                          |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Spinner.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Spinner.mdx
@@ -37,14 +37,14 @@ export default SpinnerV9BasicExample;
 
 This table maps `Spinner` v8 props to the `Spinner` v9 equivalent.
 
-| v8                | v9                | Notes                                      |
-| ----------------- | ----------------- | ------------------------------------------ |
-| \`aria-label\`    | n/a               |                                            |
-| \`aria-live\`     | n/a               |                                            |
-| \`className\`     | \`className\`     |                                            |
-| \`componentRef\`  | n/a               |                                            |
-| \`label\`         | \`label\`         |                                            |
-| \`labelPosition\` | \`labelPosition\` | Default changes from \`bottom\` to 'after' |
-| \`size\`          | \`size\`          |                                            |
-| \`styles\`        | \`className\`     |                                            |
-| \`theme\`         | n/a               | Use \`FluentProvider\` to customize themes |
+| v8              | v9              | Notes                                    |
+| --------------- | --------------- | ---------------------------------------- |
+| `aria-label`    | n/a             |                                          |
+| `aria-live`     | n/a             |                                          |
+| `className`     | `className`     |                                          |
+| `componentRef`  | n/a             |                                          |
+| `label`         | `label`         |                                          |
+| `labelPosition` | `labelPosition` | Default changes from `bottom` to 'after' |
+| `size`          | `size`          |                                          |
+| `styles`        | `className`     |                                          |
+| `theme`         | n/a             | Use `FluentProvider` to customize themes |

--- a/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Textarea.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Migration/FromV8/Components/Textarea.mdx
@@ -68,43 +68,43 @@ const TextareaV9BasicExample = () => {
 
 This table maps `TextField` v8 props to the `Textarea` v9 equivalent.
 
-| v0                           | v9               | Notes                                                                           |
-| ---------------------------- | ---------------- | ------------------------------------------------------------------------------- |
-| \`ariaLabel\`                | aria-label       |                                                                                 |
-| \`autoAdjustHeight\`         | n/a              | Auto-resize will be added in the future. See spec for more information          |
-| \`className\`                | \`className\`    | To use a custom className for the container use as follows: \`\`                |
-| \`autoComplete\`             | \`autoComplete\` |                                                                                 |
-| \`borderless\`               | \`appearance\`   | Equivalent \`appearance\` could be either \`filledLighter\` or \`filledDarker\` |
-| \`canRevealPassword\`        | n/a              |                                                                                 |
-| \`className\`                | \`className\`    |                                                                                 |
-| \`componentRef\`             | ref              |                                                                                 |
-| \`defaultValue\`             | \`defaultValue\` | Mutually exclusive with \`value\`                                               |
-| \`deferredValidationTime\`   | n/a              |                                                                                 |
-| \`description\`              | n/a              |                                                                                 |
-| \`disabled\`                 | \`disabled\`     |                                                                                 |
-| \`errorMessage\`             | n/a              |                                                                                 |
-| \`iconProps\`                | n/a              |                                                                                 |
-| \`inputClassName\`           | \`className\`    |                                                                                 |
-| \`invalid\`                  | n/a              |                                                                                 |
-| \`label\`                    | n/a              | To add a label, use the \`Label\` component                                     |
-| \`multiline\`                | n/a              | \`Textarea\` is multiline by default                                            |
-| \`onChange\`                 | \`onChange\`     |                                                                                 |
-| \`onGetErrorMessage\`        | n/a              |                                                                                 |
-| \`onNotifyValidationResult\` | n/a              |                                                                                 |
-| \`onRenderDescription\`      | n/a              |                                                                                 |
-| \`onRenderInput\`            | n/a              |                                                                                 |
-| \`onRenderLabel\`            | n/a              |                                                                                 |
-| \`onRenderPrefix\`           | n/a              |                                                                                 |
-| \`onRenderSuffix\`           | n/a              |                                                                                 |
-| \`prefix\`                   | n/a              |                                                                                 |
-| \`readOnly\`                 | \`readonly\`     | This is handled by native component                                             |
-| \`resizable\`                | \`resize\`       |                                                                                 |
-| \`revealPasswordAriaLabel\`  | n/a              |                                                                                 |
-| \`styles\`                   | \`className\`    |                                                                                 |
-| \`suffix\`                   | n/a              |                                                                                 |
-| \`theme\`                    | n/a              | use \`FluentProvider\` to customize themes                                      |
-| \`underlined\`               | n/a              |                                                                                 |
-| \`validateOnFocusIn\`        | n/a              |                                                                                 |
-| \`validateOnFocusOut\`       | n/a              |                                                                                 |
-| \`validateOnLoad\`           | n/a              |                                                                                 |
-| \`value\`                    | \`value\`        | Mutually exclusive with \`defaultValue\`                                        |
+| v0                         | v9             | Notes                                                                                                            |
+| -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `ariaLabel`                | aria-label     |                                                                                                                  |
+| `autoAdjustHeight`         | n/a            | Auto-resize will be added in the future. See spec for more information                                           |
+| `className`                | `className`    | To use a custom className for the container use as follows: `<textarea root={{ className: customClassName }} />` |
+| `autoComplete`             | `autoComplete` |                                                                                                                  |
+| `borderless`               | `appearance`   | Equivalent `appearance` could be either `filledLighter` or `filledDarker`                                        |
+| `canRevealPassword`        | n/a            |                                                                                                                  |
+| `className`                | `className`    |                                                                                                                  |
+| `componentRef`             | ref            |                                                                                                                  |
+| `defaultValue`             | `defaultValue` | Mutually exclusive with `value`                                                                                  |
+| `deferredValidationTime`   | n/a            |                                                                                                                  |
+| `description`              | n/a            |                                                                                                                  |
+| `disabled`                 | `disabled`     |                                                                                                                  |
+| `errorMessage`             | n/a            |                                                                                                                  |
+| `iconProps`                | n/a            |                                                                                                                  |
+| `inputClassName`           | `className`    |                                                                                                                  |
+| `invalid`                  | n/a            |                                                                                                                  |
+| `label`                    | n/a            | To add a label, use the `Label` component                                                                        |
+| `multiline`                | n/a            | `Textarea` is multiline by default                                                                               |
+| `onChange`                 | `onChange`     |                                                                                                                  |
+| `onGetErrorMessage`        | n/a            |                                                                                                                  |
+| `onNotifyValidationResult` | n/a            |                                                                                                                  |
+| `onRenderDescription`      | n/a            |                                                                                                                  |
+| `onRenderInput`            | n/a            |                                                                                                                  |
+| `onRenderLabel`            | n/a            |                                                                                                                  |
+| `onRenderPrefix`           | n/a            |                                                                                                                  |
+| `onRenderSuffix`           | n/a            |                                                                                                                  |
+| `prefix`                   | n/a            |                                                                                                                  |
+| `readOnly`                 | `readonly`     | This is handled by native component                                                                              |
+| `resizable`                | `resize`       |                                                                                                                  |
+| `revealPasswordAriaLabel`  | n/a            |                                                                                                                  |
+| `styles`                   | `className`    |                                                                                                                  |
+| `suffix`                   | n/a            |                                                                                                                  |
+| `theme`                    | n/a            | use `FluentProvider` to customize themes                                                                         |
+| `underlined`               | n/a            |                                                                                                                  |
+| `validateOnFocusIn`        | n/a            |                                                                                                                  |
+| `validateOnFocusOut`       | n/a            |                                                                                                                  |
+| `validateOnLoad`           | n/a            |                                                                                                                  |
+| `value`                    | `value`        | Mutually exclusive with `defaultValue`                                                                           |


### PR DESCRIPTION
restore valid Markdown tables across affected v8-to-v9 migration docs

<img width="921" height="380" alt="Screenshot 2026-08-12 at 2 15 37 AM" src="https://github.com/user-attachments/assets/e3d06e03-5f4a-4020-9e97-4ed041df5ce1" />
<img width="780" height="422" alt="Screenshot 2026-08-12 at 2 15 39 AM" src="https://github.com/user-attachments/assets/fe6bd6f4-ced0-4655-9db0-5b632abf18f3" />
<img width="628" height="365" alt="Screenshot 2026-08-12 at 2 15 47 AM" src="https://github.com/user-attachments/assets/fd00a6c6-ebb9-43e9-9ffb-afd2605a7076" />
<img width="681" height="349" alt="Screenshot 2026-08-12 at 2 15 53 AM" src="https://github.com/user-attachments/assets/1eeae4d9-4bbd-416e-be28-c3c6064bdc96" />

