### PR TITLE
fix: normalize v9 peer dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,7 @@ jobs:
           yarn nx sync:check
           yarn nx g @fluentui/workspace-plugin:tsconfig-base-all --verify
           yarn nx g @fluentui/workspace-plugin:normalize-package-dependencies --verify
+          yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies --tag=vNext
 
       - name: Type-check just.config.ts files
         run: |

--- a/change/@fluentui-eslint-plugin-react-components-f5fbc283-8af7-439c-ab67-1ae1812d3609.json
+++ b/change/@fluentui-eslint-plugin-react-components-f5fbc283-8af7-439c-ab67-1ae1812d3609.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: narrow eslint and typescript peer ranges to what @typescript-eslint/utils supports",
+  "packageName": "@fluentui/eslint-plugin-react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-global-context-6b834c53-0002-4662-9608-abcd2e57e29f.json
+++ b/change/@fluentui-global-context-6b834c53-0002-4662-9608-abcd2e57e29f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/global-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-accordion-47016221-dd77-4342-9e26-596f685e9791.json
+++ b/change/@fluentui-react-accordion-47016221-dd77-4342-9e26-596f685e9791.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-accordion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-alert-815cc4bf-093b-439c-8bf5-67ec353e4a24.json
+++ b/change/@fluentui-react-alert-815cc4bf-093b-439c-8bf5-67ec353e4a24.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-alert",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-aria-e8de6782-14f3-4846-a69d-1d1c103f85f9.json
+++ b/change/@fluentui-react-aria-e8de6782-14f3-4846-a69d-1d1c103f85f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-aria",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-avatar-e8e50831-03dd-4005-af30-5882d203be97.json
+++ b/change/@fluentui-react-avatar-e8e50831-03dd-4005-af30-5882d203be97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-avatar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-badge-ed921271-69d8-4a49-9994-9906029d3db7.json
+++ b/change/@fluentui-react-badge-ed921271-69d8-4a49-9994-9906029d3db7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-badge",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-breadcrumb-c5ff67d8-3e3c-49c5-a8f4-8da21af030aa.json
+++ b/change/@fluentui-react-breadcrumb-c5ff67d8-3e3c-49c5-a8f4-8da21af030aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-button-9911881f-4094-4530-b026-70de0edacf05.json
+++ b/change/@fluentui-react-button-9911881f-4094-4530-b026-70de0edacf05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-button",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-calendar-compat-161a52ab-f970-457a-9b94-510b92c09ef6.json
+++ b/change/@fluentui-react-calendar-compat-161a52ab-f970-457a-9b94-510b92c09ef6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-calendar-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-card-3b303453-cab2-4482-98fb-6b9207684004.json
+++ b/change/@fluentui-react-card-3b303453-cab2-4482-98fb-6b9207684004.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-card",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-carousel-f1560a48-425b-4068-8fd8-ac2d127df2e2.json
+++ b/change/@fluentui-react-carousel-f1560a48-425b-4068-8fd8-ac2d127df2e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-carousel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-checkbox-8f0d86e5-d848-4c12-988c-93497851769e.json
+++ b/change/@fluentui-react-checkbox-8f0d86e5-d848-4c12-988c-93497851769e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-color-picker-194b508c-81a0-4476-8b9f-e6d44a3577be.json
+++ b/change/@fluentui-react-color-picker-194b508c-81a0-4476-8b9f-e6d44a3577be.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-combobox-b18c6640-06b2-48af-8e30-55c72525c44a.json
+++ b/change/@fluentui-react-combobox-b18c6640-06b2-48af-8e30-55c72525c44a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused @types/react-dom peer dependency, mark @types/react as optional",
+  "packageName": "@fluentui/react-combobox",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-8404163f-5057-4c9a-8dbd-53068773c92c.json
+++ b/change/@fluentui-react-components-8404163f-5057-4c9a-8dbd-53068773c92c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-conformance-griffel-d995ca0d-3b46-4adb-b1f5-e7d060318c0e.json
+++ b/change/@fluentui-react-conformance-griffel-d995ca0d-3b46-4adb-b1f5-e7d060318c0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: declare react-dom peer dependency (used at runtime), remove unused @types/react-dom, mark @types/react as optional",
+  "packageName": "@fluentui/react-conformance-griffel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-context-selector-f8ef8024-4b0a-4e18-92e6-9f1add6b3656.json
+++ b/change/@fluentui-react-context-selector-f8ef8024-4b0a-4e18-92e6-9f1add6b3656.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-context-selector",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-datepicker-compat-cdf7576b-9649-4bcb-aac5-5bf78c5f0b08.json
+++ b/change/@fluentui-react-datepicker-compat-cdf7576b-9649-4bcb-aac5-5bf78c5f0b08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-datepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-dialog-a6e04818-a73a-4afe-8110-3e488f04c4e1.json
+++ b/change/@fluentui-react-dialog-a6e04818-a73a-4afe-8110-3e488f04c4e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-dialog",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-divider-9b3fedf5-8a69-4e4b-963f-4dda841882e1.json
+++ b/change/@fluentui-react-divider-9b3fedf5-8a69-4e4b-963f-4dda841882e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-divider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-drawer-c7c1615e-b453-4679-bdd4-477058338ad6.json
+++ b/change/@fluentui-react-drawer-c7c1615e-b453-4679-bdd4-477058338ad6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-drawer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-field-31876e9f-a742-4338-a622-de5ab66cb1af.json
+++ b/change/@fluentui-react-field-31876e9f-a742-4338-a622-de5ab66cb1af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-field",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-headless-components-preview-42074f33-420a-4743-9ca6-6b5f6d53100f.json
+++ b/change/@fluentui-react-headless-components-preview-42074f33-420a-4743-9ca6-6b5f6d53100f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-icons-compat-67b35f45-9067-468f-b7af-0475a6655517.json
+++ b/change/@fluentui-react-icons-compat-67b35f45-9067-468f-b7af-0475a6655517.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-icons-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-image-ed59c75b-69f5-497b-8037-6f0c73bf4a32.json
+++ b/change/@fluentui-react-image-ed59c75b-69f5-497b-8037-6f0c73bf4a32.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-image",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infobutton-b8b12d73-67d0-4fce-8e3e-b094cc08b8af.json
+++ b/change/@fluentui-react-infobutton-b8b12d73-67d0-4fce-8e3e-b094cc08b8af.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-infolabel-de52210c-b6ad-4467-a039-2fe7170e39a0.json
+++ b/change/@fluentui-react-infolabel-de52210c-b6ad-4467-a039-2fe7170e39a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-infolabel",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-input-81976a7e-de72-4567-9cf2-14ef20b47d23.json
+++ b/change/@fluentui-react-input-81976a7e-de72-4567-9cf2-14ef20b47d23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-input",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-jsx-runtime-7f5626fc-f8e1-4e58-9a3b-93b89efdc9b5.json
+++ b/change/@fluentui-react-jsx-runtime-7f5626fc-f8e1-4e58-9a3b-93b89efdc9b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: mark @types/react peer dependency as optional",
+  "packageName": "@fluentui/react-jsx-runtime",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-label-04f71f76-d074-4861-a54c-23a2910c221a.json
+++ b/change/@fluentui-react-label-04f71f76-d074-4861-a54c-23a2910c221a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-label",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-link-01056834-d048-4b21-a081-fd67aaf8fd86.json
+++ b/change/@fluentui-react-link-01056834-d048-4b21-a081-fd67aaf8fd86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-link",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-list-7b332c08-d173-4b8d-8075-893f6ea909d1.json
+++ b/change/@fluentui-react-list-7b332c08-d173-4b8d-8075-893f6ea909d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-list",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-f5b61c71-539e-4784-a120-cb2c8aee0f76.json
+++ b/change/@fluentui-react-menu-f5b61c71-539e-4784-a120-cb2c8aee0f76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-menu",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-menu-grid-preview-1efd184e-18d8-437a-b3fa-eead17412ed3.json
+++ b/change/@fluentui-react-menu-grid-preview-1efd184e-18d8-437a-b3fa-eead17412ed3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-menu-grid-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-message-bar-6f7564eb-0b36-4392-94fe-665d623bd789.json
+++ b/change/@fluentui-react-message-bar-6f7564eb-0b36-4392-94fe-665d623bd789.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-message-bar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v0-v9-c50c8034-feed-439d-a88f-0e16de50462b.json
+++ b/change/@fluentui-react-migration-v0-v9-c50c8034-feed-439d-a88f-0e16de50462b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-migration-v0-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-migration-v8-v9-8f5a7690-9be4-46e9-ace7-94a159e676ae.json
+++ b/change/@fluentui-react-migration-v8-v9-8f5a7690-9be4-46e9-ace7-94a159e676ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-migration-v8-v9",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-47ee4237-13e1-4967-b12b-58df4b967255.json
+++ b/change/@fluentui-react-motion-47ee4237-13e1-4967-b12b-58df4b967255.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-motion",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-motion-components-preview-821fff2e-c247-4ea2-8b4f-e539b9071158.json
+++ b/change/@fluentui-react-motion-components-preview-821fff2e-c247-4ea2-8b4f-e539b9071158.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-motion-components-preview",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-nav-8415ea04-5866-43db-9366-a04de3a5545e.json
+++ b/change/@fluentui-react-nav-8415ea04-5866-43db-9366-a04de3a5545e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-nav",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-overflow-672739dd-cc0f-4ca1-90ea-5d0e49b74a0f.json
+++ b/change/@fluentui-react-overflow-672739dd-cc0f-4ca1-90ea-5d0e49b74a0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-overflow",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-persona-8577fe8b-e878-4c48-83c3-967dd4ab91bd.json
+++ b/change/@fluentui-react-persona-8577fe8b-e878-4c48-83c3-967dd4ab91bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-persona",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-popover-c3a43ff0-24e1-4ff4-a669-3ed12e3a6400.json
+++ b/change/@fluentui-react-popover-c3a43ff0-24e1-4ff4-a669-3ed12e3a6400.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-1bf5e5bd-40a0-48f4-a3a9-9c80e4ddd909.json
+++ b/change/@fluentui-react-portal-1bf5e5bd-40a0-48f4-a3a9-9c80e4ddd909.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused @types/react-dom peer dependency, mark @types/react as optional",
+  "packageName": "@fluentui/react-portal",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-c704b8a9-46ad-4695-ac51-dad4193c924d.json
+++ b/change/@fluentui-react-portal-compat-c704b8a9-46ad-4695-ac51-dad4193c924d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: mark @types/react peer dependency as optional",
+  "packageName": "@fluentui/react-portal-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-portal-compat-context-14c6cc2d-653c-4af1-ab22-b7d6e18be365.json
+++ b/change/@fluentui-react-portal-compat-context-14c6cc2d-653c-4af1-ab22-b7d6e18be365.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: mark @types/react peer dependency as optional",
+  "packageName": "@fluentui/react-portal-compat-context",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-positioning-38fb6b5c-ca52-4426-83d4-696a92fcaddc.json
+++ b/change/@fluentui-react-positioning-38fb6b5c-ca52-4426-83d4-696a92fcaddc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional, require use-sync-external-store ^1.4.0 for react 19 support",
+  "packageName": "@fluentui/react-positioning",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-progress-0b4fe366-abed-429b-865b-09ee3e5387a8.json
+++ b/change/@fluentui-react-progress-0b4fe366-abed-429b-865b-09ee3e5387a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-progress",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-provider-d9dc71fd-0114-41c1-b457-e93c4a73731c.json
+++ b/change/@fluentui-react-provider-d9dc71fd-0114-41c1-b457-e93c4a73731c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-provider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-radio-dd8cfb16-b865-4a4c-aa37-e814c73ea800.json
+++ b/change/@fluentui-react-radio-dd8cfb16-b865-4a4c-aa37-e814c73ea800.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-radio",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-rating-7a9b8b85-a90c-4863-bf28-f3b3cf01677b.json
+++ b/change/@fluentui-react-rating-7a9b8b85-a90c-4863-bf28-f3b3cf01677b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-rating",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-search-0738ede0-38e3-478f-b91e-f8172e314536.json
+++ b/change/@fluentui-react-search-0738ede0-38e3-478f-b91e-f8172e314536.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-search",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-select-2711ae2d-e5a9-45bb-9ad1-6bd82d1bff39.json
+++ b/change/@fluentui-react-select-2711ae2d-e5a9-45bb-9ad1-6bd82d1bff39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-select",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-shared-contexts-26570b93-cc3e-4d6d-ad3b-a58cd27c965c.json
+++ b/change/@fluentui-react-shared-contexts-26570b93-cc3e-4d6d-ad3b-a58cd27c965c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: mark @types/react peer dependency as optional",
+  "packageName": "@fluentui/react-shared-contexts",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-skeleton-7a846876-d663-403b-ab06-f884d84b66bb.json
+++ b/change/@fluentui-react-skeleton-7a846876-d663-403b-ab06-f884d84b66bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-skeleton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-slider-04e61d41-7b68-4e10-b1ab-b2b854dc3995.json
+++ b/change/@fluentui-react-slider-04e61d41-7b68-4e10-b1ab-b2b854dc3995.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-slider",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinbutton-00c069ed-91c3-4a84-b0b1-86c4bc106a13.json
+++ b/change/@fluentui-react-spinbutton-00c069ed-91c3-4a84-b0b1-86c4bc106a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-spinbutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-spinner-8d7db78b-4765-4f74-8d3f-75419c083262.json
+++ b/change/@fluentui-react-spinner-8d7db78b-4765-4f74-8d3f-75419c083262.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-spinner",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-storybook-addon-bf6bd820-5f10-4f0a-9b4d-4c494f194561.json
+++ b/change/@fluentui-react-storybook-addon-bf6bd820-5f10-4f0a-9b4d-4c494f194561.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-swatch-picker-e9a9729e-4ffd-47fb-9e09-e5897e6c7057.json
+++ b/change/@fluentui-react-swatch-picker-e9a9729e-4ffd-47fb-9e09-e5897e6c7057.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-swatch-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-switch-e85ee204-7e82-47df-9908-c5cecdb94d63.json
+++ b/change/@fluentui-react-switch-e85ee204-7e82-47df-9908-c5cecdb94d63.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-switch",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-table-d3135c79-0ae9-4458-be0c-748003ab5c13.json
+++ b/change/@fluentui-react-table-d3135c79-0ae9-4458-be0c-748003ab5c13.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-table",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabs-a0291350-8bc7-4f89-969c-2c320bc99017.json
+++ b/change/@fluentui-react-tabs-a0291350-8bc7-4f89-969c-2c320bc99017.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-tabs",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tabster-56d3cbaf-451d-4cd9-884c-1b84e6018939.json
+++ b/change/@fluentui-react-tabster-56d3cbaf-451d-4cd9-884c-1b84e6018939.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-tabster",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-4481861f-d9b1-4e91-b3e9-43d1ffc14203.json
+++ b/change/@fluentui-react-tag-picker-4481861f-d9b1-4e91-b3e9-43d1ffc14203.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused @types/react-dom peer dependency, mark @types/react as optional",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tags-d53b0eac-9813-4e14-b85f-7ec30c24e44e.json
+++ b/change/@fluentui-react-tags-d53b0eac-9813-4e14-b85f-7ec30c24e44e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-tags",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-7f05836f-7755-4521-8307-f12819a5e531.json
+++ b/change/@fluentui-react-teaching-popover-7f05836f-7755-4521-8307-f12819a5e531.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional, require use-sync-external-store ^1.4.0 for react 19 support",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-text-b0cde57a-f5f1-4ac8-bf45-bf265b839fc9.json
+++ b/change/@fluentui-react-text-b0cde57a-f5f1-4ac8-bf45-bf265b839fc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-text",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-textarea-ac92166e-954e-4cd4-872f-3bca0167c252.json
+++ b/change/@fluentui-react-textarea-ac92166e-954e-4cd4-872f-3bca0167c252.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-textarea",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-timepicker-compat-e5395385-c15f-4aa5-a19a-84b6d5ca14f4.json
+++ b/change/@fluentui-react-timepicker-compat-e5395385-c15f-4aa5-a19a-84b6d5ca14f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-timepicker-compat",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toast-d3a45fab-cbe8-4207-956b-41cfbcbe92ce.json
+++ b/change/@fluentui-react-toast-d3a45fab-cbe8-4207-956b-41cfbcbe92ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-toast",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-toolbar-1d763b45-b904-47b0-8c7e-f1913615d37d.json
+++ b/change/@fluentui-react-toolbar-1d763b45-b904-47b0-8c7e-f1913615d37d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-toolbar",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tooltip-6edcabb9-7b8e-4f0a-bd3e-4644c682e984.json
+++ b/change/@fluentui-react-tooltip-6edcabb9-7b8e-4f0a-bd3e-4644c682e984.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused react-dom and @types/react-dom peer dependencies, mark @types/react as optional",
+  "packageName": "@fluentui/react-tooltip",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tree-30c34404-dee2-4737-b6fe-69fcb16e5ec9.json
+++ b/change/@fluentui-react-tree-30c34404-dee2-4737-b6fe-69fcb16e5ec9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: remove unused @types/react-dom peer dependency, mark @types/react as optional",
+  "packageName": "@fluentui/react-tree",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-utilities-0030f645-2670-45b6-82f4-139b3fd4e2df.json
+++ b/change/@fluentui-react-utilities-0030f645-2670-45b6-82f4-139b3fd4e2df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "chore: mark @types/react peer dependency as optional",
+  "packageName": "@fluentui/react-utilities",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-78a2739c-07f2-4ac8-840f-53a7dc62c7a0.json
+++ b/change/@fluentui-react-virtualizer-78a2739c-07f2-4ac8-840f-53a7dc62c7a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: remove unused @types/react-dom peer dependency, mark @types/react as optional",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/component-selector-preview/library/package.json
+++ b/packages/react-components/component-selector-preview/library/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/deprecated/react-alert/package.json
+++ b/packages/react-components/deprecated/react-alert/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/deprecated/react-alert/package.json
+++ b/packages/react-components/deprecated/react-alert/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/deprecated/react-infobutton/package.json
+++ b/packages/react-components/deprecated/react-infobutton/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/deprecated/react-infobutton/package.json
+++ b/packages/react-components/deprecated/react-infobutton/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/deprecated/react-virtualizer/package.json
+++ b/packages/react-components/deprecated/react-virtualizer/package.json
@@ -23,6 +23,11 @@
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/deprecated/react-virtualizer/package.json
+++ b/packages/react-components/deprecated/react-virtualizer/package.json
@@ -20,7 +20,6 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },

