### PR TITLE
feat(skills): add /release-recovery skill for npm/repo release desync

### DIFF
--- a/.agents/skills/release-recovery/SKILL.md
+++ b/.agents/skills/release-recovery/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: release-recovery
+description: >-
+  Diagnose and repair a release that published packages to npm but failed to push the version bumps and changelogs back to the repository. Accepts an optional failed Azure DevOps pipeline run URL for context. Always presents a read-only diagnosis first and requires explicit approval before changing branches, commits or pull requests.
+disable-model-invocation: true
+argument-hint: '[pipeline-url] [--ref upstream/master] [--remote upstream]'
+allowed-tools: Bash Read Grep Glob
+---
+
+# Release Recovery
+
+Repair the desync a failed release leaves behind: packages are live on npm, but the repository still
+has the old versions.
+
+npm publishes are irreversible, so **npm is the source of truth**. Recovery always means moving the
+repository forward to match the registry — never the other way round.
+
+The default operation is read-only. Do not create branches, commits or pull requests until the user
+explicitly approves a proposed plan.
+
+## Scope
+
+Recovery restores **version bumps and changelogs**. It does **not** recreate release git tags:
+
+- A recovery commit is not the commit the release was built from, so tags created against it would
+  point at the wrong history — worse than having no tag.
+- A single release spans dozens of packages (a v9 release touches ~90), so bulk tag creation is
+  noisy and effectively unreviewable.
+- Tags are not load-bearing for consumers; npm is what they install from.
+
+Missing tags can still be _reported_ for awareness with `--check-tags` on the diagnostic, but they
+are informational. If tags are genuinely needed for a specific release, create them deliberately as
+a separate, explicitly-approved task.
+
+## When to use
+
+- A release pipeline failed after the "Publishing" step (typically a git push `403`/auth failure).
+- A release was published to npm deliberately without pushing (a forced release that skips the git
+  push).
+
+## Defaults
+
+| Argument       | Default                                 | Purpose                                             |
+| -------------- | --------------------------------------- | --------------------------------------------------- |
+| `pipeline-url` | none                                    | Failed ADO run, used only for context and reporting |
+| `--ref`        | the release branch on the remote        | Git ref whose versions are compared against npm     |
+| `--remote`     | remote pointing at `microsoft/fluentui` | Used for fetching and pushing                       |
+
+Resolve `--remote` by inspecting `git remote -v` for the one pointing at `microsoft/fluentui`. It is
+often `upstream` in a fork checkout, so never assume `origin`.
+
+## Workflow
+
+### Step 1 — Establish context
+
+Confirm tooling and record the starting ref so it can be restored later:
+
+```bash
+gh auth status
+git remote -v
+git status --porcelain
+```
+
+Record `START_REF` (`git symbolic-ref --quiet --short HEAD || git rev-parse HEAD`).
+
+If the working tree has uncommitted changes, stop and ask the user to deal with them. Recovery
+rewrites `package.json`, changelog and lockfile content and must not mix with unrelated edits.
+
+Fetch the release branch so the comparison is not made against a stale checkout:
+
+```bash
+git fetch "$REMOTE" master
+```
+
+### Step 2 — Read the failed pipeline (optional)
+
+If a pipeline URL was supplied, use it for context only. Parse the organization, project and build id
+from a URL of the form
+`https://dev.azure.com/<org>/<project>/_build/results?buildId=<id>`.
+
+```bash
+az pipelines runs show --org "https://dev.azure.com/$ORG" --project "$PROJECT" --id "$BUILD_ID"
+```
+
+Useful signals in the log:
+
+- `Publishing - <pkg>@<version>` followed by `Published!` — packages that reached npm.
+- `Something went wrong with publishing! Manually update these package and versions:` — beachball's
+  own list of what needs recovering.
+- `remote: ... forbids access via a personal access tokens (classic)` or
+  `The requested URL returned error: 403` — the push failed on auth, which is the usual cause.
+
+Treat all of this as **corroboration only**. If `az` is not authenticated or the run has been purged,
+say so and continue: the diagnosis in Step 3 does not depend on it.
+
+### Step 3 — Diagnose (read-only)
+
+Run the sync check against the up-to-date release branch:
+
+```bash
+node -r ./scripts/ts-node/src/register ./scripts/executors/src/check-release-sync.ts \
+  --remote "$REMOTE" --ref "$REMOTE/master"
+```
+
+Add `--json` when the output needs parsing.
+
+Always pass `--ref` pointing at the remote release branch. Comparing the working tree of a stale
+checkout reports every package released since as a false desync.
+
+The check classifies each public package:
+
+| Status        | Meaning                                                              | Action           |
+| ------------- | -------------------------------------------------------------------- | ---------------- |
+| `in-sync`     | repo and npm agree                                                   | none             |
+| `npm-ahead`   | published, but the repo never recorded the bump                      | recover versions |
+| `repo-ahead`  | repo is newer than npm's `latest` (unreleased work, prerelease tags) | none — benign    |
+| `unpublished` | never released                                                       | none             |
+
+Only `npm-ahead` requires recovery.
+
+### Step 4 — Present the plan and get approval
+
+```markdown
+## Release recovery plan
+
+- Pipeline: <url or "not supplied">
+- Remote: upstream
+- Compared against: upstream/master
+- Version desync: 2 package(s)
+
+### Version desync
+
+| Package         | Repo    | npm     |
+| --------------- | ------- | ------- |
+| @fluentui/react | 8.125.6 | 8.125.7 |
+
+### Proposed actions
+
+1. Regenerate bumps + changelogs from the pending change files
+2. Verify the result matches npm exactly
+3. Open a recovery PR
+
+Release tags are not recreated - see the skill's Scope section.
+```
+
+Stop here if there is no `npm-ahead` drift. Otherwise ask the user to approve or cancel. Never treat
+invoking the skill as approval to mutate anything.
+
+### Step 5 — Recover versions
+
+Skip this step when nothing is `npm-ahead`.
+
+Create a branch from the current release branch:
+
+```bash
+git switch -c "release-recovery/$(date -u +%Y%m%d-%H%M%S)" "$REMOTE/master"
+yarn install
+```
+
+Regenerate the release locally. The change files consumed by the failed run are still in the repo
+(their deletion was never committed), so beachball reproduces the same bumps and changelogs:
+
+```bash
+yarn beachball bump --config scripts/beachball/src/<release>.config.js
+```
+
+Pick the config matching the failed pipeline:
+
+| Release        | Config                                                   | Pipeline                                     |
+| -------------- | -------------------------------------------------------- | -------------------------------------------- |
+| v8             | `scripts/beachball/src/release-v8.config.js`             | `azure-pipelines.release.yml`                |
+| v9 (vNext)     | `scripts/beachball/src/release-vNext.config.js`          | `azure-pipelines.release-vnext.yml`          |
+| web-components | `scripts/beachball/src/release-web-components.config.js` | `azure-pipelines.release.web-components.yml` |
+| headless       | `scripts/beachball/src/release-headless.config.js`       | `azure-pipelines.release.headless.yml`       |
+| tools          | `scripts/beachball/src/release-tools.config.js`          | `azure-pipelines.release.tools.yml`          |
+
+`beachball bump` only writes files — it does **not** commit, tag or push. Tagging and pushing live
+exclusively in beachball's `bumpAndPush`, which is reachable only from the `publish` command.
+Verified empirically against `3.0.0-alpha.7`: a full `bump` run changed 123 files and created 0 tags,
+0 commits and 0 branches.
+
+It does **not** run the `precommit` hook either (that also only runs on the push path), so apply the
+same fixups a real release would. Keep this in sync with `hooks.precommit` in
+[scripts/beachball/src/shared.config.ts](../../../scripts/beachball/src/shared.config.ts):
+
+```bash
+yarn nx g @fluentui/workspace-plugin:dependency-mismatch
+yarn nx g @fluentui/workspace-plugin:normalize-package-dependencies
+yarn install --mode=update-lockfile
+```
+
+Expect `bump` to consume **more change files than it bumps packages**. `type: "none"` change files
+are deleted without producing a version bump — that is normal, and matches what a real release does.
+
+**Verify before committing.** Re-run the sync check against the working tree:
+
+```bash
+node -r ./scripts/ts-node/src/register ./scripts/executors/src/check-release-sync.ts --remote "$REMOTE"
+```
+
+Every previously `npm-ahead` package must now be `in-sync`. If any version overshoots npm, extra
+change files landed after the failed release, so a plain replay is not correct — stop, report the
+mismatch, and let the user decide. Never hand-edit versions to force a match.
+
+Commit and open a PR:
+
+```bash
+git add -A
+git commit -m "release: applying package updates (manual recovery)"
+git push "$PUSH_REMOTE" HEAD
+gh pr create --repo microsoft/fluentui --base master \
+  --title "release: applying package updates (manual recovery)" \
+  --body-file "$PR_BODY_FILE"
+```
+
+The PR body must state which pipeline failed and that the packages are already on npm.
+
+### Step 6 — Restore and report
+
+```bash
+git switch "$START_REF"
+```
+
+Report:
+
+- Packages recovered, with repo and npm versions.
+- Recovery PR URL.
+- Anything skipped, with the reason.
+- A reminder to fix the underlying cause — usually rotating the GitHub PAT in the
+  `Github and NPM secrets` variable group — since the next release fails identically otherwise.
+
+## Guardrails
+
+- Always diagnose and obtain approval before mutating anything.
+- Never unpublish, deprecate or re-publish an npm package to "fix" a mismatch. npm is the source of
+  truth; the repository moves to match it.
+- Never hand-edit versions to force agreement with npm. Regenerate with beachball so changelogs and
+  dependency ranges stay consistent, and stop if the result disagrees.
+- Never commit directly to `master`; always go through a PR.
+- Never create or push release tags as part of recovery. They would point at a commit the release was
+  not built from, and a single release spans dozens of packages.
+- Never assume `origin` points at `microsoft/fluentui` — resolve the remote explicitly.
+- Never trust a diagnosis made against a stale checkout; always compare against the fetched release
+  branch.
+- Never request or print a GitHub or npm token.
+- Do not proceed when the working tree has uncommitted changes.

