### PR TITLE
fix(react-headless-components-preview): use valid focusgroup nomemory token for TabList

### DIFF
--- a/change/@fluentui-react-headless-components-preview-0d15f2e0-c6bd-44df-96f7-c769e56ad08b.json
+++ b/change/@fluentui-react-headless-components-preview-0d15f2e0-c6bd-44df-96f7-c769e56ad08b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use the valid nomemory focusgroup token for TabList",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/TabList.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/TabList.test.tsx
@@ -22,7 +22,7 @@ describe('TabList', () => {
 
     expect(tablist).toBeInTheDocument();
     expect(tablist).toHaveAttribute('data-orientation', 'horizontal');
-    expect(tablist).toHaveAttribute('focusgroup', 'tablist inline wrap no-memory');
+    expect(tablist).toHaveAttribute('focusgroup', 'tablist inline wrap nomemory');
 
     const tabs = getAllByRole('tab');
 
@@ -41,6 +41,6 @@ describe('TabList', () => {
     const tablist = getByRole('tablist');
 
     expect(tablist).toHaveAttribute('data-orientation', 'vertical');
-    expect(tablist).toHaveAttribute('focusgroup', 'tablist block wrap no-memory');
+    expect(tablist).toHaveAttribute('focusgroup', 'tablist block wrap nomemory');
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/useTabList.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/useTabList.ts
@@ -13,7 +13,7 @@ export const useTabList = (props: TabListProps, ref: React.Ref<HTMLElement>): Ta
   const state: TabListState = useTabListBase_unstable(props, ref);
 
   // eslint-disable-next-line react-hooks/immutability
-  state.root.focusgroup = state.vertical ? 'tablist block wrap no-memory' : 'tablist inline wrap no-memory';
+  state.root.focusgroup = `tablist ${state.vertical ? 'block' : 'inline'} wrap nomemory`;
   // eslint-disable-next-line react-hooks/immutability
   state.root['data-orientation'] = state.vertical ? 'vertical' : 'horizontal';
 


### PR DESCRIPTION
## Previous Behavior

Headless `TabList` rendered the proposed `focusgroup` attribute with the legacy/non-supported `no-memory` token.

## New Behavior

Headless `TabList` renders the valid `nomemory` token for both horizontal and vertical orientations. Tests and the base hook example now assert the same token.

## Validation

- `yarn nx run react-headless-components-preview:test`
- `yarn beachball check`

## Related Issue(s)

N/A