--- a/packages/react-components/eslint-plugin-react-components/package.json
+++ b/packages/react-components/eslint-plugin-react-components/package.json
@@ -18,8 +18,8 @@
     "@typescript-eslint/utils": "^8.46.2"
   },
   "peerDependencies": {
-    "eslint": ">= 8.0.0",
-    "typescript": ">= 5.0.0",
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=5.0.0 <6.0.0",
     "typescript-eslint": ">= 8.46.2"
   },
   "exports": {

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -18,9 +18,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/global-context/package.json
+++ b/packages/react-components/global-context/package.json
@@ -20,6 +20,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -29,6 +29,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-accordion/library/package.json
+++ b/packages/react-components/react-accordion/library/package.json
@@ -27,9 +27,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-aria/library/package.json
+++ b/packages/react-components/react-aria/library/package.json
@@ -23,6 +23,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -32,6 +32,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-avatar/library/package.json
+++ b/packages/react-components/react-avatar/library/package.json
@@ -30,9 +30,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-badge/library/package.json
+++ b/packages/react-components/react-badge/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-breadcrumb/library/package.json
+++ b/packages/react-components/react-breadcrumb/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-button/library/package.json
+++ b/packages/react-components/react-button/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-calendar-compat/library/package.json
+++ b/packages/react-components/react-calendar-compat/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-card/library/package.json
+++ b/packages/react-components/react-card/library/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-card/library/package.json
+++ b/packages/react-components/react-card/library/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major"

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -39,6 +39,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-carousel/library/package.json
+++ b/packages/react-components/react-carousel/library/package.json
@@ -37,9 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-checkbox/library/package.json
+++ b/packages/react-components/react-checkbox/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-color-picker/library/package.json
+++ b/packages/react-components/react-color-picker/library/package.json
@@ -30,9 +30,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-color-picker/library/package.json
+++ b/packages/react-components/react-color-picker/library/package.json
@@ -32,6 +32,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-colorpicker-compat/package.json
+++ b/packages/react-components/react-colorpicker-compat/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -32,6 +32,11 @@
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-combobox/library/package.json
+++ b/packages/react-components/react-combobox/library/package.json
@@ -29,7 +29,6 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -77,9 +77,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -79,6 +79,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major"

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -12,7 +12,7 @@
   "peerDependencies": {
     "@fluentui/react-conformance": "^0.20.1",
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
+    "react-dom": ">=16.14.0 <20.0.0",
     "typescript": "^4.3.0"
   },
   "dependencies": {

--- a/packages/react-components/react-conformance-griffel/package.json
+++ b/packages/react-components/react-conformance-griffel/package.json
@@ -15,6 +15,11 @@
     "react-dom": ">=16.14.0 <20.0.0",
     "typescript": "^4.3.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1"

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -23,6 +23,11 @@
     "react": ">=16.14.0 <20.0.0",
     "scheduler": ">=0.19.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-context-selector/package.json
+++ b/packages/react-components/react-context-selector/package.json
@@ -20,9 +20,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0",
     "scheduler": ">=0.19.0"
   },
   "beachball": {

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -32,6 +32,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-datepicker-compat/library/package.json
+++ b/packages/react-components/react-datepicker-compat/library/package.json
@@ -30,9 +30,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-dialog/library/package.json
+++ b/packages/react-components/react-dialog/library/package.json
@@ -31,6 +31,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-divider/library/package.json
+++ b/packages/react-components/react-divider/library/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-divider/library/package.json
+++ b/packages/react-components/react-divider/library/package.json
@@ -23,6 +23,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-drawer/library/package.json
+++ b/packages/react-components/react-drawer/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-drawer/library/package.json
+++ b/packages/react-components/react-drawer/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-field/library/package.json
+++ b/packages/react-components/react-field/library/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -74,9 +74,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -76,6 +76,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -28,9 +28,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-icons-compat/library/package.json
+++ b/packages/react-components/react-icons-compat/library/package.json
@@ -30,6 +30,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-image/library/package.json
+++ b/packages/react-components/react-image/library/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-image/library/package.json
+++ b/packages/react-components/react-image/library/package.json
@@ -23,6 +23,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-infolabel/library/package.json
+++ b/packages/react-components/react-infolabel/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-input/library/package.json
+++ b/packages/react-components/react-input/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-input/library/package.json
+++ b/packages/react-components/react-input/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-jsx-runtime/package.json
+++ b/packages/react-components/react-jsx-runtime/package.json
@@ -19,6 +19,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-label/library/package.json
+++ b/packages/react-components/react-label/library/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-label/library/package.json
+++ b/packages/react-components/react-label/library/package.json
@@ -23,6 +23,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-link/library/package.json
+++ b/packages/react-components/react-link/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-list/library/package.json
+++ b/packages/react-components/react-list/library/package.json
@@ -32,9 +32,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-list/library/package.json
+++ b/packages/react-components/react-list/library/package.json
@@ -34,6 +34,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-menu-grid-preview/library/package.json
+++ b/packages/react-components/react-menu-grid-preview/library/package.json
@@ -33,9 +33,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-menu-grid-preview/library/package.json
+++ b/packages/react-components/react-menu-grid-preview/library/package.json
@@ -35,6 +35,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -32,6 +32,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-menu/library/package.json
+++ b/packages/react-components/react-menu/library/package.json
@@ -30,9 +30,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-message-bar/library/package.json
+++ b/packages/react-components/react-message-bar/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -29,6 +29,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-migration-v0-v9/library/package.json
+++ b/packages/react-components/react-migration-v0-v9/library/package.json
@@ -27,9 +27,7 @@
   "peerDependencies": {
     "@fluentui/react-northstar": "^0.66.5",
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-migration-v8-v9/library/package.json
+++ b/packages/react-components/react-migration-v8-v9/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major"

--- a/packages/react-components/react-motion-components-preview/library/package.json
+++ b/packages/react-components/react-motion-components-preview/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-motion-components-preview/library/package.json
+++ b/packages/react-components/react-motion-components-preview/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-motion/library/package.json
+++ b/packages/react-components/react-motion/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-nav/library/package.json
+++ b/packages/react-components/react-nav/library/package.json
@@ -31,9 +31,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-nav/library/package.json
+++ b/packages/react-components/react-nav/library/package.json
@@ -33,6 +33,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -21,9 +21,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-overflow/library/package.json
+++ b/packages/react-components/react-overflow/library/package.json
@@ -23,6 +23,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "prerelease",

--- a/packages/react-components/react-persona/library/package.json
+++ b/packages/react-components/react-persona/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-persona/library/package.json
+++ b/packages/react-components/react-persona/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-popover/library/package.json
+++ b/packages/react-components/react-popover/library/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-popover/library/package.json
+++ b/packages/react-components/react-popover/library/package.json
@@ -31,6 +31,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-portal-compat-context/package.json
+++ b/packages/react-components/react-portal-compat-context/package.json
@@ -18,6 +18,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-portal-compat/package.json
+++ b/packages/react-components/react-portal-compat/package.json
@@ -21,6 +21,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-portal/library/package.json
+++ b/packages/react-components/react-portal/library/package.json
@@ -23,6 +23,11 @@
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-portal/library/package.json
+++ b/packages/react-components/react-portal/library/package.json
@@ -20,7 +20,6 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -19,7 +19,7 @@
     "@fluentui/react-utilities": "^9.26.6",
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1",
-    "use-sync-external-store": "^1.2.0"
+    "use-sync-external-store": "^1.4.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-positioning/library/package.json
+++ b/packages/react-components/react-positioning/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major"

--- a/packages/react-components/react-progress/library/package.json
+++ b/packages/react-components/react-progress/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-progress/library/package.json
+++ b/packages/react-components/react-progress/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-provider/library/package.json
+++ b/packages/react-components/react-provider/library/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-radio/library/package.json
+++ b/packages/react-components/react-radio/library/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-radio/library/package.json
+++ b/packages/react-components/react-radio/library/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-rating/library/package.json
+++ b/packages/react-components/react-rating/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-search/library/package.json
+++ b/packages/react-components/react-search/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-select/library/package.json
+++ b/packages/react-components/react-select/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-shared-contexts/library/package.json
+++ b/packages/react-components/react-shared-contexts/library/package.json
@@ -19,6 +19,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-skeleton/library/package.json
+++ b/packages/react-components/react-skeleton/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-skeleton/library/package.json
+++ b/packages/react-components/react-skeleton/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-slider/library/package.json
+++ b/packages/react-components/react-slider/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-slider/library/package.json
+++ b/packages/react-components/react-slider/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -26,6 +26,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-spinbutton/library/package.json
+++ b/packages/react-components/react-spinbutton/library/package.json
@@ -24,9 +24,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-spinner/library/package.json
+++ b/packages/react-components/react-spinner/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-spinner/library/package.json
+++ b/packages/react-components/react-spinner/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -36,6 +36,11 @@
     "react": ">=16.14.0 <20.0.0",
     "storybook": "^9.1.17"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-storybook-addon/package.json
+++ b/packages/react-components/react-storybook-addon/package.json
@@ -33,9 +33,7 @@
     "@storybook/icons": "^1.3.2",
     "@storybook/react-webpack5": "^9.1.17",
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0",
     "storybook": "^9.1.17"
   },
   "beachball": {

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-swatch-picker/library/package.json
+++ b/packages/react-components/react-swatch-picker/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-switch/library/package.json
+++ b/packages/react-components/react-switch/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-table/library/package.json
+++ b/packages/react-components/react-table/library/package.json
@@ -31,6 +31,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major"

--- a/packages/react-components/react-tabs/library/package.json
+++ b/packages/react-components/react-tabs/library/package.json
@@ -23,9 +23,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tabs/library/package.json
+++ b/packages/react-components/react-tabs/library/package.json
@@ -25,6 +25,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-tabster/package.json
+++ b/packages/react-components/react-tabster/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -41,6 +41,11 @@
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-tag-picker/library/package.json
+++ b/packages/react-components/react-tag-picker/library/package.json
@@ -38,7 +38,6 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-tags/library/package.json
+++ b/packages/react-components/react-tags/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -37,6 +37,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -35,9 +35,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-teaching-popover/library/package.json
+++ b/packages/react-components/react-teaching-popover/library/package.json
@@ -31,7 +31,7 @@
     "@fluentui/react-utilities": "^9.26.6",
     "@griffel/react": "^1.5.32",
     "@swc/helpers": "^0.5.1",
-    "use-sync-external-store": "^1.2.0"
+    "use-sync-external-store": "^1.4.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",

--- a/packages/react-components/react-text/library/package.json
+++ b/packages/react-components/react-text/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-text/library/package.json
+++ b/packages/react-components/react-text/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-textarea/library/package.json
+++ b/packages/react-components/react-textarea/library/package.json
@@ -24,6 +24,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-textarea/library/package.json
+++ b/packages/react-components/react-textarea/library/package.json
@@ -22,9 +22,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -31,9 +31,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-timepicker-compat/library/package.json
+++ b/packages/react-components/react-timepicker-compat/library/package.json
@@ -33,6 +33,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -28,9 +28,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-toast/library/package.json
+++ b/packages/react-components/react-toast/library/package.json
@@ -30,6 +30,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-toolbar/library/package.json
+++ b/packages/react-components/react-toolbar/library/package.json
@@ -28,6 +28,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "prerelease",

--- a/packages/react-components/react-toolbar/library/package.json
+++ b/packages/react-components/react-toolbar/library/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tooltip/library/package.json
+++ b/packages/react-components/react-tooltip/library/package.json
@@ -27,6 +27,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/react-tooltip/library/package.json
+++ b/packages/react-components/react-tooltip/library/package.json
@@ -25,9 +25,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -35,6 +35,11 @@
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react-components/react-tree/library/package.json
+++ b/packages/react-components/react-tree/library/package.json
@@ -32,7 +32,6 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0",
     "react-dom": ">=16.14.0 <20.0.0"
   },

--- a/packages/react-components/react-utilities-compat/library/package.json
+++ b/packages/react-components/react-utilities-compat/library/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.8.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.8.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/react-utilities/package.json
+++ b/packages/react-components/react-utilities/package.json
@@ -20,6 +20,11 @@
     "@types/react": ">=16.14.0 <20.0.0",
     "react": ">=16.14.0 <20.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "beachball": {
     "disallowedChangeTypes": [
       "major",

--- a/packages/react-components/recipes/package.json
+++ b/packages/react-components/recipes/package.json
@@ -29,9 +29,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "exports": {
     ".": {

--- a/packages/react-components/theme-designer/package.json
+++ b/packages/react-components/theme-designer/package.json
@@ -26,9 +26,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/tools/workspace-plugin/generators.json
+++ b/tools/workspace-plugin/generators.json
@@ -70,6 +70,11 @@
       "schema": "./src/generators/normalize-package-dependencies/schema.json",
       "description": "Normalizes all projects dependencies within package.json (used on CI)"
     },
+    "verify-peer-dependencies": {
+      "implementation": "./src/generators/verify-peer-dependencies/index.ts",
+      "schema": "./src/generators/verify-peer-dependencies/schema.json",
+      "description": "Verifies peer dependency forwarding chains and peer metadata across all projects (used on CI)"
+    },
     "version-bump": {
       "implementation": "./src/generators/version-bump/index.ts",
       "schema": "./src/generators/version-bump/schema.json",

--- a/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
+++ b/tools/workspace-plugin/src/generators/react-library/files/package.json__tmpl__
@@ -30,9 +30,12 @@
   },
   "peerDependencies": {
     "@types/react": ">=16.14.0 <20.0.0",
-    "@types/react-dom": ">=16.9.0 <20.0.0",
-    "react": ">=16.14.0 <20.0.0",
-    "react-dom": ">=16.14.0 <20.0.0"
+    "react": ">=16.14.0 <20.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {

--- a/tools/workspace-plugin/src/generators/verify-peer-dependencies/README.md
+++ b/tools/workspace-plugin/src/generators/verify-peer-dependencies/README.md
@@ -1,0 +1,163 @@
+# verify-peer-dependencies
+
+Workspace Generator that validates peer dependency **forwarding chains** and peer metadata across all projects.
+
+A peer dependency is a promise about what the _consumer_ must provide. This generator checks that the
+promises we make are internally consistent and satisfiable.
+
+### How peers resolve, by installer
+
+| Installer                                        | Resolution                                                                                                 |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| npm / yarn classic (hoisted)                     | `require` walks up the directory tree; the nearest ancestor providing the peer wins                        |
+| pnpm, midgard-yarn-strict (isolated, [RFC 0042]) | peer metadata is propagated up the graph automatically, stopping at a real dependency or a local workspace |
+| Yarn PnP strict                                  | no ancestor walk — every package in the chain must declare the peer itself                                 |
+
+Only the last one requires a package to re-declare its dependencies' peers, which is why
+`missing-peer-forward` is **opt-in**: Fluent UI targets hoisted and isolated installs, so peer
+forwarding is not maintained for Yarn PnP strict. Note this applies to _which package provides_ a peer. The other
+checks are about _which versions_ a peer range accepts, which is version math and therefore
+installer-independent - they stay on by default. Declaring peers a package never imports is not free: the peer set is
+part of a package's virtual instance key, so it forks the virtual store on a dimension the package does not
+care about, and it asks consumers to satisfy a module that is never loaded.
+
+[RFC 0042]: https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md
+
+<!-- toc -->
+
+- [Usage](#usage)
+- [Checks](#checks)
+- [Options](#options)
+
+<!-- tocstop -->
+
+## Usage
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies
+```
+
+Verify a single project:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies react-dialog
+```
+
+Verify everything tagged `vNext`, which is what CI runs on every PR:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies --tag=vNext
+```
+
+Fix every missing forward automatically:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies --fix
+```
+
+Use nx's global `--verbose` flag (or `NX_VERBOSE_LOGGING=true`) to see exactly what was checked and
+what was skipped - useful when a clean result looks suspicious, since "nothing to report" and
+"nothing verified" otherwise look identical. Output goes through `logger.verbose`, so nx gates it:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies react-portal --verbose
+```
+
+```
+scope
+  checks   incompatible-peer-range, invalid-peer-range, orphaned-peer-meta
+  packages 1 verified, 255 skipped (127 private, 128 outside --project)
+
+@fluentui/react-portal packages/react-components/react-portal/library/package.json
+  declares @types/react, react, react-dom
+  react '>=16.8.0 <20.0.0' required by @griffel/react -> satisfied by peer '>=16.14.0 <20.0.0'
+
+totals
+  4 peer requirement(s) checked across 1 package(s)
+  skipped: 3 optional, 0 provided as own dependency, 0 outside --peers
+```
+
+Scope the run to a single peer while paying down existing debt:
+
+```sh
+yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies --peers=react-dom,scheduler
+```
+
+## Checks
+
+| Check                     | Default | Description                                                                                                                  |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `incompatible-peer-range` | on      | The range we advertise accepts versions one of our own dependencies rejects (e.g. `>=16.8.0` onto `>=16.14.0`)               |
+| `invalid-peer-range`      | on      | A peer range is not a valid semver range                                                                                     |
+| `orphaned-peer-meta`      | on      | A `peerDependenciesMeta` entry has no matching `peerDependencies` entry                                                      |
+| `missing-peer-forward`    | off     | A dependency requires a non-optional peer that this package neither declares as a peer nor owns outright                     |
+| `unverified-peer-range`   | off     | A range was only checked against the installed copy, while the declared dependency range permits older, uninspected versions |
+
+Use `--checks=all` to include the opt-in checks, or pass an explicit comma separated list.
+
+### On `unverified-peer-range`
+
+Peer ranges are validated against the dependency manifest this workspace has installed. A consumer
+resolving the same declared range may legally get an older version with a narrower peer range, so a
+passing range check is only as strong as the gap between the declared floor and the installed
+version. This check reports that gap, without needing network access.
+
+Both peer bugs found while building this tool had exactly that shape - `@typescript-eslint/utils`
+(`^8.46.2` declared, `8.57.1` installed) and `use-sync-external-store` (`^1.2.0` declared, `1.6.0`
+installed). Closing the gap means raising the dependency floor to the version whose peer range you
+actually rely on.
+
+It is opt-in because it reports a limit on what can be verified offline rather than a defect, and
+closing it is a judgement call rather than a mechanical fix.
+
+Resolution rules applied:
+
+- **Only publishable packages are verified.** A private package is never installed by a consumer, so it has
+  no peer contract to honour, and it satisfies its own dependencies' peers from `devDependencies` at install
+  time. Private packages are still read, because publishable packages depend on them.
+- A peer is satisfied by `dependencies` (terminates the chain) or by `peerDependencies` (forwards it).
+  `devDependencies` never satisfy a published contract.
+- Peers marked `peerDependenciesMeta.<name>.optional` are exempt from forwarding, since they may be
+  absent. Their version constraint still applies when the peer **is** declared.
+- Only `missing-peer-forward` is auto-fixable, so `--fix` enables it even though it is not a default
+  check. Everything else reports a conflict that needs a human decision.
+
+> [!IMPORTANT]
+> Only mark a peer `optional` when the package can genuinely run without it. `optional` silences the
+> install warning but does **not** make the import resolvable — so for a peer that is actually imported it
+> converts a loud install-time warning into a silent runtime crash. It is appropriate for types-only peers
+> such as `@types/react`, and inappropriate for runtime peers such as `react`, `react-dom` or `scheduler`.
+
+## Options
+
+#### `project`
+
+Comma separated list of projects to verify, accepting either the nx project name (`react-dialog`) or the
+package name (`@fluentui/react-dialog`). Defaults to every publishable project. An unknown name is an
+error rather than a silent pass.
+
+#### `tag`
+
+Comma separated list of nx project tags to verify, e.g. `vNext`. Defaults to every tag. An unknown
+tag is an error rather than a silent pass. CI verifies `vNext` on every PR.
+
+#### `checks`
+
+Comma separated list of checks to run, or `all`. Defaults to every check except `missing-peer-forward`.
+
+#### `fix`
+
+Add every missing forwarded peer to the offending `package.json`, using the range required by the
+dependency. When several dependencies require different ranges the narrowest one is used; if no range
+contains all the others the conflict is reported instead of guessed.
+
+Forwarding cascades, so this runs to a fixpoint: adding a peer to one package creates the same
+requirement for its dependents.
+
+> [!NOTE] > `--fix` never throws, even when violations remain that it cannot fix automatically. Throwing from a
+> generator makes nx discard the whole tree, which would silently drop the fixes it just applied. Re-run
+> without `--fix` to get a failing exit code.
+
+#### `peers`
+
+Comma separated list of peer names to check. Defaults to all.

--- a/tools/workspace-plugin/src/generators/verify-peer-dependencies/index.spec.ts
+++ b/tools/workspace-plugin/src/generators/verify-peer-dependencies/index.spec.ts
@@ -1,0 +1,533 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration, readJson, writeJson } from '@nx/devkit';
+
+import generator from './index';
+import { PackageJson } from '../../types';
+
+describe('verify-peer-dependencies generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('missing-peer-forward (opt-in)', () => {
+    const checks = 'missing-peer-forward';
+
+    it('should fail when a package does not forward a peer required by its dependency', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'missing-peer-forward' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+
+    it('should pass when the peer is forwarded', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks })).resolves.toBeUndefined();
+    });
+
+    it('should pass when the peer is provided as a hard dependency, terminating the chain', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'app', {
+        dependencies: { '@proj/react-portal': '*', 'react-dom': '18.3.1' },
+      });
+
+      await expect(generator(tree, { checks })).resolves.toBeUndefined();
+    });
+
+    it('should ignore optional peers', async () => {
+      setupPackage(tree, 'react-portal', {
+        peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' },
+        peerDependenciesMeta: { 'react-dom': { optional: true } },
+      });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks })).resolves.toBeUndefined();
+    });
+
+    it('should not verify private packages', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'private-app', {
+        private: true,
+        dependencies: { '@proj/react-portal': '*' },
+      });
+
+      await expect(generator(tree, { checks })).resolves.toBeUndefined();
+    });
+
+    it('should reject devDependencies for publishable packages', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        devDependencies: { 'react-dom': '18.3.1' },
+      });
+
+      await expect(generator(tree, { checks })).rejects.toThrow('peer dependency violations found (1)');
+    });
+  });
+
+  describe('--project filter', () => {
+    it('should only verify the requested project', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+      setupPackage(tree, 'react-menu', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'all', project: 'react-dialog' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+
+    it('should accept a package name as well as a project name', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'all', project: '@proj/react-dialog' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+
+    it('should pass when the scoped project is clean even though others are not', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+      setupPackage(tree, 'react-menu', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks: 'all', project: 'react-menu' })).resolves.toBeUndefined();
+    });
+
+    it('should throw on an unknown project rather than silently verifying nothing', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+
+      await expect(generator(tree, { checks: 'all', project: 'does-not-exist' })).rejects.toThrow(
+        'Unknown project(s): does-not-exist',
+      );
+    });
+  });
+
+  describe('incompatible-peer-range', () => {
+    it('should detect a range unbounded below', async () => {
+      // `*` contributes no lower comparator, so probing only comparator versions would miss that
+      // it permits everything beneath the required floor
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '*' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should detect an upper-bounded range that is still unbounded below', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '<20.0.0' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should validate the range of an optional peer that this package declares', async () => {
+      // optional means the peer may be absent, not that its version constraint disappears
+      setupPackage(tree, 'react-portal', {
+        peerDependencies: { 'react-dom': '^18.0.0' },
+        peerDependenciesMeta: { 'react-dom': { optional: true } },
+      });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { 'react-dom': '^19.0.0' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should still not require forwarding of an optional peer', async () => {
+      setupPackage(tree, 'react-portal', {
+        peerDependencies: { 'react-dom': '^18.0.0' },
+        peerDependenciesMeta: { 'react-dom': { optional: true } },
+      });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'all' })).resolves.toBeUndefined();
+    });
+
+    it('should fail when the forwarded range is wider than what the dependency supports', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>=16.8.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should pass when the forwarded range is narrower than what the dependency supports', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.8.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+    });
+
+    it('should treat a union of carets as its combined range', async () => {
+      // `^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0` is exactly `>=16.8.0 <20.0.0`.
+      // semver.subset() reports this as a violation because it compares against each
+      // comparator set in isolation.
+      setupPackage(tree, 'use-sync-external-store-like', {
+        peerDependencies: { react: '^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0' },
+      });
+      setupPackage(tree, 'react-positioning', {
+        dependencies: { '@proj/use-sync-external-store-like': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+    });
+
+    it('should still detect a union of carets that stops short of the declared range', async () => {
+      // missing `^19.0.0`, so react 19 is promised but unsupported
+      setupPackage(tree, 'use-sync-external-store-like', {
+        peerDependencies: { react: '^16.8.0 || ^17.0.0 || ^18.0.0' },
+      });
+      setupPackage(tree, 'react-positioning', {
+        dependencies: { '@proj/use-sync-external-store-like': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should detect an exclusive lower bound that escapes the required range', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.15.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>16.14.0' },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+  });
+
+  describe('manifest validation', () => {
+    it('should fail on an invalid semver range', async () => {
+      setupPackage(tree, 'react-one', { peerDependencies: { react: 'not-a-range' } });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should fail on peerDependenciesMeta without a matching peerDependencies entry', async () => {
+      setupPackage(tree, 'react-one', {
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+        peerDependenciesMeta: { 'react-dom': { optional: true } },
+      });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+  });
+
+  describe('--peers filter', () => {
+    it('should only check the requested peers', async () => {
+      setupPackage(tree, 'react-portal', {
+        peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0', scheduler: '>=0.19.0' },
+      });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'all', peers: 'scheduler' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+  });
+
+  describe('--tag filter', () => {
+    it('should only verify projects carrying the tag', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } }, ['vNext']);
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } }, ['vNext']);
+      setupPackage(tree, 'legacy-thing', { dependencies: { '@proj/react-portal': '*' } }, ['v8']);
+
+      await expect(generator(tree, { checks: 'all', tag: 'vNext' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+
+    it('should pass when every violation sits outside the tag', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } }, ['vNext']);
+      setupPackage(tree, 'legacy-thing', { dependencies: { '@proj/react-portal': '*' } }, ['v8']);
+
+      await expect(generator(tree, { checks: 'all', tag: 'vNext' })).resolves.toBeUndefined();
+    });
+
+    it('should throw on an unknown tag rather than silently verifying nothing', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } }, ['vNext']);
+
+      await expect(generator(tree, { checks: 'all', tag: 'nope' })).rejects.toThrow('Unknown tag(s): nope');
+    });
+  });
+
+  describe('optional peer metadata', () => {
+    it('should not require forwarding of a peer marked optional by the dependency', async () => {
+      setupPackage(tree, 'react-utilities', {
+        peerDependencies: { '@types/react': '>=16.14.0 <20.0.0', react: '>=16.14.0 <20.0.0' },
+        peerDependenciesMeta: { '@types/react': { optional: true } },
+      });
+      setupPackage(tree, 'react-button', {
+        dependencies: { '@proj/react-utilities': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('default checks', () => {
+    it('should not report missing-peer-forward by default', async () => {
+      // hoisted and isolated-mode installers resolve the peer from the nearest ancestor that
+      // provides it, so forwarding is only required under Yarn PnP strict
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+    });
+
+    it('should still report the installer-independent checks by default', async () => {
+      setupPackage(tree, 'react-one', { peerDependencies: { react: 'not-a-range' } });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should report missing-peer-forward when explicitly requested', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await expect(generator(tree, { checks: 'all' })).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should throw on an unknown check', async () => {
+      setupPackage(tree, 'react-one', {});
+
+      await expect(generator(tree, { checks: 'nonsense' })).rejects.toThrow('Unknown check(s): nonsense');
+    });
+  });
+
+  describe('--verbose', () => {
+    // nx strips `--verbose` from the generator schema but sets NX_VERBOSE_LOGGING, which is what
+    // logger.verbose is gated on
+    beforeEach(() => {
+      process.env.NX_VERBOSE_LOGGING = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.NX_VERBOSE_LOGGING;
+    });
+
+    it('should report what was verified and what was skipped', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+      setupPackage(tree, 'private-app', { private: true, dependencies: { '@proj/react-portal': '*' } });
+
+      const log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+
+      const output = log.mock.calls.flat().join('\n');
+
+      expect(output).toContain('scope');
+      expect(output).toContain('skipped');
+      expect(output).toContain('private');
+      expect(output).toContain('@proj/react-dialog');
+      expect(output).toContain('required by @proj/react-portal');
+      expect(output).toContain('peer requirement(s) checked');
+    });
+
+    it('should not change the outcome', async () => {
+      setupPackage(tree, 'react-one', { peerDependencies: { react: 'not-a-range' } });
+
+      await expect(generator(tree)).rejects.toThrow('peer dependency violations found (1)');
+    });
+
+    it('should stay silent without NX_VERBOSE_LOGGING', async () => {
+      delete process.env.NX_VERBOSE_LOGGING;
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+
+      const log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await generator(tree);
+
+      expect(log.mock.calls.flat().join('\n')).not.toContain('peer requirement(s) checked');
+    });
+  });
+
+  describe('unverified-peer-range', () => {
+    it('should be off by default', async () => {
+      setupPackage(tree, 'react-one', {
+        dependencies: { 'external-dep': '^1.0.0' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+      writeJson(tree, 'node_modules/external-dep/package.json', {
+        name: 'external-dep',
+        version: '1.5.0',
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree)).resolves.toBeUndefined();
+    });
+
+    it('should report when the declared range permits a version that was not inspected', async () => {
+      setupPackage(tree, 'react-one', {
+        dependencies: { 'external-dep': '^1.0.0' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+      writeJson(tree, 'node_modules/external-dep/package.json', {
+        name: 'external-dep',
+        version: '1.5.0',
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks: 'unverified-peer-range' })).rejects.toThrow(
+        'peer dependency violations found (1)',
+      );
+    });
+
+    it('should stay silent when the declared floor is the inspected version', async () => {
+      setupPackage(tree, 'react-one', {
+        dependencies: { 'external-dep': '1.5.0' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+      writeJson(tree, 'node_modules/external-dep/package.json', {
+        name: 'external-dep',
+        version: '1.5.0',
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks: 'unverified-peer-range' })).resolves.toBeUndefined();
+    });
+
+    it('should not apply to workspace dependencies', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { react: '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '^9.0.0' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks: 'unverified-peer-range' })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('--fix', () => {
+    it('should enable missing-peer-forward even though it is not a default check', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      const { readPackageJson } = setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+      });
+
+      await generator(tree, { fix: true });
+
+      expect(readPackageJson().peerDependencies).toEqual({ 'react-dom': '>=16.14.0 <20.0.0' });
+    });
+    it('should add the missing peer using the range required by the dependency', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      const { readPackageJson } = setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>=16.14.0 <20.0.0' },
+      });
+
+      await generator(tree, { checks: 'all', fix: true });
+
+      expect(readPackageJson().peerDependencies).toEqual({
+        react: '>=16.14.0 <20.0.0',
+        'react-dom': '>=16.14.0 <20.0.0',
+      });
+    });
+
+    it('should pick the narrowest range when dependencies disagree', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.8.0 <20.0.0' } });
+      setupPackage(tree, 'react-combobox', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      const { readPackageJson } = setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*', '@proj/react-combobox': '*' },
+      });
+
+      await generator(tree, { checks: 'all', fix: true });
+
+      expect(readPackageJson().peerDependencies).toEqual({ 'react-dom': '>=16.14.0 <20.0.0' });
+    });
+
+    it('should be idempotent', async () => {
+      setupPackage(tree, 'react-portal', { peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-portal': '*' } });
+
+      await generator(tree, { checks: 'all', fix: true });
+      await expect(generator(tree, { checks: 'all' })).resolves.toBeUndefined();
+    });
+
+    it('should persist fixes even when unfixable violations remain', async () => {
+      // an incompatible range cannot be auto-fixed; the missing forward still must be written
+      setupPackage(tree, 'react-portal', {
+        peerDependencies: { 'react-dom': '>=16.14.0 <20.0.0', react: '>=16.14.0 <20.0.0' },
+      });
+      const { readPackageJson } = setupPackage(tree, 'react-dialog', {
+        dependencies: { '@proj/react-portal': '*' },
+        peerDependencies: { react: '>=16.8.0 <20.0.0' },
+      });
+
+      await expect(generator(tree, { checks: 'all', fix: true })).resolves.toBeUndefined();
+
+      expect(readPackageJson().peerDependencies).toEqual({
+        react: '>=16.8.0 <20.0.0',
+        'react-dom': '>=16.14.0 <20.0.0',
+      });
+    });
+
+    it('should resolve a cascading chain in a single run', async () => {
+      // scheduler originates in the leaf and has to reach the top of the chain
+      setupPackage(tree, 'react-context-selector', { peerDependencies: { scheduler: '>=0.19.0' } });
+      setupPackage(tree, 'react-menu', { dependencies: { '@proj/react-context-selector': '*' } });
+      setupPackage(tree, 'react-dialog', { dependencies: { '@proj/react-menu': '*' } });
+      const { readPackageJson } = setupPackage(tree, 'react-components', {
+        dependencies: { '@proj/react-dialog': '*' },
+      });
+
+      await generator(tree, { checks: 'all', fix: true });
+
+      expect(readPackageJson().peerDependencies).toEqual({ scheduler: '>=0.19.0' });
+      await expect(generator(tree, { checks: 'all' })).resolves.toBeUndefined();
+    });
+  });
+});
+
+function setupPackage(tree: Tree, name: string, packageJson: Partial<PackageJson>, tags: string[] = []) {
+  const root = `packages/${name}`;
+
+  addProjectConfiguration(tree, name, { root, projectType: 'library', tags });
+
+  const packageJsonPath = `${root}/package.json`;
+
+  writeJson<Partial<PackageJson>>(tree, packageJsonPath, {
+    name: `@proj/${name}`,
+    version: '9.0.0',
+    ...packageJson,
+  });
+
+  return {
+    readPackageJson: () => readJson<PackageJson>(tree, packageJsonPath),
+  };
+}

--- a/tools/workspace-plugin/src/generators/verify-peer-dependencies/index.ts
+++ b/tools/workspace-plugin/src/generators/verify-peer-dependencies/index.ts
@@ -1,0 +1,859 @@
+import { Tree, formatFiles, getProjects, joinPathFragments, logger, readJson, updateJson } from '@nx/devkit';
+import chalk from 'chalk';
+import semver from 'semver';
+
+import type { PackageJson } from '../../types';
+import { PeerDependencyCheck, VerifyPeerDependenciesGeneratorSchema } from './schema';
+
+type ViolationKind = PeerDependencyCheck;
+
+const ALL_CHECKS: ViolationKind[] = [
+  'missing-peer-forward',
+  'incompatible-peer-range',
+  'invalid-peer-range',
+  'orphaned-peer-meta',
+  'unverified-peer-range',
+];
+
+/**
+ * `missing-peer-forward` is opt-in. Hoisted (npm/yarn classic) and isolated-mode installers
+ * (pnpm, midgard-yarn-strict) resolve a peer from the nearest ancestor that provides it, and
+ * isolated mode additionally propagates peer metadata up the graph on its own, so re-declaring a
+ * dependency's peer is a no-op there. It is only required under Yarn PnP strict resolution, and
+ * declaring peers a package never imports actively costs something: the peer set is part of a
+ * package's virtual instance key, and consumers are asked to satisfy a module that is never loaded.
+ */
+/**
+ * `unverified-peer-range` is opt-in for a different reason: it reports a gap in what we are able
+ * to verify offline rather than a defect, and closing it means either raising a dependency floor
+ * or accepting the risk - both judgement calls rather than mechanical fixes.
+ */
+const OPT_IN_CHECKS: ViolationKind[] = ['missing-peer-forward', 'unverified-peer-range'];
+
+const DEFAULT_CHECKS: ViolationKind[] = ALL_CHECKS.filter(check => !OPT_IN_CHECKS.includes(check));
+
+interface Violation {
+  kind: ViolationKind;
+  /** package that owns the problem */
+  packageName: string;
+  packageJsonPath: string;
+  /** the peer dependency name */
+  peer: string;
+  /** dependency that requires the peer (missing-peer-forward / incompatible-peer-range only) */
+  requiredBy?: string;
+  /** range required by `requiredBy` */
+  requiredRange?: string;
+  /** range currently declared by `packageName` */
+  declaredRange?: string;
+  /** version of `requiredBy` whose manifest was actually consulted */
+  inspectedVersion?: string;
+  /** lowest version the dependency range permits, when it differs from `inspectedVersion` */
+  lowestPermittedVersion?: string;
+}
+
+/**
+ * Records what the run actually looked at. Without it a clean result is ambiguous: nothing to
+ * report and nothing verified look identical.
+ */
+interface Trace {
+  skipped: Array<{ packageName: string; reason: string }>;
+  verified: Array<{
+    packageName: string;
+    packageJsonPath: string;
+    declared: string[];
+    requirements: Array<{ peer: string; requiredBy: string; requiredRange: string; verdict: string }>;
+  }>;
+  /** dependency name -> packages that depend on it */
+  unresolved: Map<string, Set<string>>;
+  skippedRequirements: { optional: number; filtered: number; ownDependency: number };
+}
+
+function createTrace(): Trace {
+  return {
+    skipped: [],
+    verified: [],
+    unresolved: new Map(),
+    skippedRequirements: { optional: 0, filtered: 0, ownDependency: 0 },
+  };
+}
+
+interface PackageEntry {
+  packageJson: PackageJson;
+  packageJsonPath: string;
+  /** nx project name, absent for the workspace root package.json */
+  projectName?: string;
+  /** nx project tags, e.g. `vNext` / `v8` */
+  tags: string[];
+  /** published to npm - only publishable packages carry a peer contract worth verifying */
+  publishable: boolean;
+}
+
+/**
+ * Ranges that carry no semver meaning for a published consumer, so they are skipped
+ * during compatibility math.
+ */
+/**
+ * Protocol ranges carry no semver meaning, so version math cannot say anything about them.
+ * `*` is deliberately not listed: it is a valid semver range, and as a peer range it is a real
+ * (maximally broad) claim that should be validated like any other.
+ */
+const NON_SEMVER_RANGE = /^(workspace:|portal:|link:|file:|npm:|patch:)/;
+
+/**
+ * Forwarding cascades - adding a peer to a package creates the same requirement for its
+ * dependents - so `--fix` runs to a fixpoint. The bound only guards against a pathological
+ * graph; in practice this settles in a handful of passes.
+ */
+const MAX_FIX_PASSES = 20;
+
+/**
+ * `--verbose` is an nx global flag: nx strips it from the generator schema but sets
+ * `NX_VERBOSE_LOGGING`, which is exactly what `logger.verbose` is gated on. Tracing is therefore
+ * built whenever that env var is set, and `logger.verbose` decides whether it is printed.
+ */
+function isVerbose() {
+  return process.env.NX_VERBOSE_LOGGING === 'true';
+}
+
+export default async function (tree: Tree, schema: VerifyPeerDependenciesGeneratorSchema = {}) {
+  const verbose = isVerbose();
+  const peerFilter = toFilter(schema.peers);
+  const projectFilter = toFilter(schema.project);
+  const tagFilter = toFilter(schema.tag);
+  // `--fix` can only repair missing-peer-forward, which is not a default check, so a bare
+  // `--fix` would otherwise collect nothing and silently change nothing.
+  const checks = resolveChecks(schema.checks, { fix: Boolean(schema.fix) });
+
+  if (projectFilter || tagFilter) {
+    assertFiltersMatch({ packages: readWorkspacePackages(tree), projectFilter, tagFilter });
+  }
+
+  const verify = (trace: Trace | null = null) => {
+    const packages = readWorkspacePackages(tree);
+
+    return {
+      packages,
+      violations: collectViolations(tree, { packages, peerFilter, projectFilter, tagFilter, checks, trace }),
+    };
+  };
+
+  if (schema.fix) {
+    let fixedCount = 0;
+
+    for (let pass = 0; pass < MAX_FIX_PASSES; pass++) {
+      const { packages, violations } = verify();
+      const fixed = applyFixes(tree, { packages, violations });
+
+      if (fixed.size === 0) {
+        break;
+      }
+
+      fixedCount += fixed.size;
+    }
+
+    await formatFiles(tree);
+
+    const trace = verbose ? createTrace() : null;
+    const { violations } = verify(trace);
+
+    if (trace) {
+      reportTrace(trace, checks);
+    }
+
+    report(violations, { fixedCount, throwOnViolations: false });
+
+    return;
+  }
+
+  const trace = verbose ? createTrace() : null;
+  const { violations } = verify(trace);
+
+  if (trace) {
+    reportTrace(trace, checks);
+  }
+
+  report(violations, { fixedCount: 0, throwOnViolations: true });
+}
+
+const FIXABLE_CHECKS: ViolationKind[] = ['missing-peer-forward'];
+
+function resolveChecks(value: string | undefined, options: { fix: boolean } = { fix: false }): Set<ViolationKind> {
+  if (!value) {
+    return new Set(options.fix ? [...DEFAULT_CHECKS, ...FIXABLE_CHECKS] : DEFAULT_CHECKS);
+  }
+
+  const requested = value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+  if (requested.includes('all')) {
+    return new Set(ALL_CHECKS);
+  }
+
+  const unknown = requested.filter(check => !ALL_CHECKS.includes(check as ViolationKind));
+
+  if (unknown.length > 0) {
+    throw new Error(`Unknown check(s): ${unknown.join(', ')}. Known checks: ${ALL_CHECKS.join(', ')}, all`);
+  }
+
+  const resolved = new Set(requested as ViolationKind[]);
+
+  if (options.fix) {
+    FIXABLE_CHECKS.forEach(check => resolved.add(check));
+  }
+
+  return resolved;
+}
+
+function toFilter(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const values = value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+  return values.length > 0 ? new Set(values) : null;
+}
+
+/**
+ * A project name that matches nothing would silently verify nothing, which reads as a pass.
+ */
+function assertFiltersMatch(options: {
+  packages: Map<string, PackageEntry>;
+  projectFilter: Set<string> | null;
+  tagFilter: Set<string> | null;
+}) {
+  const { packages, projectFilter, tagFilter } = options;
+  const knownProjects = new Set<string>();
+  const knownTags = new Set<string>();
+
+  for (const [packageName, entry] of packages) {
+    knownProjects.add(packageName);
+
+    if (entry.projectName) {
+      knownProjects.add(entry.projectName);
+    }
+
+    entry.tags.forEach(tag => knownTags.add(tag));
+  }
+
+  const unknownProjects = [...(projectFilter ?? [])].filter(name => !knownProjects.has(name));
+
+  if (unknownProjects.length > 0) {
+    throw new Error(`Unknown project(s): ${unknownProjects.join(', ')}`);
+  }
+
+  const unknownTags = [...(tagFilter ?? [])].filter(tag => !knownTags.has(tag));
+
+  if (unknownTags.length > 0) {
+    throw new Error(`Unknown tag(s): ${unknownTags.join(', ')}`);
+  }
+}
+
+function readWorkspacePackages(tree: Tree) {
+  const packages = new Map<string, PackageEntry>();
+
+  const register = (packageJsonPath: string, options: { projectName?: string; tags?: string[] } = {}) => {
+    if (!tree.exists(packageJsonPath)) {
+      return;
+    }
+
+    const packageJson = readJson<PackageJson>(tree, packageJsonPath);
+
+    if (!packageJson.name) {
+      return;
+    }
+
+    packages.set(packageJson.name, {
+      packageJson,
+      packageJsonPath,
+      projectName: options.projectName,
+      tags: options.tags ?? [],
+      publishable: !packageJson.private,
+    });
+  };
+
+  getProjects(tree).forEach((project, projectName) =>
+    register(joinPathFragments(project.root, 'package.json'), { projectName, tags: project.tags ?? [] }),
+  );
+  register('package.json');
+
+  return packages;
+}
+
+/**
+ * Peers of a dependency. Workspace packages are read from the tree, everything else from
+ * the installed node_modules copy. A dependency that cannot be resolved is skipped rather
+ * than reported, so the generator stays usable before `yarn install`.
+ */
+function getDependencyManifest(
+  tree: Tree,
+  options: { packages: Map<string, PackageEntry>; dependencyName: string },
+): { manifest: PackageJson; isWorkspace: boolean } | null {
+  const { packages, dependencyName } = options;
+  const workspacePackage = packages.get(dependencyName);
+
+  if (workspacePackage) {
+    return { manifest: workspacePackage.packageJson, isWorkspace: true };
+  }
+
+  const externalPackageJsonPath = `node_modules/${dependencyName}/package.json`;
+
+  return tree.exists(externalPackageJsonPath)
+    ? { manifest: readJson<PackageJson>(tree, externalPackageJsonPath), isWorkspace: false }
+    : null;
+}
+
+/**
+ * The manifest we can read offline is whichever version this workspace happens to have installed.
+ * A consumer resolving the same declared range may legally get an older version with a narrower
+ * peer range, so a range check against the installed copy is only as strong as the gap between
+ * the two.
+ */
+function getUnverifiedFloor(options: { declaredDependencyRange: string; inspectedVersion: string }) {
+  const { declaredDependencyRange, inspectedVersion } = options;
+
+  if (NON_SEMVER_RANGE.test(declaredDependencyRange) || semver.validRange(declaredDependencyRange) === null) {
+    return null;
+  }
+
+  const lowest = semver.minVersion(declaredDependencyRange);
+
+  if (!lowest || !semver.valid(inspectedVersion) || lowest.version === inspectedVersion) {
+    return null;
+  }
+
+  return lowest.version;
+}
+
+function collectViolations(
+  tree: Tree,
+  options: {
+    packages: Map<string, PackageEntry>;
+    peerFilter: Set<string> | null;
+    projectFilter: Set<string> | null;
+    tagFilter: Set<string> | null;
+    checks: Set<ViolationKind>;
+    trace: Trace | null;
+  },
+) {
+  const { packages, peerFilter, projectFilter, tagFilter, checks, trace } = options;
+  const violations: Violation[] = [];
+  const isChecked = (peer: string) => !peerFilter || peerFilter.has(peer);
+
+  for (const [packageName, entry] of packages) {
+    const skipReason = getSkipReason({ packageName, entry, projectFilter, tagFilter });
+
+    if (skipReason) {
+      trace?.skipped.push({ packageName, reason: skipReason });
+      continue;
+    }
+
+    const { packageJson, packageJsonPath } = entry;
+    const traced: Trace['verified'][number] = {
+      packageName,
+      packageJsonPath,
+      declared: Object.keys(packageJson.peerDependencies ?? {}),
+      requirements: [],
+    };
+    trace?.verified.push(traced);
+
+    violations.push(...getManifestViolations({ packageName, packageJsonPath, packageJson, isChecked, checks }));
+
+    for (const [dependencyName, declaredDependencyRange] of Object.entries(packageJson.dependencies ?? {})) {
+      const resolvedDependency = getDependencyManifest(tree, { packages, dependencyName });
+
+      if (!resolvedDependency) {
+        if (trace) {
+          const dependents = trace.unresolved.get(dependencyName) ?? new Set<string>();
+          dependents.add(packageName);
+          trace.unresolved.set(dependencyName, dependents);
+        }
+
+        continue;
+      }
+
+      const dependencyManifest = resolvedDependency.manifest;
+      const unverifiedFloor = resolvedDependency.isWorkspace
+        ? null
+        : getUnverifiedFloor({ declaredDependencyRange, inspectedVersion: dependencyManifest.version });
+
+      for (const [peer, requiredRange] of Object.entries(dependencyManifest.peerDependencies ?? {})) {
+        if (!isChecked(peer)) {
+          if (trace) {
+            trace.skippedRequirements.filtered++;
+          }
+
+          continue;
+        }
+
+        // `optional` means the peer may be absent, not that its version constraint disappears.
+        // When this package does declare the peer, the range still has to be compatible.
+        const isOptional = Boolean(dependencyManifest.peerDependenciesMeta?.[peer]?.optional);
+        const declaredRange = packageJson.peerDependencies?.[peer];
+
+        if (isOptional && !declaredRange) {
+          if (trace) {
+            trace.skippedRequirements.optional++;
+          }
+
+          continue;
+        }
+
+        // `dependencies` terminates the chain, `peerDependencies` forwards it. `devDependencies`
+        // are never installed for consumers, so they cannot satisfy a published contract.
+        if (packageJson.dependencies?.[peer]) {
+          if (trace) {
+            trace.skippedRequirements.ownDependency++;
+          }
+
+          continue;
+        }
+
+        traced.requirements.push({
+          peer,
+          requiredBy: dependencyName,
+          requiredRange,
+          verdict: !declaredRange
+            ? 'not declared'
+            : isRangeCompatible(declaredRange, requiredRange)
+            ? `satisfied by peer '${declaredRange}'`
+            : `INCOMPATIBLE with peer '${declaredRange}'`,
+        });
+
+        if (!declaredRange) {
+          if (checks.has('missing-peer-forward')) {
+            violations.push({
+              kind: 'missing-peer-forward',
+              packageName,
+              packageJsonPath,
+              peer,
+              requiredBy: dependencyName,
+              requiredRange,
+            });
+          }
+
+          continue;
+        }
+
+        if (checks.has('incompatible-peer-range') && !isRangeCompatible(declaredRange, requiredRange)) {
+          violations.push({
+            kind: 'incompatible-peer-range',
+            packageName,
+            packageJsonPath,
+            peer,
+            requiredBy: dependencyName,
+            requiredRange,
+            declaredRange,
+            inspectedVersion: dependencyManifest.version,
+          });
+
+          continue;
+        }
+
+        // The range check above only proves compatibility with the installed copy.
+        if (checks.has('unverified-peer-range') && unverifiedFloor) {
+          violations.push({
+            kind: 'unverified-peer-range',
+            packageName,
+            packageJsonPath,
+            peer,
+            requiredBy: dependencyName,
+            requiredRange,
+            declaredRange,
+            inspectedVersion: dependencyManifest.version,
+            lowestPermittedVersion: unverifiedFloor,
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Only publishable packages are verified: a private package is never installed by a consumer,
+ * so it has no peer contract to honour and satisfies its own dependencies' peers from
+ * devDependencies at install time.
+ */
+function getSkipReason(options: {
+  packageName: string;
+  entry: PackageEntry;
+  projectFilter: Set<string> | null;
+  tagFilter: Set<string> | null;
+}): string | null {
+  const { packageName, entry, projectFilter, tagFilter } = options;
+
+  if (!entry.publishable) {
+    return 'private';
+  }
+
+  if (tagFilter && !entry.tags.some(tag => tagFilter.has(tag))) {
+    return 'outside --tag';
+  }
+
+  if (
+    projectFilter &&
+    !(projectFilter.has(packageName) || (entry.projectName && projectFilter.has(entry.projectName)))
+  ) {
+    return 'outside --project';
+  }
+
+  return null;
+}
+
+function getManifestViolations(options: {
+  packageName: string;
+  packageJsonPath: string;
+  packageJson: PackageJson;
+  isChecked: (peer: string) => boolean;
+  checks: Set<ViolationKind>;
+}) {
+  const { packageName, packageJsonPath, packageJson, isChecked, checks } = options;
+  const violations: Violation[] = [];
+  const peerDependencies = packageJson.peerDependencies ?? {};
+
+  for (const [peer, range] of Object.entries(peerDependencies)) {
+    if (!isChecked(peer) || NON_SEMVER_RANGE.test(range)) {
+      continue;
+    }
+
+    if (checks.has('invalid-peer-range') && semver.validRange(range) === null) {
+      violations.push({ kind: 'invalid-peer-range', packageName, packageJsonPath, peer, declaredRange: range });
+    }
+  }
+
+  for (const peer of Object.keys(packageJson.peerDependenciesMeta ?? {})) {
+    if (checks.has('orphaned-peer-meta') && isChecked(peer) && !peerDependencies[peer]) {
+      violations.push({ kind: 'orphaned-peer-meta', packageName, packageJsonPath, peer });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Boundary versions of every comparator in a range, i.e. the points where membership can flip.
+ */
+function getRangeBoundaries(range: string) {
+  const boundaries = new Set<string>();
+
+  try {
+    for (const comparators of new semver.Range(range).set) {
+      for (const comparator of comparators) {
+        const version = comparator.semver?.version;
+
+        if (version) {
+          boundaries.add(version);
+        }
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return [...boundaries];
+}
+
+/**
+ * `semver.subset` reports a false negative when the dominant range is a union of carets such
+ * as `^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0`: it tests containment against each comparator
+ * set individually rather than against their union, so a range spanning several carets looks
+ * unsupported even though the union covers it.
+ *
+ * Probing boundaries is union-safe and deterministic. Both ranges are unions of intervals whose
+ * endpoints are comparator versions, so whenever `sub` is not contained in `dom` a witness
+ * version exists at - or immediately above - one of those endpoints.
+ */
+function isSubset(sub: string, dom: string) {
+  const probes = new Set<string>();
+
+  // Comparator versions alone miss ranges that are unbounded below - `*` and `<20.0.0` contribute
+  // no lower boundary, so nothing would probe beneath the dominant range's floor.
+  const lowest = semver.minVersion(sub);
+
+  if (lowest) {
+    probes.add(lowest.version);
+  }
+
+  for (const range of [sub, dom]) {
+    for (const boundary of getRangeBoundaries(range)) {
+      probes.add(boundary);
+
+      const justAbove = semver.inc(boundary, 'patch');
+
+      if (justAbove) {
+        probes.add(justAbove);
+      }
+    }
+  }
+
+  for (const probe of probes) {
+    if (semver.satisfies(probe, sub) && !semver.satisfies(probe, dom)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * A peer range is a promise to consumers: "install any version in here and I work". It is only
+ * honest when every version it accepts is also accepted by our own dependencies, otherwise a
+ * consumer can follow the contract exactly and still end up with a version one of our
+ * dependencies rejects.
+ *
+ * Unlike `missing-peer-forward` this is installer-independent - it is version math, not
+ * resolution mechanics.
+ */
+function isRangeCompatible(declaredRange: string, requiredRange: string) {
+  if (NON_SEMVER_RANGE.test(declaredRange) || NON_SEMVER_RANGE.test(requiredRange)) {
+    return true;
+  }
+
+  if (semver.validRange(declaredRange) === null || semver.validRange(requiredRange) === null) {
+    return true;
+  }
+
+  return isSubset(declaredRange, requiredRange);
+}
+
+function applyFixes(tree: Tree, options: { packages: Map<string, PackageEntry>; violations: Violation[] }) {
+  const { packages, violations } = options;
+  const fixed = new Set<Violation>();
+  const fixable = violations.filter(violation => violation.kind === 'missing-peer-forward');
+  const byPackage = new Map<string, Violation[]>();
+
+  for (const violation of fixable) {
+    byPackage.set(violation.packageName, (byPackage.get(violation.packageName) ?? []).concat(violation));
+  }
+
+  for (const [packageName, packageViolations] of byPackage) {
+    const entry = packages.get(packageName);
+
+    if (!entry) {
+      continue;
+    }
+
+    const resolved = new Map<string, string>();
+
+    for (const [peer, peerViolations] of groupBy(packageViolations, violation => violation.peer)) {
+      const range = getNarrowestRange(peerViolations.map(violation => violation.requiredRange!));
+
+      if (range === null) {
+        logger.warn(
+          `[${packageName}] cannot auto-fix '${peer}': dependencies require mutually exclusive ranges ` +
+            `(${peerViolations.map(violation => violation.requiredRange).join(', ')}). Resolve manually.`,
+        );
+        continue;
+      }
+
+      resolved.set(peer, range);
+      peerViolations.forEach(violation => fixed.add(violation));
+    }
+
+    if (resolved.size === 0) {
+      continue;
+    }
+
+    updateJson<PackageJson>(tree, entry.packageJsonPath, json => {
+      const peerDependencies = { ...(json.peerDependencies ?? {}) };
+
+      for (const [peer, range] of resolved) {
+        peerDependencies[peer] = range;
+      }
+
+      json.peerDependencies = sortKeys(peerDependencies);
+
+      return json;
+    });
+  }
+
+  return fixed;
+}
+
+/**
+ * Picks the range that every other candidate contains, so the forwarded range never
+ * promises more than the strictest dependency allows. Returns `null` when no candidate
+ * dominates - that needs a human.
+ */
+function getNarrowestRange(ranges: string[]) {
+  const unique = [...new Set(ranges)];
+
+  if (unique.length === 1) {
+    return unique[0];
+  }
+
+  return (
+    unique.find(candidate =>
+      unique.every(other =>
+        semver.validRange(candidate) && semver.validRange(other) ? isSubset(candidate, other) : candidate === other,
+      ),
+    ) ?? null
+  );
+}
+
+function groupBy<T>(items: T[], getKey: (item: T) => string) {
+  const result = new Map<string, T[]>();
+
+  for (const item of items) {
+    const key = getKey(item);
+    result.set(key, (result.get(key) ?? []).concat(item));
+  }
+
+  return result;
+}
+
+function sortKeys(record: Record<string, string>) {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function reportTrace(trace: Trace, checks: Set<ViolationKind>) {
+  const requirementCount = trace.verified.reduce((total, entry) => total + entry.requirements.length, 0);
+  const skippedByReason = groupBy(trace.skipped, item => item.reason);
+
+  logger.verbose(chalk.bold('\nscope'));
+  logger.verbose(`  checks   ${[...checks].join(', ')}`);
+  logger.verbose(
+    `  packages ${trace.verified.length} verified, ${trace.skipped.length} skipped` +
+      (trace.skipped.length
+        ? chalk.grey(` (${[...skippedByReason].map(([reason, items]) => `${items.length} ${reason}`).join(', ')})`)
+        : ''),
+  );
+
+  for (const entry of trace.verified) {
+    logger.verbose('');
+    logger.verbose(chalk.bold(entry.packageName) + chalk.grey(` ${entry.packageJsonPath}`));
+    logger.verbose(
+      `  declares ${entry.declared.length ? entry.declared.join(', ') : chalk.grey('(no peer dependencies)')}`,
+    );
+
+    if (entry.requirements.length === 0) {
+      logger.verbose(chalk.grey('  no peer requirements from dependencies'));
+      continue;
+    }
+
+    for (const requirement of entry.requirements) {
+      const verdict = requirement.verdict.startsWith('INCOMPATIBLE')
+        ? chalk.red(requirement.verdict)
+        : requirement.verdict === 'not declared'
+        ? chalk.yellow(requirement.verdict)
+        : chalk.green(requirement.verdict);
+
+      logger.verbose(
+        `  ${requirement.peer} ${chalk.grey(
+          `'${requirement.requiredRange}' required by ${requirement.requiredBy}`,
+        )} -> ${verdict}`,
+      );
+    }
+  }
+
+  if (trace.unresolved.size > 0) {
+    logger.verbose(chalk.bold('\nunresolved dependencies') + chalk.grey(' (not installed, peers unknown - skipped)'));
+
+    for (const [dependencyName, dependents] of [...trace.unresolved].sort()) {
+      logger.verbose(chalk.grey(`  ${dependencyName} (required by ${dependents.size} package(s))`));
+    }
+  }
+
+  const { optional, filtered, ownDependency } = trace.skippedRequirements;
+
+  logger.verbose(chalk.bold('\ntotals'));
+  logger.verbose(`  ${requirementCount} peer requirement(s) checked across ${trace.verified.length} package(s)`);
+  logger.verbose(
+    chalk.grey(
+      `  skipped: ${optional} optional, ${ownDependency} provided as own dependency, ${filtered} outside --peers`,
+    ),
+  );
+}
+
+const VIOLATION_DESCRIPTIONS: Record<ViolationKind, string> = {
+  'missing-peer-forward':
+    'under Yarn PnP strict a package must re-declare every non-optional peer its dependencies require',
+  'incompatible-peer-range': 'the range we advertise to consumers accepts versions one of our own dependencies rejects',
+  'invalid-peer-range': 'peer dependency range is not a valid semver range',
+  'orphaned-peer-meta': 'peerDependenciesMeta entry has no matching peerDependencies entry',
+  'unverified-peer-range':
+    'the range was only checked against the installed copy; the declared dependency range permits older versions that were not inspected',
+};
+
+function report(violations: Violation[], options: { fixedCount: number; throwOnViolations: boolean }) {
+  if (options.fixedCount > 0) {
+    logger.info(chalk.green(`✔ fixed ${options.fixedCount} missing peer dependency forward(s)`));
+  }
+
+  if (violations.length === 0) {
+    logger.info(chalk.green('✔ no peer dependency violations found'));
+    return;
+  }
+
+  for (const [kind, kindViolations] of groupBy(violations, violation => violation.kind)) {
+    logger.log('');
+    logger.log(chalk.red.bold(`${kind} (${kindViolations.length})`));
+    logger.log(chalk.grey(`  ${VIOLATION_DESCRIPTIONS[kind as ViolationKind]}`));
+
+    for (const violation of [...kindViolations].sort((a, b) => a.packageName.localeCompare(b.packageName))) {
+      logger.log(chalk.red(`  ✘ ${violation.packageName}`) + chalk.grey(` (${violation.packageJsonPath})`));
+
+      switch (violation.kind) {
+        case 'missing-peer-forward':
+          logger.log(
+            `      must declare peerDependencies['${violation.peer}'] ` +
+              chalk.grey(`- required by ${violation.requiredBy} as '${violation.requiredRange}'`),
+          );
+          break;
+        case 'incompatible-peer-range':
+          logger.log(
+            `      declares '${violation.peer}': '${violation.declaredRange}' ` +
+              chalk.grey(
+                `but ${violation.requiredBy}@${violation.inspectedVersion ?? 'workspace'} requires '${
+                  violation.requiredRange
+                }'`,
+              ),
+          );
+          break;
+        case 'invalid-peer-range':
+          logger.log(`      '${violation.peer}': '${violation.declaredRange}' is not a valid semver range`);
+          break;
+        case 'unverified-peer-range':
+          logger.log(
+            `      '${violation.peer}': '${violation.declaredRange}' checked against ${violation.requiredBy}@${violation.inspectedVersion} ` +
+              chalk.grey(
+                `but the declared range also permits ${violation.requiredBy}@${violation.lowestPermittedVersion}`,
+              ),
+          );
+          break;
+        case 'orphaned-peer-meta':
+          logger.log(`      peerDependenciesMeta['${violation.peer}'] has no peerDependencies['${violation.peer}']`);
+          break;
+      }
+    }
+  }
+
+  logger.log('');
+
+  // Only missing-peer-forward is auto-fixable; promising `--fix` for anything else sends people
+  // to a command that cannot help them.
+  if (violations.some(violation => FIXABLE_CHECKS.includes(violation.kind))) {
+    logger.info(`🛠️ FIX: run 'nx g @fluentui/workspace-plugin:verify-peer-dependencies --fix'`);
+  } else {
+    logger.info(`🛠️ These violations need a manual decision - '--fix' cannot resolve them.`);
+  }
+
+  // Throwing from a generator makes nx discard the whole tree, so in --fix mode the applied
+  // fixes must be allowed to flush. Re-run in verify mode to get a failing exit code.
+  if (!options.throwOnViolations) {
+    logger.warn(
+      chalk.yellow(`${violations.length} violation(s) could not be fixed automatically and need manual attention`),
+    );
+
+    return;
+  }
+
+  throw new Error(`peer dependency violations found (${violations.length})`);
+}

--- a/tools/workspace-plugin/src/generators/verify-peer-dependencies/schema.json
+++ b/tools/workspace-plugin/src/generators/verify-peer-dependencies/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "id": "verify-peer-dependencies",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Comma separated list of projects to verify. Defaults to every publishable project.",
+      "x-dropdown": "projects",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "tag": {
+      "type": "string",
+      "description": "Comma separated list of nx project tags to verify, e.g. `vNext`. Defaults to every tag."
+    },
+    "checks": {
+      "type": "string",
+      "description": "Comma separated list of checks to run. Defaults to every check except `missing-peer-forward`, which only matters under Yarn PnP strict resolution."
+    },
+    "fix": {
+      "type": "boolean",
+      "description": "Automatically add every missing forwarded peer dependency to the offending package.json"
+    },
+    "peers": {
+      "type": "string",
+      "description": "Comma separated list of peer dependency names to check. Defaults to all."
+    }
+  },
+  "required": []
+}

