### PR TITLE
feat(react-headless-components-preview): add focusgroup typings

### DIFF
--- a/change/@fluentui-react-headless-components-preview-focusgroup-typings.json
+++ b/change/@fluentui-react-headless-components-preview-focusgroup-typings.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add development-time types for focusgroup attributes",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
@@ -32,9 +32,9 @@ import { MenuItemSwitchProps } from '@fluentui/react-menu';
 import { MenuItemSwitchSlots } from '@fluentui/react-menu';
 import { MenuItemSwitchState } from '@fluentui/react-menu';
 import type { MenuListContextValues } from '@fluentui/react-menu';
-import type { MenuListProps as MenuListProps_2 } from '@fluentui/react-menu';
-import type { MenuListSlots } from '@fluentui/react-menu';
-import type { MenuListState as MenuListState_2 } from '@fluentui/react-menu';
+import { MenuListProps } from '@fluentui/react-menu';
+import { MenuListSlots } from '@fluentui/react-menu';
+import { MenuListState } from '@fluentui/react-menu';
 import { MenuOpenChangeData } from '@fluentui/react-menu';
 import { MenuOpenEvent } from '@fluentui/react-menu';
 import { MenuPopoverProps } from '@fluentui/react-menu';
@@ -148,7 +148,6 @@ export { MenuItemSlots }
 // @public (undocumented)
 export type MenuItemState = MenuItemState_2 & {
     root: {
-        focusgroupstart?: string;
         'data-disabled'?: string;
         'data-has-submenu'?: string;
         'data-submenu-open'?: string;
@@ -167,17 +166,11 @@ export { MenuItemSwitchState }
 // @public
 export const MenuList: ForwardRefComponent<MenuListProps>;
 
-// @public (undocumented)
-export type MenuListProps = MenuListProps_2;
+export { MenuListProps }
 
 export { MenuListSlots }
 
-// @public (undocumented)
-export type MenuListState = MenuListState_2 & {
-    root: {
-        focusgroup?: string;
-    };
-};
+export { MenuListState }
 
 export { MenuOpenChangeData }
 
@@ -234,7 +227,7 @@ export { renderMenuItemRadio }
 export { renderMenuItemSwitch }
 
 // @public (undocumented)
-export const renderMenuList: (state: MenuListState_2, contextValues: MenuListContextValues) => JSXElement;
+export const renderMenuList: (state: MenuListState, contextValues: MenuListContextValues) => JSXElement;
 
 // @public (undocumented)
 export const renderMenuPopover: (state: MenuPopoverState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/nav.api.md
@@ -9,7 +9,6 @@ import type { ComponentState } from '@fluentui/react-utilities';
 import type { DividerBaseProps } from '@fluentui/react-divider';
 import { DividerBaseState } from '@fluentui/react-divider';
 import type { DividerSlots as DividerSlots_2 } from '@fluentui/react-divider';
-import { DrawerBodyState } from '@fluentui/react-drawer';
 import { DrawerFooterState } from '@fluentui/react-drawer';
 import { DrawerHeaderState } from '@fluentui/react-drawer';
 import type { EventHandler } from '@fluentui/react-utilities';
@@ -17,7 +16,6 @@ import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { InlineDrawerBaseProps } from '@fluentui/react-drawer';
 import { InlineDrawerSlots } from '@fluentui/react-drawer';
 import { JSXElement } from '@fluentui/react-utilities';
-import type { NavBaseState } from '@fluentui/react-nav';
 import { NavCategoryContextValues } from '@fluentui/react-nav';
 import { NavCategoryItemProvider } from '@fluentui/react-nav';
 import { NavCategoryProps } from '@fluentui/react-nav';
@@ -27,6 +25,7 @@ import { NavContextValue } from '@fluentui/react-nav';
 import { NavContextValues } from '@fluentui/react-nav';
 import { DrawerBodyProps as NavDrawerBodyProps } from '@fluentui/react-drawer';
 import { DrawerBodySlots as NavDrawerBodySlots } from '@fluentui/react-drawer';
+import { DrawerBodyState as NavDrawerBodyState } from '@fluentui/react-drawer';
 import { DrawerFooterProps as NavDrawerFooterProps } from '@fluentui/react-drawer';
 import { DrawerFooterSlots as NavDrawerFooterSlots } from '@fluentui/react-drawer';
 import { DrawerHeaderProps as NavDrawerHeaderProps } from '@fluentui/react-drawer';
@@ -39,6 +38,7 @@ import { NavItemValue } from '@fluentui/react-nav';
 import { NavBaseProps as NavProps } from '@fluentui/react-nav';
 import { NavProvider } from '@fluentui/react-nav';
 import { NavSlots } from '@fluentui/react-nav';
+import { NavBaseState as NavState } from '@fluentui/react-nav';
 import type { NavSubItemBaseState } from '@fluentui/react-nav';
 import { NavSubItemBaseProps as NavSubItemProps } from '@fluentui/react-nav';
 import { NavSubItemSlots } from '@fluentui/react-nav';
@@ -135,12 +135,7 @@ export { NavDrawerBodyProps }
 
 export { NavDrawerBodySlots }
 
-// @public (undocumented)
-export type NavDrawerBodyState = DrawerBodyState & {
-    root: DrawerBodyState['root'] & {
-        focusgroup?: string;
-    };
-};
+export { NavDrawerBodyState }
 
 // @public
 export const NavDrawerFooter: ForwardRefComponent<NavDrawerFooterProps>;
@@ -215,12 +210,7 @@ export type NavSectionHeaderState = ComponentState<NavSectionHeaderSlots>;
 
 export { NavSlots }
 
-// @public (undocumented)
-export type NavState = NavBaseState & {
-    root: NavBaseState['root'] & {
-        focusgroup?: string;
-    };
-};
+export { NavState }
 
 // @public
 export const NavSubItem: ForwardRefComponent<NavSubItemProps>;
@@ -271,7 +261,7 @@ export const renderNavDivider: (state: DividerBaseState) => JSXElement;
 export const renderNavDrawer: (state: NavDrawerState, contextValues: NavContextValues) => JSXElement;
 
 // @public
-export const renderNavDrawerBody: (state: DrawerBodyState) => JSXElement;
+export const renderNavDrawerBody: (state: NavDrawerBodyState) => JSXElement;
 
 // @public
 export const renderNavDrawerFooter: (state: DrawerFooterState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/etc/swatch-picker.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/swatch-picker.api.md
@@ -108,7 +108,6 @@ export { SwatchPickerSlots }
 export type SwatchPickerState = SwatchPickerBaseState & {
     root: {
         'data-layout'?: SwatchPickerBaseState['layout'];
-        focusgroup?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tab-list.api.md
@@ -36,7 +36,6 @@ export type TabListSlots = TabListSlots_2;
 // @public
 export type TabListState = TabListBaseState & {
     root: {
-        focusgroup?: string;
         'data-orientation'?: 'vertical' | 'horizontal';
     };
 };
@@ -49,7 +48,6 @@ export { TabSlots }
 // @public (undocumented)
 export type TabState = TabBaseState & {
     root: {
-        focusgroupstart?: string;
         'data-icon-only'?: string;
         'data-selected'?: string;
         'data-disabled'?: string;

--- a/packages/react-components/react-headless-components-preview/library/etc/tag-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tag-group.api.md
@@ -29,7 +29,6 @@ export { TagGroupSlots }
 // @public (undocumented)
 export type TagGroupState = TagGroupBaseState & {
     root: {
-        focusgroup?: string;
         'data-disabled'?: string;
         'data-dismissible'?: string;
     };

--- a/packages/react-components/react-headless-components-preview/library/etc/tag-picker.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tag-picker.api.md
@@ -37,7 +37,7 @@ import { TagPickerControlInternalSlots } from '@fluentui/react-tag-picker';
 import { TagPickerControlProps } from '@fluentui/react-tag-picker';
 import { TagPickerControlSlots } from '@fluentui/react-tag-picker';
 import type { TagPickerGroupBaseState } from '@fluentui/react-tag-picker';
-import type { TagPickerGroupSlots } from '@fluentui/react-tag-picker';
+import type { TagPickerGroupSlots as TagPickerGroupSlots_2 } from '@fluentui/react-tag-picker';
 import type { TagPickerInputBaseState } from '@fluentui/react-tag-picker';
 import { TagPickerInputBaseProps as TagPickerInputProps } from '@fluentui/react-tag-picker';
 import { TagPickerInputSlots } from '@fluentui/react-tag-picker';
@@ -113,12 +113,12 @@ export const TagPickerGroup: ForwardRefComponent<TagPickerGroupProps>;
 // @public
 export type TagPickerGroupProps = ComponentProps<TagPickerGroupSlots> & Pick<TagGroupBaseProps, 'dismissible' | 'onDismiss'>;
 
-export { TagPickerGroupSlots }
+// @public (undocumented)
+export type TagPickerGroupSlots = TagPickerGroupSlots_2;
 
 // @public
 export type TagPickerGroupState = TagPickerGroupBaseState & {
     root: {
-        focusgroup?: string;
         'data-disabled'?: string;
     };
 };

--- a/packages/react-components/react-headless-components-preview/library/etc/toolbar.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/toolbar.api.md
@@ -10,26 +10,26 @@ import { DividerBaseState } from '@fluentui/react-divider';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import { JSXElement } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
-import type { ToolbarBaseProps } from '@fluentui/react-toolbar';
 import { ToolbarBaseState } from '@fluentui/react-toolbar';
 import type { ToolbarButtonBaseProps } from '@fluentui/react-toolbar';
 import type { ToolbarButtonBaseState } from '@fluentui/react-toolbar';
 import { ToolbarContextValue } from '@fluentui/react-toolbar';
-import { ToolbarContextValues as ToolbarContextValues_2 } from '@fluentui/react-toolbar';
+import { ToolbarContextValues } from '@fluentui/react-toolbar';
 import type { ToolbarDividerBaseProps } from '@fluentui/react-toolbar';
 import type { ToolbarDividerBaseState } from '@fluentui/react-toolbar';
 import type { ToolbarGroupProps as ToolbarGroupProps_2 } from '@fluentui/react-toolbar';
 import { ToolbarGroupState as ToolbarGroupState_2 } from '@fluentui/react-toolbar';
+import { ToolbarBaseProps as ToolbarProps } from '@fluentui/react-toolbar';
 import type { ToolbarRadioButtonBaseProps } from '@fluentui/react-toolbar';
 import type { ToolbarRadioButtonBaseState } from '@fluentui/react-toolbar';
 import type { ToolbarRadioGroupProps as ToolbarRadioGroupProps_2 } from '@fluentui/react-toolbar';
 import type { ToolbarRadioGroupState as ToolbarRadioGroupState_2 } from '@fluentui/react-toolbar';
-import type { ToolbarSlots as ToolbarSlots_2 } from '@fluentui/react-toolbar';
+import { ToolbarSlots } from '@fluentui/react-toolbar';
 import type { ToolbarToggleButtonBaseProps } from '@fluentui/react-toolbar';
 import type { ToolbarToggleButtonBaseState } from '@fluentui/react-toolbar';
 
 // @public
-export const renderToolbar: (state: ToolbarBaseState, contextValues: ToolbarContextValues_2) => JSXElement;
+export const renderToolbar: (state: ToolbarBaseState, contextValues: ToolbarContextValues) => JSXElement;
 
 // @public
 export const renderToolbarButton: (state: ButtonBaseState) => JSXElement;
@@ -68,8 +68,7 @@ export type ToolbarButtonState = ToolbarButtonBaseState & {
     };
 };
 
-// @public (undocumented)
-export type ToolbarContextValues = ToolbarContextValues_2;
+export { ToolbarContextValues }
 
 // @public
 export const ToolbarDivider: ForwardRefComponent<ToolbarDividerProps>;
@@ -97,8 +96,7 @@ export type ToolbarGroupState = ToolbarGroupState_2 & {
     };
 };
 
-// @public (undocumented)
-export type ToolbarProps = ToolbarBaseProps;
+export { ToolbarProps }
 
 // @public
 export const ToolbarRadioButton: ForwardRefComponent<ToolbarRadioButtonProps>;
@@ -130,14 +128,12 @@ export type ToolbarRadioGroupState = ToolbarRadioGroupState_2 & {
     };
 };
 
-// @public (undocumented)
-export type ToolbarSlots = ToolbarSlots_2;
+export { ToolbarSlots }
 
 // @public (undocumented)
 export type ToolbarState = ToolbarBaseState & {
     root: {
         'data-vertical'?: string;
-        focusgroup?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -6,7 +6,6 @@ export type MenuItemProps = MenuItemBaseProps;
 
 export type MenuItemState = MenuItemBaseState & {
   root: {
-    focusgroupstart?: string;
     'data-disabled'?: string;
     'data-has-submenu'?: string;
     'data-submenu-open'?: string;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.types.ts
@@ -1,17 +1,7 @@
-import type {
-  MenuListProps as MenuListBaseProps,
+export type {
+  MenuListProps,
   MenuListSlots,
-  MenuListState as MenuListBaseState,
+  MenuListState,
   MenuCheckedValueChangeData,
   MenuCheckedValueChangeEvent,
 } from '@fluentui/react-menu';
-
-export type MenuListProps = MenuListBaseProps;
-
-export type MenuListState = MenuListBaseState & {
-  root: {
-    focusgroup?: string;
-  };
-};
-
-export type { MenuListSlots, MenuCheckedValueChangeData, MenuCheckedValueChangeEvent };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.types.ts
@@ -1,9 +1,7 @@
-import type { NavBaseState } from '@fluentui/react-nav';
-
-export type { NavSlots, NavBaseProps as NavProps, OnNavItemSelectData, NavItemValue } from '@fluentui/react-nav';
-
-export type NavState = NavBaseState & {
-  root: NavBaseState['root'] & {
-    focusgroup?: string;
-  };
-};
+export type {
+  NavSlots,
+  NavBaseProps as NavProps,
+  NavBaseState as NavState,
+  OnNavItemSelectData,
+  NavItemValue,
+} from '@fluentui/react-nav';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavDrawerBody/NavDrawerBody.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavDrawerBody/NavDrawerBody.types.ts
@@ -1,12 +1,5 @@
-import type { DrawerBodyState } from '../../Drawer/DrawerBody/DrawerBody.types';
-
 export type {
+  DrawerBodyState as NavDrawerBodyState,
   DrawerBodyProps as NavDrawerBodyProps,
   DrawerBodySlots as NavDrawerBodySlots,
 } from '../../Drawer/DrawerBody/DrawerBody.types';
-
-export type NavDrawerBodyState = DrawerBodyState & {
-  root: DrawerBodyState['root'] & {
-    focusgroup?: string;
-  };
-};

--- a/packages/react-components/react-headless-components-preview/library/src/components/SwatchPicker/SwatchPicker.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/SwatchPicker/SwatchPicker.types.ts
@@ -8,9 +8,5 @@ export type SwatchPickerState = SwatchPickerBaseState & {
      * Whether SwatchPicker is row or grid
      */
     'data-layout'?: SwatchPickerBaseState['layout'];
-    /**
-     * Arrow navigation mode for SwatchPicker
-     */
-    focusgroup?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/Tab.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/Tab/Tab.types.ts
@@ -6,7 +6,6 @@ export type TabProps = TabBaseProps;
 
 export type TabState = TabBaseState & {
   root: {
-    focusgroupstart?: string;
     'data-icon-only'?: string;
     'data-selected'?: string;
     'data-disabled'?: string;

--- a/packages/react-components/react-headless-components-preview/library/src/components/TabList/TabList.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TabList/TabList.types.ts
@@ -20,7 +20,6 @@ export type TabListProps = TabListBaseProps;
  */
 export type TabListState = TabListBaseState & {
   root: {
-    focusgroup?: string;
     /**
      * Data attribute set to reflect the orientation of the tab list. Value is 'vertical' or 'horizontal'.
      */

--- a/packages/react-components/react-headless-components-preview/library/src/components/TagGroup/TagGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TagGroup/TagGroup.types.ts
@@ -5,12 +5,6 @@ export type { TagGroupBaseProps as TagGroupProps, TagGroupSlots } from '@fluentu
 export type TagGroupState = TagGroupBaseState & {
   root: {
     /**
-     * Native WICG `focusgroup` attribute for arrow-key navigation across tags.
-     * Defaults to `'toolbar inline wrap'`.
-     */
-    focusgroup?: string;
-
-    /**
      * Data attribute set when the group is disabled.
      */
     'data-disabled'?: string;

--- a/packages/react-components/react-headless-components-preview/library/src/components/TagPicker/TagPickerGroup/TagPickerGroup.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TagPicker/TagPickerGroup/TagPickerGroup.types.ts
@@ -1,8 +1,11 @@
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { TagGroupBaseProps } from '@fluentui/react-tags';
-import type { TagPickerGroupBaseState, TagPickerGroupSlots } from '@fluentui/react-tag-picker';
+import type {
+  TagPickerGroupBaseState,
+  TagPickerGroupSlots as TagPickerGroupBaseSlots,
+} from '@fluentui/react-tag-picker';
 
-export type { TagPickerGroupSlots };
+export type TagPickerGroupSlots = TagPickerGroupBaseSlots;
 
 /**
  * TagPickerGroup Props
@@ -15,11 +18,6 @@ export type TagPickerGroupProps = ComponentProps<TagPickerGroupSlots> &
  */
 export type TagPickerGroupState = TagPickerGroupBaseState & {
   root: {
-    /**
-     * Native WICG `focusgroup` attribute for arrow-key navigation across the selected tags.
-     * Replaces the Tabster `useArrowNavigationGroup` used by the styled TagPickerGroup.
-     */
-    focusgroup?: string;
     /**
      * Data attribute set when the group is disabled.
      */

--- a/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Toolbar/Toolbar.types.ts
@@ -1,13 +1,6 @@
-import type {
-  ToolbarSlots as ToolbarBaseSlots,
-  ToolbarBaseProps,
-  ToolbarContextValues as ToolbarBaseContextValues,
-  ToolbarBaseState,
-} from '@fluentui/react-toolbar';
+import type { ToolbarBaseState } from '@fluentui/react-toolbar';
 
-export type ToolbarSlots = ToolbarBaseSlots;
-
-export type ToolbarProps = ToolbarBaseProps;
+export type { ToolbarContextValues, ToolbarSlots, ToolbarBaseProps as ToolbarProps } from '@fluentui/react-toolbar';
 
 export type ToolbarState = ToolbarBaseState & {
   root: {
@@ -15,12 +8,5 @@ export type ToolbarState = ToolbarBaseState & {
      * Data attribute set when the toolbar is vertically oriented.
      */
     'data-vertical'?: string;
-
-    /**
-     * Data attribute to define the focus behavior of the toolbar's children
-     */
-    focusgroup?: string;
   };
 };
-
-export type ToolbarContextValues = ToolbarBaseContextValues;

--- a/packages/react-components/react-headless-components-preview/library/tsconfig.cy.json
+++ b/packages/react-components/react-headless-components-preview/library/tsconfig.cy.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "isolatedModules": false,
-    "types": ["node", "cypress", "cypress-real-events"],
-    "typeRoots": ["../../../../node_modules", "../../../../node_modules/@types"],
+    "types": ["node", "cypress", "cypress-real-events", "focusgroup"],
+    "typeRoots": ["../../../../node_modules", "../../../../node_modules/@types", "../../../../typings"],
     "lib": ["ES2019", "dom"]
   },
   "include": ["**/*.cy.ts", "**/*.cy.tsx"]

--- a/packages/react-components/react-headless-components-preview/library/tsconfig.lib.json
+++ b/packages/react-components/react-headless-components-preview/library/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "declarationDir": "../../../../dist/out-tsc/types",
     "outDir": "../../../../dist/out-tsc",
     "inlineSources": true,
-    "types": ["static-assets", "environment"]
+    "types": ["static-assets", "environment", "focusgroup"]
   },
   "exclude": [
     "./src/testing/**",

--- a/packages/react-components/react-headless-components-preview/library/tsconfig.spec.json
+++ b/packages/react-components/react-headless-components-preview/library/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist",
-    "types": ["jest", "node", "@testing-library/jest-dom"]
+    "types": ["jest", "node", "@testing-library/jest-dom", "focusgroup"]
   },
   "include": [
     "**/*.spec.ts",

--- a/packages/react-components/react-headless-components-preview/stories/tsconfig.lib.json
+++ b/packages/react-components/react-headless-components-preview/stories/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "outDir": "../../../../dist/out-tsc",
     "inlineSources": true,
-    "types": ["static-assets", "environment"]
+    "types": ["static-assets", "environment", "focusgroup"]
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }

--- a/typings/focusgroup/README.md
+++ b/typings/focusgroup/README.md
@@ -1,0 +1,73 @@
+# focusgroup
+
+Adds a typed `focusgroup` attribute to React's `HTMLAttributes` for components that use the experimental [Open UI Focusgroup V2 proposal](https://open-ui.org/components/focusgroup-v2.explainer/).
+
+This typing is intended for development-time validation only. It does not provide focusgroup behavior or become part of a package's public API.
+
+## Usage
+
+Opt into the typing from the consuming project's TypeScript configuration:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["focusgroup"]
+  }
+}
+```
+
+The repository's root `typeRoots` already includes `typings`. A project that overrides `typeRoots` must also include the repository typings directory.
+
+React elements then accept supported focusgroup values:
+
+```tsx
+<div focusgroup="toolbar inline wrap" />;
+<div focusgroup="radiogroup" />;
+<div focusgroup="feed block nowrap nomemory" />;
+<div focusgroup="grid manual rowflow colflow" />;
+<button focusgroup="none" />;
+```
+
+Unsupported behaviors, modifiers, and modifier ordering produce TypeScript errors:
+
+```tsx
+<div focusgroup="tree" />;
+<div focusgroup="toolbar manual" />;
+<div focusgroup="feed rowflow" />;
+```
+
+## Supported values
+
+The first token identifies the behavior:
+
+- `toolbar`
+- `menubar`
+- `tablist`
+- `radiogroup`
+- `listbox`
+- `menu`
+- `grid`
+- `feed`
+
+`none` is a standalone value that opts an element and its subtree out of an ancestor focusgroup.
+
+Linear behaviors support these modifiers:
+
+- Axis: `inline` or `block`
+- Wrapping: `wrap` or `nowrap`
+- Memory: `nomemory`
+- Nested controls: `itemcontrols` or `noitemcontrols`
+
+The `grid` behavior supports:
+
+- Topology: `manual`
+- Both-axis edges: `wrap`, `nowrap`, or `flow`
+- Inline-axis edges: `rowwrap` or `rowflow`
+- Block-axis edges: `colwrap` or `colflow`
+- Memory: `nomemory`
+- Nested controls: `itemcontrols` or `noitemcontrols`
+
+The Open UI syntax permits tokens in any order. To keep React's ambient attribute type tractable, this typing uses the conventional order recommended by the explainer:
+
+- Linear: behavior, axis, wrapping, memory, nested controls
+- Grid: `grid`, topology, edge behavior, memory, nested controls

--- a/typings/focusgroup/index.d.ts
+++ b/typings/focusgroup/index.d.ts
@@ -1,0 +1,47 @@
+import 'react';
+
+type FocusgroupLinearBehavior = 'toolbar' | 'menubar' | 'tablist' | 'radiogroup' | 'listbox' | 'menu' | 'feed';
+type FocusgroupAxis = 'inline' | 'block';
+type FocusgroupWrap = 'wrap' | 'nowrap';
+type FocusgroupMemory = 'nomemory';
+type FocusgroupItemControls = 'itemcontrols' | 'noitemcontrols';
+type FocusgroupGridEdge = 'wrap' | 'nowrap' | 'flow';
+type FocusgroupGridRowEdge = 'rowwrap' | 'rowflow';
+type FocusgroupGridColumnEdge = 'colwrap' | 'colflow';
+
+type FocusgroupLinearWithAxis = FocusgroupLinearBehavior | `${FocusgroupLinearBehavior} ${FocusgroupAxis}`;
+type FocusgroupLinearWithWrap = FocusgroupLinearWithAxis | `${FocusgroupLinearWithAxis} ${FocusgroupWrap}`;
+type FocusgroupLinearWithMemory = FocusgroupLinearWithWrap | `${FocusgroupLinearWithWrap} ${FocusgroupMemory}`;
+type FocusgroupLinearAttribute = FocusgroupLinearWithMemory | `${FocusgroupLinearWithMemory} ${FocusgroupItemControls}`;
+
+type FocusgroupGridWithTopology = 'grid' | 'grid manual';
+type FocusgroupGridWithEdges =
+  | FocusgroupGridWithTopology
+  | `${FocusgroupGridWithTopology} ${FocusgroupGridEdge}`
+  | `${FocusgroupGridWithTopology} ${FocusgroupGridRowEdge}`
+  | `${FocusgroupGridWithTopology} ${FocusgroupGridColumnEdge}`
+  | `${FocusgroupGridWithTopology} ${FocusgroupGridRowEdge} ${FocusgroupGridColumnEdge}`;
+type FocusgroupGridWithMemory = FocusgroupGridWithEdges | `${FocusgroupGridWithEdges} ${FocusgroupMemory}`;
+type FocusgroupGridAttribute = FocusgroupGridWithMemory | `${FocusgroupGridWithMemory} ${FocusgroupItemControls}`;
+
+type FocusgroupAttribute = 'none' | FocusgroupLinearAttribute | FocusgroupGridAttribute;
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    /**
+     * The `focusgroup` attribute is used to indicate that a group of elements should be treated as
+     * a single focusable unit for keyboard navigation purposes. It can be used to create accessible
+     * components that support keyboard navigation and focus management.
+     */
+    focusgroup?: FocusgroupAttribute;
+
+    /**
+     * The `focusgroupstart` attribute is used to indicate that an element is the starting
+     * point of a focus group. It can be used in conjunction with the `focusgroup` attribute
+     * to create accessible components that support keyboard navigation and focus management.
+     */
+    focusgroupstart?: string;
+  }
+}
+
+export {};

--- a/typings/focusgroup/tsconfig.json
+++ b/typings/focusgroup/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["*.d.ts"]
+}

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "./find-free-port/tsconfig.json"
+    },
+    {
+      "path": "./focusgroup/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
## Previous Behavior

The headless components preview package declared experimental `focusgroup` attributes independently as untyped strings across component state APIs. Invalid Focusgroup V2 behavior and modifier combinations were not caught during development (dissussed in https://github.com/microsoft/fluentui/pull/36560#discussion_r3768365153)

## New Behavior

- Adds an opt-in workspace `focusgroup` React typing based on the Open UI Focusgroup V2 proposal.
- Enables the typing for the headless preview library, tests, Cypress tests, and stories without adding it to the published package API.
- Removes duplicated focusgroup attribute declarations from component state types and updates generated API reports.
- Adds a patch change file for `@fluentui/react-headless-components-preview`.

Validation:
- `yarn nx type-check react-headless-components-preview --skipNxCache`
- `yarn nx run react-headless-components-preview:generate-api --skipNxCache`

## Related Issue(s)

- Related to https://github.com/microsoft/polyfills/issues/67
- Spec: https://open-ui.org/components/focusgroup-v2.explainer/