--- a/.claude/skills/release-recovery/SKILL.md
+++ b/.claude/skills/release-recovery/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/release-recovery/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,19 +91,20 @@ state.root.className = mergeClasses(
 
 ## Skills (Slash Commands)
 
-| Skill                | Command                    | Purpose                                                                   |
-| -------------------- | -------------------------- | ------------------------------------------------------------------------- |
-| `v9-component`       | `/v9-component Name`       | Scaffold a new v9 component with all required files                       |
-| `headless-component` | `/headless-component Name` | Author an unstyled v9 primitive with state attributes, tests, and stories |
-| `change`             | `/change`                  | Create beachball change file from current diff                            |
-| `lint-check`         | `/lint-check [pkg]`        | Run lint, parse errors, and auto-fix common issues                        |
-| `token-lookup`       | `/token-lookup val`        | Find the design token for a hardcoded CSS value                           |
-| `package-info`       | `/package-info pkg`        | Quick lookup: path, deps, owner, tests, structure                         |
-| `visual-test`        | `/visual-test Name`        | Visually verify a component via Storybook + playwright-cli                |
-| `review-pr`          | `/review-pr #123`          | Review a PR with confidence scoring and category checks                   |
-| `triage-issues`      | `/triage-issues`           | Walk the Needs-Triage queue and recommend labels/assignee                 |
-| `dependabot-rollup`  | `/dependabot-rollup`       | Dry-run and optionally roll up at most 11 Dependabot patch/minor PRs      |
-| `assign-prs`         | `/assign-prs`              | Assign reviewers to the team review queues by area and current load       |
+| Skill                | Command                            | Purpose                                                                   |
+| -------------------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| `v9-component`       | `/v9-component Name`               | Scaffold a new v9 component with all required files                       |
+| `headless-component` | `/headless-component Name`         | Author an unstyled v9 primitive with state attributes, tests, and stories |
+| `change`             | `/change`                          | Create beachball change file from current diff                            |
+| `lint-check`         | `/lint-check [pkg]`                | Run lint, parse errors, and auto-fix common issues                        |
+| `token-lookup`       | `/token-lookup val`                | Find the design token for a hardcoded CSS value                           |
+| `package-info`       | `/package-info pkg`                | Quick lookup: path, deps, owner, tests, structure                         |
+| `visual-test`        | `/visual-test Name`                | Visually verify a component via Storybook + playwright-cli                |
+| `review-pr`          | `/review-pr #123`                  | Review a PR with confidence scoring and category checks                   |
+| `triage-issues`      | `/triage-issues`                   | Walk the Needs-Triage queue and recommend labels/assignee                 |
+| `dependabot-rollup`  | `/dependabot-rollup`               | Dry-run and optionally roll up at most 11 Dependabot patch/minor PRs      |
+| `assign-prs`         | `/assign-prs`                      | Assign reviewers to the team review queues by area and current load       |
+| `release-recovery`   | `/release-recovery [pipeline-url]` | Diagnose and repair a release that published to npm but failed to push    |
 
 ## Package Layout
 

--- a/scripts/executors/src/check-release-sync.ts
+++ b/scripts/executors/src/check-release-sync.ts
@@ -1,0 +1,318 @@
+import { spawnSync } from 'child_process';
+import https from 'https';
+
+import { getAllPackageInfo } from '@fluentui/scripts-monorepo';
+import * as semver from 'semver';
+import yargs from 'yargs';
+
+/**
+ * Read-only diagnosis of drift between the local repo and the npm registry.
+ *
+ * Used by the `release-recovery` skill to work out what a failed release left behind.
+ *
+ * The failure mode that matters is `npm-ahead`: the package was published but the version bump never
+ * reached the repo. That is the "publish succeeded, git push failed" desync, and it is what recovery
+ * repairs.
+ *
+ * Missing release tags can also be reported via `--check-tags`, but they are informational only.
+ * Recovery deliberately does NOT recreate them: a recovery commit is not the commit the release was
+ * actually built from, so tags created against it would point at the wrong history. A single v9
+ * release also spans ~90 packages, which makes bulk tag creation both noisy and hard to review.
+ *
+ * Nothing here mutates the repo, the registry, or git.
+ */
+
+type SyncStatus = 'in-sync' | 'npm-ahead' | 'repo-ahead' | 'unpublished' | 'error';
+
+interface PackageStatus {
+  name: string;
+  localVersion: string;
+  npmVersion?: string;
+  status: SyncStatus;
+  /** Expected git tag for the currently published version */
+  tag?: string;
+  tagExists?: boolean;
+  error?: string;
+}
+
+/** Fetch the `latest` dist-tag straight from the registry (much faster than shelling out to npm). */
+function fetchLatestVersion(name: string): Promise<string | undefined> {
+  return new Promise(resolve => {
+    const url = `https://registry.npmjs.org/${name.replace('/', '%2F')}`;
+
+    const request = https.get(url, { timeout: 20000 }, response => {
+      if (response.statusCode === 404) {
+        response.resume();
+        return resolve(undefined);
+      }
+
+      if (response.statusCode !== 200) {
+        response.resume();
+        return resolve(undefined);
+      }
+
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', chunk => (body += chunk));
+      response.on('end', () => {
+        try {
+          resolve(JSON.parse(body)['dist-tags']?.latest);
+        } catch {
+          resolve(undefined);
+        }
+      });
+    });
+
+    request.on('timeout', () => {
+      request.destroy();
+      resolve(undefined);
+    });
+    request.on('error', () => resolve(undefined));
+  });
+}
+
+/** Run `fn` over `items` with bounded concurrency so we don't open 250 sockets at once. */
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await fn(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+
+  return results;
+}
+
+/** All tags on the remote, fetched in a single call. */
+function getRemoteTags(remote: string): Set<string> | undefined {
+  const result = spawnSync('git', ['ls-remote', '--tags', remote], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  const tags = new Set<string>();
+  for (const line of (result.stdout || '').split('\n')) {
+    const match = line.match(/refs\/tags\/(.+?)(\^\{\})?$/);
+    if (match) {
+      tags.add(match[1]);
+    }
+  }
+
+  return tags;
+}
+
+interface Options {
+  remote: string;
+  json: boolean;
+  concurrency: number;
+  ref?: string;
+  checkTags: boolean;
+}
+
+/**
+ * Read package versions either from the working tree or, when `ref` is given, from a git ref.
+ *
+ * Reading from a ref matters: running the diagnosis on a stale checkout makes every package that
+ * has been released since look like a desync. Pointing at `upstream/master` removes that trap.
+ */
+function getLocalVersions(ref: string | undefined): Array<{ name: string; localVersion: string }> {
+  const allPackages = getAllPackageInfo();
+
+  const publicPackages = Object.values(allPackages)
+    .filter(info => !info.packageJson.private)
+    .sort((a, b) => a.packageJson.name.localeCompare(b.packageJson.name));
+
+  if (!ref) {
+    return publicPackages.map(info => ({ name: info.packageJson.name, localVersion: info.packageJson.version }));
+  }
+
+  return publicPackages.flatMap(info => {
+    const gitPath = `${info.packagePath.replace(/\\/g, '/')}/package.json`;
+    const result = spawnSync('git', ['show', `${ref}:${gitPath}`], { encoding: 'utf8' });
+
+    if (result.status !== 0) {
+      // Package does not exist on that ref yet - not a desync, just newer than the ref.
+      return [];
+    }
+
+    try {
+      return [{ name: info.packageJson.name, localVersion: JSON.parse(result.stdout).version }];
+    } catch {
+      return [];
+    }
+  });
+}
+
+async function main(options: Options): Promise<void> {
+  const publicPackages = getLocalVersions(options.ref);
+
+  if (!options.json) {
+    const source = options.ref ? `git ref "${options.ref}"` : 'the working tree';
+    console.log(`Checking ${publicPackages.length} public package(s) from ${source} against the npm registry...\n`);
+  }
+
+  const remoteTags = options.checkTags ? getRemoteTags(options.remote) : undefined;
+  if (options.checkTags && !remoteTags && !options.json) {
+    console.warn(`[WARN] Could not list tags on "${options.remote}" - tag checks will be skipped.\n`);
+  }
+
+  const statuses = await mapWithConcurrency(publicPackages, options.concurrency, async pkg => {
+    const npmVersion = await fetchLatestVersion(pkg.name);
+
+    const result: PackageStatus = {
+      name: pkg.name,
+      localVersion: pkg.localVersion,
+      npmVersion,
+      status: 'in-sync',
+    };
+
+    if (!npmVersion) {
+      result.status = 'unpublished';
+      return result;
+    }
+
+    if (npmVersion === pkg.localVersion) {
+      result.status = 'in-sync';
+    } else if (semver.valid(npmVersion) && semver.valid(pkg.localVersion)) {
+      // Direction matters. `npm-ahead` means the registry has a version the repo never recorded,
+      // which is the desync a failed release leaves behind. `repo-ahead` is normal and benign -
+      // it just means the registry's `latest` dist-tag lags the repo (for example a package whose
+      // most recent publishes were prereleases).
+      result.status = semver.gt(npmVersion, pkg.localVersion) ? 'npm-ahead' : 'repo-ahead';
+    } else {
+      result.status = 'error';
+      result.error = `Could not compare versions (repo="${pkg.localVersion}", npm="${npmVersion}")`;
+    }
+
+    // Tag check always uses the PUBLISHED version - that is the one a release should have tagged.
+    const tag = `${pkg.name}_v${npmVersion}`;
+    result.tag = tag;
+    result.tagExists = remoteTags ? remoteTags.has(tag) : undefined;
+
+    return result;
+  });
+
+  const npmAhead = statuses.filter(s => s.status === 'npm-ahead');
+  const repoAhead = statuses.filter(s => s.status === 'repo-ahead');
+  const errored = statuses.filter(s => s.status === 'error');
+  const missingTags = statuses.filter(s => s.status !== 'unpublished' && s.tagExists === false);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          remote: options.remote,
+          totals: {
+            checked: statuses.length,
+            inSync: statuses.filter(s => s.status === 'in-sync').length,
+            npmAhead: npmAhead.length,
+            repoAhead: repoAhead.length,
+            unpublished: statuses.filter(s => s.status === 'unpublished').length,
+            errored: errored.length,
+            ...(options.checkTags && { missingTags: missingTags.length }),
+          },
+          npmAhead,
+          repoAhead,
+          errored,
+          // Informational only - recovery does not recreate tags.
+          ...(options.checkTags && { missingTags }),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`Checked: ${statuses.length}`);
+  console.log(`  in sync:        ${statuses.filter(s => s.status === 'in-sync').length}`);
+  console.log(`  npm ahead:      ${npmAhead.length}   <- needs recovery`);
+  console.log(`  repo ahead:     ${repoAhead.length}   (normal: unreleased work or prerelease dist-tag)`);
+  console.log(`  never released: ${statuses.filter(s => s.status === 'unpublished').length}`);
+  console.log(`  uncomparable:   ${errored.length}`);
+  if (options.checkTags) {
+    console.log(`  missing tags:   ${remoteTags ? missingTags.length : 'n/a'}   (informational only)`);
+  }
+  console.log();
+
+  if (npmAhead.length) {
+    console.log('Published to npm but NOT reflected in the repo (version desync):\n');
+    console.log('  package'.padEnd(52) + 'repo'.padEnd(20) + 'npm');
+    for (const pkg of npmAhead) {
+      console.log(`  ${pkg.name.padEnd(50)}${pkg.localVersion.padEnd(20)}${pkg.npmVersion}`);
+    }
+    console.log();
+  }
+
+  if (errored.length) {
+    console.log('Could not compare (inspect manually):\n');
+    for (const pkg of errored) {
+      console.log(`  ${pkg.name}: ${pkg.error}`);
+    }
+    console.log();
+  }
+
+  if (options.checkTags && missingTags.length) {
+    console.log('Published versions with no git tag on the remote (informational - not recovered):\n');
+    for (const pkg of missingTags) {
+      console.log(`  ${pkg.tag}`);
+    }
+    console.log(
+      '\n  Release tags are not recreated during recovery: a recovery commit is not the commit\n' +
+        '  the release was built from, so tags against it would point at the wrong history.\n',
+    );
+  }
+
+  if (!npmAhead.length) {
+    console.log('No version desync detected - the repo and npm are in sync.\n');
+  }
+}
+
+const argv = yargs
+  .option('remote', {
+    type: 'string',
+    describe: 'Git remote to check tags against',
+    default: 'origin',
+  })
+  .option('json', {
+    type: 'boolean',
+    describe: 'Emit machine-readable JSON instead of a table',
+    default: false,
+  })
+  .option('concurrency', {
+    type: 'number',
+    describe: 'Maximum parallel registry requests',
+    default: 12,
+  })
+  .option('ref', {
+    type: 'string',
+    describe:
+      'Read package versions from this git ref instead of the working tree. Use the up-to-date ' +
+      'release branch (e.g. upstream/master) to avoid false positives from a stale checkout.',
+  })
+  .option('check-tags', {
+    type: 'boolean',
+    describe:
+      'Also report published versions that have no git tag on the remote. Informational only - ' +
+      'recovery does not recreate tags. Adds a slow ls-remote over tens of thousands of refs.',
+    default: false,
+  })
+  .strict().argv;
+
+main({
+  remote: argv.remote,
+  json: argv.json,
+  concurrency: argv.concurrency,
+  ref: argv.ref,
+  checkTags: argv['check-tags'],
+}).catch(err => {
+  console.error('Failed to check release sync state:', err);
+  process.exit(1);
+});

--- a/scripts/executors/src/check-release-sync.ts
+++ b/scripts/executors/src/check-release-sync.ts
@@ -35,20 +35,34 @@ interface PackageStatus {
   error?: string;
 }
 
-/** Fetch the `latest` dist-tag straight from the registry (much faster than shelling out to npm). */
-function fetchLatestVersion(name: string): Promise<string | undefined> {
+/**
+ * Outcome of a registry lookup. A missing version is only meaningful when the lookup itself
+ * succeeded, so "package is not published" and "we could not reach the registry" have to stay
+ * distinguishable - otherwise a flaky registry silently reports healthy packages as unreleased.
+ */
+type RegistryLookup = { ok: true; version?: string } | { ok: false; reason: string };
+
+/** Statuses worth retrying: rate limiting and transient server-side failures. */
+function isRetriableStatus(status: number | undefined): boolean {
+  return status === 408 || status === 429 || (status !== undefined && status >= 500);
+}
+
+function requestLatestVersion(name: string): Promise<RegistryLookup> {
   return new Promise(resolve => {
     const url = `https://registry.npmjs.org/${name.replace('/', '%2F')}`;
 
     const request = https.get(url, { timeout: 20000 }, response => {
-      if (response.statusCode === 404) {
+      const status = response.statusCode;
+
+      // A 404 is a real answer: the package has never been published.
+      if (status === 404) {
         response.resume();
-        return resolve(undefined);
+        return resolve({ ok: true, version: undefined });
       }
 
-      if (response.statusCode !== 200) {
+      if (status !== 200) {
         response.resume();
-        return resolve(undefined);
+        return resolve({ ok: false, reason: `registry responded HTTP ${status}` });
       }
 
       let body = '';
@@ -56,19 +70,51 @@ function fetchLatestVersion(name: string): Promise<string | undefined> {
       response.on('data', chunk => (body += chunk));
       response.on('end', () => {
         try {
-          resolve(JSON.parse(body)['dist-tags']?.latest);
+          resolve({ ok: true, version: JSON.parse(body)['dist-tags']?.latest });
         } catch {
-          resolve(undefined);
+          resolve({ ok: false, reason: 'registry returned a malformed response' });
         }
       });
     });
 
     request.on('timeout', () => {
       request.destroy();
-      resolve(undefined);
+      resolve({ ok: false, reason: 'registry request timed out' });
     });
-    request.on('error', () => resolve(undefined));
+    request.on('error', error => resolve({ ok: false, reason: `registry request failed: ${error.message}` }));
   });
+}
+
+/**
+ * Fetch the `latest` dist-tag straight from the registry (much faster than shelling out to npm).
+ *
+ * Retries transient failures: this fires one request per public package, so brushing up against
+ * rate limiting is realistic, and a diagnostic that quietly downgrades packages on a 429 is worse
+ * than useless during an incident.
+ */
+async function fetchLatestVersion(name: string, attempts = 3): Promise<RegistryLookup> {
+  let last: RegistryLookup = { ok: false, reason: 'no attempt was made' };
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    last = await requestLatestVersion(name);
+
+    if (last.ok) {
+      return last;
+    }
+
+    const status = Number(last.reason.match(/HTTP (\d+)/)?.[1]) || undefined;
+    const retriable = status === undefined || isRetriableStatus(status);
+
+    if (!retriable || attempt === attempts) {
+      return last;
+    }
+
+    await new Promise(resolve => {
+      setTimeout(resolve, 300 * 2 ** (attempt - 1));
+    });
+  }
+
+  return last;
 }
 
 /** Run `fn` over `items` with bounded concurrency so we don't open 250 sockets at once. */
@@ -76,7 +122,11 @@ async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T)
   const results: R[] = new Array(items.length);
   let next = 0;
 
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+  // Never drop below a single worker: a limit of 0 (or a negative one) would spawn no workers at
+  // all and resolve instantly with an array of holes, which looks like a clean run.
+  const workerCount = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+
+  const workers = Array.from({ length: workerCount }, async () => {
     while (next < items.length) {
       const index = next++;
       results[index] = await fn(items[index]);
@@ -163,7 +213,8 @@ async function main(options: Options): Promise<void> {
   }
 
   const statuses = await mapWithConcurrency(publicPackages, options.concurrency, async pkg => {
-    const npmVersion = await fetchLatestVersion(pkg.name);
+    const lookup = await fetchLatestVersion(pkg.name);
+    const npmVersion = lookup.ok ? lookup.version : undefined;
 
     const result: PackageStatus = {
       name: pkg.name,
@@ -171,6 +222,15 @@ async function main(options: Options): Promise<void> {
       npmVersion,
       status: 'in-sync',
     };
+
+    // Only trust "no version" when the registry actually answered. A failed lookup must never be
+    // reported as `unpublished`, because unpublished packages are dropped from the recovery set -
+    // a transient 429 would otherwise hide a genuine desync.
+    if (!lookup.ok) {
+      result.status = 'error';
+      result.error = lookup.reason;
+      return result;
+    }
 
     if (!npmVersion) {
       result.status = 'unpublished';
@@ -236,7 +296,7 @@ async function main(options: Options): Promise<void> {
   console.log(`  npm ahead:      ${npmAhead.length}   <- needs recovery`);
   console.log(`  repo ahead:     ${repoAhead.length}   (normal: unreleased work or prerelease dist-tag)`);
   console.log(`  never released: ${statuses.filter(s => s.status === 'unpublished').length}`);
-  console.log(`  uncomparable:   ${errored.length}`);
+  console.log(`  not checked:    ${errored.length}   (registry error or unparseable version)`);
   if (options.checkTags) {
     console.log(`  missing tags:   ${remoteTags ? missingTags.length : 'n/a'}   (informational only)`);
   }
@@ -252,7 +312,7 @@ async function main(options: Options): Promise<void> {
   }
 
   if (errored.length) {
-    console.log('Could not compare (inspect manually):\n');
+    console.log('Could not be checked - re-run before trusting the result above:\n');
     for (const pkg of errored) {
       console.log(`  ${pkg.name}: ${pkg.error}`);
     }
@@ -271,7 +331,14 @@ async function main(options: Options): Promise<void> {
   }
 
   if (!npmAhead.length) {
-    console.log('No version desync detected - the repo and npm are in sync.\n');
+    if (errored.length) {
+      console.log(
+        `No version desync detected in the ${statuses.length - errored.length} package(s) that could be\n` +
+          `checked, but ${errored.length} could not be compared (see above) - this is NOT a clean bill of health.\n`,
+      );
+    } else {
+      console.log('No version desync detected - the repo and npm are in sync.\n');
+    }
   }
 }
 


### PR DESCRIPTION
## Previous Behavior

When a release pipeline publishes to npm and then fails to push (expired or policy-blocked git PAT), npm and the repo are left out of sync: versions and changelogs exist on the registry but not in git.

Recovering that is a manual, error-prone slog — reconstruct which packages were published, re-derive every bump, replay changelogs, and get it right under time pressure. The v8 release on 2026-06-30 needed exactly that: 18 packages published, every push retry `403`, repo fixed by hand days later.

There was no tooling to detect the desync either. It is currently possible for a package to sit out of sync indefinitely without anyone noticing.

## New Behavior

Adds a `/release-recovery` skill that diagnoses and repairs the desync, optionally pointed at the failed pipeline run.

It derives the expected state **from the npm registry** rather than from a pipeline artifact, so it also works on releases that predate this tooling — including desyncs nobody noticed at the time.

Also adds `check-release-sync`, the read-only diagnostic behind it, which compares every public package's version in a git ref against the registry and classifies each as `in-sync` / `npm-ahead` / `repo-ahead` / `unpublished`. Useful standalone for auditing release health:

```bash
node -r ./scripts/ts-node/src/register ./scripts/executors/src/check-release-sync.ts \
  --remote origin --ref origin/master
```

Running it against `master` today surfaces a **real, currently-outstanding desync**: `@fluentui/web-components` is `3.0.2` in the repo but `3.0.3` on npm.

### Deliberately does not recreate git tags

A recovery commit is not the commit the release was built from, so tags created during recovery would point at the wrong revision — worse than missing tags. A v9 release also spans ~90 packages. Missing tags can be *reported* with `--check-tags`, but are treated as informational.

### Notes for reviewers

- The skill is diagnose-first and approval-gated: it reports a plan and waits before writing anything.
- `beachball bump` writes files but does **not** commit, tag or push — tagging/pushing live only in `bumpAndPush`, reachable only from `publish`. Verified empirically: a full bump run changed 123 files and created 0 tags, 0 commits, 0 branches.
- `bump` consumes more change files than it bumps packages; `type: "none"` files are deleted without a bump. Normal, and matches a real release.
- `scripts/executors` is private, so no change file is required.

Independent of the other two PRs in this series (#36563, #36564) — mergeable in any order.

## Related Issue(s)

N/A — follow-up to the 2026-06-30 v8 release incident.