--- a/tools/workspace-plugin/src/generators/verify-peer-dependencies/schema.ts
+++ b/tools/workspace-plugin/src/generators/verify-peer-dependencies/schema.ts
@@ -1,0 +1,31 @@
+export type PeerDependencyCheck =
+  | 'missing-peer-forward'
+  | 'incompatible-peer-range'
+  | 'invalid-peer-range'
+  | 'orphaned-peer-meta'
+  | 'unverified-peer-range';
+
+export interface VerifyPeerDependenciesGeneratorSchema {
+  /**
+   * Comma separated list of projects to verify. Defaults to every publishable project.
+   */
+  project?: string;
+  /**
+   * Comma separated list of nx project tags to verify, e.g. `vNext`. Defaults to every tag.
+   */
+  tag?: string;
+  /**
+   * Comma separated list of checks to run. Defaults to every check except `missing-peer-forward`,
+   * which only matters under Yarn PnP strict resolution.
+   */
+  checks?: string;
+  /**
+   * Automatically add every missing forwarded peer dependency to the offending package.json.
+   * Without this flag the generator only reports violations and fails.
+   */
+  fix?: boolean;
+  /**
+   * Comma separated list of peer dependency names to check. Defaults to all.
+   */
+  peers?: string;
+}

--- a/tools/workspace-plugin/src/types.ts
+++ b/tools/workspace-plugin/src/types.ts
@@ -52,6 +52,7 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   exports?: Record<
     string,
     | string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,8 +2721,8 @@ __metadata:
     "@typescript-eslint/utils": "npm:^8.46.2"
     eslint-plugin-eslint-plugin: "npm:6.4.0"
   peerDependencies:
-    eslint: ">= 8.0.0"
-    typescript: ">= 5.0.0"
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=5.0.0 <6.0.0"
     typescript-eslint: ">= 8.46.2"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,7 +5071,7 @@ __metadata:
     "@fluentui/react-utilities": "npm:^9.26.6"
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
-    use-sync-external-store: "npm:^1.2.0"
+    use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
@@ -5598,7 +5598,7 @@ __metadata:
     "@fluentui/scripts-cypress": "npm:*"
     "@griffel/react": "npm:^1.5.32"
     "@swc/helpers": "npm:^0.5.1"
-    use-sync-external-store: "npm:^1.2.0"
+    use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
@@ -31700,12 +31700,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.2.0":
-  version: 1.2.2
-  resolution: "use-sync-external-store@npm:1.2.2"
+"use-sync-external-store@npm:^1.4.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/23b1597c10adf15b26ade9e8c318d8cc0abc9ec0ab5fc7ca7338da92e89c2536abd150a5891bf076836c352fdfa104fc7231fb48f806fd9960e0cbe03601abaf
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/35e1179f872a53227bdf8a827f7911da4c37c0f4091c29b76b1e32473d1670ebe7bcd880b808b7549ba9a5605c233350f800ffab963ee4a4ee346ee983b6019b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,9 +2675,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3125,9 +3123,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3348,9 +3344,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3369,9 +3363,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3393,9 +3385,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3424,9 +3414,7 @@ __metadata:
     es6-weak-map: "npm:^2.0.2"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3449,9 +3437,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3503,9 +3489,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3531,9 +3515,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3560,9 +3542,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3587,9 +3567,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3637,9 +3615,7 @@ __metadata:
     embla-carousel-fade: "npm:^8.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3762,9 +3738,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3788,9 +3762,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3805,9 +3777,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3837,7 +3807,6 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
