### PR TITLE
fix(web-components): support middle-click to open links in new tab (Fixes #36567)

### DIFF
--- a/packages/web-components/src/anchor-button/anchor-button.base.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.base.ts
@@ -184,6 +184,23 @@ export class BaseAnchor extends FASTElement {
   }
 
   /**
+   * Handles the anchor auxclick event (middle mouse button).
+   * Opens the link in a new tab when the middle mouse button is clicked.
+   *
+   * @param e - The event object
+   * @internal
+   */
+  public auxclickHandler(e: PointerEvent): boolean {
+    if (e.button !== 1 || !this.href) {
+      return true;
+    }
+
+    e.preventDefault();
+    window.open(this.href, '_blank');
+    return true;
+  }
+
+  /**
    * Handles keydown events for the anchor.
    *
    * @param e - the keyboard event

--- a/packages/web-components/src/anchor-button/anchor-button.template.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.template.ts
@@ -11,6 +11,7 @@ export function anchorTemplate<T extends AnchorButton>(options: AnchorOptions = 
     <template
       tabindex="0"
       @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"
+      @auxclick="${(x, c) => x.auxclickHandler(c.event as PointerEvent)}"
       @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
       ${startSlotTemplate(options)}

--- a/packages/web-components/src/link/link.template.ts
+++ b/packages/web-components/src/link/link.template.ts
@@ -10,6 +10,7 @@ export function anchorTemplate<T extends Link>(): ViewTemplate<T> {
     <template
       tabindex="0"
       @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"
+      @auxclick="${(x, c) => x.auxclickHandler(c.event as PointerEvent)}"
       @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
       <slot></slot>


### PR DESCRIPTION
## Description

`fluent-link` and `fluent-anchor-button` did not respond to middle mouse button clicks. The `@click` event only fires for left-button clicks; middle-click triggers the `auxclick` event, which was not handled.

When a user middle-clicks a native `<a>` element, the browser opens the link in a new tab. These components should provide the same behavior.

## Changes

1. **`anchor-button.base.ts`**: Added `auxclickHandler` method to `BaseAnchor` that opens the link in a new tab when the middle mouse button (`event.button === 1`) is pressed.
2. **`anchor-button.template.ts`**: Added `@auxclick` binding to the template.
3. **`link.template.ts`**: Added `@auxclick` binding to the template (Link extends BaseAnchor, so it inherits the handler).

## Testing

- Middle-click on `fluent-link` with `href` → opens in new tab
- Middle-click on `fluent-anchor-button` with `href` → opens in new tab
- Left-click behavior unchanged
- Ctrl/Cmd+click behavior unchanged
- Right-click context menu unchanged

Fixes #36567