### PR TITLE
feat(headless-dropdown): expose data-attributes

### DIFF
--- a/change/@fluentui-react-headless-components-preview-c00fc5f6-dee8-494a-a4e9-61e4e74ae664.json
+++ b/change/@fluentui-react-headless-components-preview-c00fc5f6-dee8-494a-a4e9-61e4e74ae664.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: expose Dropdown invalid and clear button visibility data attributes",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/dropdown.api.md
@@ -32,10 +32,14 @@ export type DropdownProps = Omit<DropdownBaseHookProps, 'inlinePopup' | 'mountNo
 
 // @public (undocumented)
 export type DropdownState = DropdownBaseHookState & {
-    button: {
+    button: DropdownBaseHookState['button'] & {
         'data-state'?: 'open' | 'closed';
         'data-disabled'?: string;
         'data-placeholder'?: string;
+        'data-invalid'?: string;
+    };
+    clearButton?: DropdownBaseHookState['clearButton'] & {
+        'data-visible'?: string;
     };
 };
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Dropdown.types.ts
@@ -10,7 +10,7 @@ export type {
 export type DropdownProps = Omit<DropdownBaseHookProps, 'inlinePopup' | 'mountNode'>;
 
 export type DropdownState = DropdownBaseHookState & {
-  button: {
+  button: DropdownBaseHookState['button'] & {
     /**
      * Whether the dropdown is currently open.
      */
@@ -23,5 +23,18 @@ export type DropdownState = DropdownBaseHookState & {
      * Whether the trigger element is currently displaying a placeholder.
      */
     'data-placeholder'?: string;
+    /**
+     * Whether the trigger element is currently invalid.
+     */
+    'data-invalid'?: string;
+  };
+  /**
+   * The resolved clear button slot state.
+   */
+  clearButton?: DropdownBaseHookState['clearButton'] & {
+    /**
+     * Whether the clear button is currently visible.
+     */
+    'data-visible'?: string;
   };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/index.ts
@@ -1,5 +1,5 @@
 export { Dropdown } from './Dropdown';
-export type { DropdownProps, DropdownState } from './Dropdown.types';
+export type { DropdownProps, DropdownState, DropdownSlots } from './Dropdown.types';
 export { renderDropdown } from './renderDropdown';
 export { useDropdown } from './useDropdown';
 export { useDropdownContextValues } from './useDropdownContextValues';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useDropdown.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/useDropdown.ts
@@ -60,6 +60,7 @@ export const useDropdown = (props: DropdownProps, ref: React.Ref<HTMLButtonEleme
       'data-state': open ? 'open' : 'closed',
       'data-disabled': stringifyDataAttribute(trigger.disabled),
       'data-placeholder': stringifyDataAttribute(!baseState.value),
+      'data-invalid': stringifyDataAttribute(trigger['aria-invalid']),
     },
     listbox: open || hasFocus ? listbox : undefined,
     clearButton: slot.optional(mergedProps.clearButton, {
@@ -93,6 +94,7 @@ export const useDropdown = (props: DropdownProps, ref: React.Ref<HTMLButtonEleme
 
   if (state.clearButton) {
     state.clearButton.onClick = onClearButtonClick;
+    state.clearButton['data-visible'] = stringifyDataAttribute(showClearButton);
   }
 
   // Heads up! We don't support "clearable" in multiselect mode, so we should never display a slot


### PR DESCRIPTION
a follow-up for Fluent Modern Dropdown styling surface contract implementation -> to expose `data-invalid`, `data-visible` and `DropdownSlots` type