@@ -3964,9 +3933,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3979,7 +3946,7 @@ __metadata:
   peerDependencies:
     "@fluentui/react-conformance": ^0.20.1
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
+    react-dom: ">=16.14.0 <20.0.0"
     typescript: ^4.3.0
   languageName: unknown
   linkType: soft
@@ -4013,9 +3980,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
     scheduler: ">=0.19.0"
   languageName: unknown
   linkType: soft
@@ -4062,9 +4027,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4094,9 +4057,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4118,9 +4079,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4175,9 +4134,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4270,9 +4227,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4371,9 +4326,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4424,9 +4377,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4505,9 +4456,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4526,9 +4475,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4554,9 +4501,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4579,9 +4524,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4627,9 +4570,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4653,9 +4594,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4681,9 +4620,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4710,9 +4647,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4743,9 +4678,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4772,9 +4705,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4802,9 +4733,7 @@ __metadata:
   peerDependencies:
     "@fluentui/react-northstar": ^0.66.5
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4828,9 +4757,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4878,9 +4805,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4899,9 +4824,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4933,9 +4856,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5028,9 +4949,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5054,9 +4973,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5086,9 +5003,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5134,7 +5049,6 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
@@ -5160,9 +5074,7 @@ __metadata:
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5186,9 +5098,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5224,9 +5134,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5251,9 +5159,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5277,9 +5183,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5303,9 +5207,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5329,9 +5231,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5372,9 +5272,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5398,9 +5296,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5425,9 +5321,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5450,9 +5344,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5495,9 +5387,7 @@ __metadata:
     "@storybook/icons": ^1.3.2
     "@storybook/react-webpack5": ^9.1.17
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
     storybook: ^9.1.17
   languageName: unknown
   linkType: soft
@@ -5524,9 +5414,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5552,9 +5440,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5584,9 +5470,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5610,9 +5494,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5629,9 +5511,7 @@ __metadata:
     tabster: "npm:^8.8.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5663,7 +5543,6 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
@@ -5692,9 +5571,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5724,9 +5601,7 @@ __metadata:
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5748,9 +5623,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5773,9 +5646,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5823,9 +5694,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5854,9 +5723,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5883,9 +5750,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5911,9 +5776,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5946,7 +5809,6 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
@@ -5970,9 +5832,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.8.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6000,7 +5860,6 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
@@ -6058,9 +5917,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.1"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6386,9 +6243,7 @@ __metadata:
     dedent: "npm:^1.2.0"
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
-    "@types/react-dom": ">=16.9.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
-    react-dom: ">=16.14.0 <20.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,6 +3124,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3345,6 +3348,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3364,6 +3370,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3386,6 +3395,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3415,6 +3427,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3438,6 +3453,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3490,6 +3508,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3516,6 +3537,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3543,6 +3567,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3568,6 +3595,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3616,6 +3646,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3739,6 +3772,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3763,6 +3799,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3809,6 +3848,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3934,6 +3976,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3948,6 +3993,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
     typescript: ^4.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3982,6 +4030,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     scheduler: ">=0.19.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4028,6 +4079,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4058,6 +4112,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4080,6 +4137,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4135,6 +4195,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4228,6 +4291,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4327,6 +4393,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4378,6 +4447,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4457,6 +4529,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4476,6 +4551,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4502,6 +4580,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4525,6 +4606,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4549,6 +4633,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4571,6 +4658,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4595,6 +4685,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4621,6 +4714,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4648,6 +4744,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4679,6 +4778,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4706,6 +4808,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4734,6 +4839,9 @@ __metadata:
     "@fluentui/react-northstar": ^0.66.5
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4758,6 +4866,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4806,6 +4917,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4825,6 +4939,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4857,6 +4974,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4950,6 +5070,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4974,6 +5097,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5004,6 +5130,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5015,6 +5144,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5029,6 +5161,9 @@ __metadata:
     "@fluentui/react-components": ^9.74.7
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5051,6 +5186,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5075,6 +5213,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5099,6 +5240,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5135,6 +5279,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5160,6 +5307,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5184,6 +5334,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5208,6 +5361,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5232,6 +5388,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5250,6 +5409,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5273,6 +5435,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5297,6 +5462,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5322,6 +5490,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5345,6 +5516,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5389,6 +5563,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     storybook: ^9.1.17
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5415,6 +5592,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5441,6 +5621,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5471,6 +5654,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5495,6 +5681,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5512,6 +5701,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5545,6 +5737,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5572,6 +5767,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5602,6 +5800,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5624,6 +5825,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5647,6 +5851,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5695,6 +5902,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5724,6 +5934,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5751,6 +5964,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5777,6 +5993,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5811,6 +6030,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5846,6 +6068,9 @@ __metadata:
   peerDependencies:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5862,6 +6087,9 @@ __metadata:
     "@types/react": ">=16.14.0 <20.0.0"
     react: ">=16.14.0 <20.0.0"
     react-dom: ">=16.14.0 <20.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Removes v9 peer dependencies we never use, and adds a generator that stops us re-introducing inconsistent ones.

## Why

Peers we don't import aren't free. A package's peer set is part of its **virtual instance key**, so declaring `react-dom` in a package that never touches the DOM forks the virtual store on a dimension the package doesn't care about, and asks consumers to satisfy a module that is never loaded.

## What changed

| | before | after |
| --- | --- | --- |
| `react-dom` peer (v9) | 76 | **7** |
| `@types/react-dom` peer (v9) | 76 | **0** |
| `@types/react` required peer | 76 | **0** (now optional) |

**`react-dom` / `@types/react-dom`** — only 7 packages reference `react-dom` in shipped code, verified against source *and* built `lib/`. The rest inherited the declaration from the scaffolding template. `@types/react-dom` is dropped everywhere; it appears in **0 of 337** api.md reports and **0 of 698** emitted `.d.ts`, so it was never part of the published type surface.

Removal is safe in the install models Fluent UI targets: hoisted layouts resolve `react-dom` from the consuming app, which always has it, and isolated layouts propagate the peer from the packages that genuinely declare it. **Yarn PnP strict is explicitly not targeted** — it has no ancestor walk, so it would require every package in the chain to re-declare peers it never imports. That is the trade-off this PR makes deliberately, and `missing-peer-forward` remains available (`--checks=all`) for anyone who needs to audit it.

**`@types/react`** — erased at build time, so only TypeScript consumers need it. Marked `optional`, which stops npm 7+ auto-installing React types into JS-only projects. Safe *only* because it's types-only: `optional` silences the install warning without making a module resolvable, so `react` and `react-dom` stay required.

**`use-sync-external-store`** — declared `^1.2.0` while promising react `<20.0.0`, but React 19 support landed in 1.4.0 and the lockfile was pinned to 1.2.2, so the combination we shipped was the broken one. Floor is now `^1.4.0`.

**`eslint-plugin-react-components`** — declared `eslint >= 8.0.0` and `typescript >= 5.0.0`, both wider than `@typescript-eslint/utils` supports, promising eslint 8.0–8.56 and typescript 6 support its own dependency can't honour.

## Enforcement

New `verify-peer-dependencies` generator, run on PRs as `--tag=vNext`:

```sh
yarn nx g @fluentui/workspace-plugin:verify-peer-dependencies --tag=vNext
```

Default checks are **installer-independent**: `incompatible-peer-range`, `invalid-peer-range`, `orphaned-peer-meta`. All derived from the package.json graph, so results are deterministic. Only publishable packages are verified.

A fourth check, `missing-peer-forward`, is **opt-in** (`--checks=all`) because whether it matters depends on the installer:

| Installer | Peer resolution |
| --- | --- |
| npm / yarn classic (hoisted) | `require` walks up the tree; nearest ancestor providing the peer wins |
| pnpm, midgard-yarn-strict ([RFC 0042][rfc]) | peer metadata is propagated up the graph automatically, stopping at a real dependency or a local workspace |
| Yarn PnP strict | no ancestor walk — every package in the chain must declare it |

Only the last requires re-declaring a dependency's peers, so enforcing it by default would push us toward declaring peers we don't use — the opposite of this PR.

[rfc]: https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md

## Notes for review

- Metadata only. No source, build output or runtime behaviour changes.
- `react-positioning` and `react-storybook-addon-export-to-sandbox` match `react-dom` only in a comment URL and in sandbox template strings, so they correctly get no peer.
- `react-conformance-griffel` had the inverse bug — it declared `@types/react-dom` but not `react-dom`, while doing `await import('react-dom')` at runtime. Swapped.
- Range containment is decided by probing range boundaries, not `semver.subset`, which rejects `>=16.14.0 <20.0.0` ⊆ `^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0` even though the caret union is exactly `>=16.8.0 <20.0.0`.
- Verified: `yarn install --immutable` exits 0, 285 workspace-plugin tests pass, `--tag=vNext` reports no violations.

## Related Issue(s)

- Follows up on #36551


