### PR TITLE
docs(react-docsite-components): flag Markdown enableRenderHtmlBlock as unsafe

### DIFF
--- a/change/@fluentui-react-docsite-components-8f3a1c42-6b7e-4d29-9a1e-2c5b7f0d3e14.json
+++ b/change/@fluentui-react-docsite-components-8f3a1c42-6b7e-4d29-9a1e-2c5b7f0d3e14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: warn that Markdown's `enableRenderHtmlBlock` renders unsanitized HTML and must only be used with developer-authored content",
+  "packageName": "@fluentui/react-docsite-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.test.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Markdown } from './Markdown';
+
+// CodeSnippet pulls in react-syntax-highlighter's untranspiled ESM build, which jest can't parse.
+jest.mock('../CodeSnippet/index', () => {
+  const mockCodeSnippet: React.FunctionComponent<React.PropsWithChildren<{}>> = props => <code>{props.children}</code>;
+  return { CodeSnippet: mockCodeSnippet };
+});
+
+// Same problem via react-monaco-editor, reached through this barrel.
+jest.mock('../../utilities/index2', () => ({
+  removeAnchorLink: (url: string) => url.split('#')[0],
+}));
+
+const renderHtmlMarkdown = ['```renderhtml', '<div class="injected">raw</div>', '```'].join('\n');
+
+describe('Markdown renderhtml code blocks', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('does not render raw HTML by default', () => {
+    const { container } = render(<Markdown>{renderHtmlMarkdown}</Markdown>);
+
+    expect(container.querySelector('.injected')).toBeNull();
+    expect(container.textContent).toContain('<div class="injected">raw</div>');
+  });
+
+  it('does not render raw HTML when enableRenderHtmlBlock is explicitly false', () => {
+    const { container } = render(<Markdown enableRenderHtmlBlock={false}>{renderHtmlMarkdown}</Markdown>);
+
+    expect(container.querySelector('.injected')).toBeNull();
+  });
+
+  it('renders raw HTML only when enableRenderHtmlBlock is opted into', () => {
+    const { container } = render(<Markdown enableRenderHtmlBlock>{renderHtmlMarkdown}</Markdown>);
+
+    expect(container.querySelector('.injected')).not.toBeNull();
+  });
+
+  it('warns when enableRenderHtmlBlock is opted into', () => {
+    render(<Markdown enableRenderHtmlBlock>{renderHtmlMarkdown}</Markdown>);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('enableRenderHtmlBlock'));
+  });
+});

--- a/packages/react-docsite-components/src/components/Markdown/Markdown.types.ts
+++ b/packages/react-docsite-components/src/components/Markdown/Markdown.types.ts
@@ -12,6 +12,16 @@ export interface IMarkdownProps {
   /**
    * If true, using a code block with language name `renderhtml` will render the contents as HTML.
    * This is to work around markdown-to-jsx's limited support for nested HTML elements.
+   *
+   * @deprecated **UNSAFE.** The contents of a `renderhtml` block are injected verbatim via
+   * `dangerouslySetInnerHTML` with no sanitization, so they can execute arbitrary script in the
+   * origin of the hosting application.
+   *
+   * Only enable this for markdown that is fully authored and reviewed by the application's own
+   * developers, such as documentation files bundled at build time. **Never** enable it for markdown
+   * that any user, tenant, contributor or remote service can influence, and never for markdown
+   * loaded at runtime. If you need to render untrusted markdown, leave this off (the default) or
+   * sanitize the HTML yourself before it reaches this component.
    */
   enableRenderHtmlBlock?: boolean;
 

--- a/packages/react-docsite-components/src/components/Markdown/MarkdownPre.tsx
+++ b/packages/react-docsite-components/src/components/Markdown/MarkdownPre.tsx
@@ -4,6 +4,16 @@ export interface IMarkdownPreProps extends React.HTMLAttributes<HTMLPreElement> 
   /**
    * If true, using a code block with language name `renderhtml` will render the contents as HTML.
    * This is to work around markdown-to-jsx's limited support for nested HTML elements.
+   *
+   * @deprecated **UNSAFE.** The contents of a `renderhtml` block are injected verbatim via
+   * `dangerouslySetInnerHTML` with no sanitization, so they can execute arbitrary script in the
+   * origin of the hosting application.
+   *
+   * Only enable this for markdown that is fully authored and reviewed by the application's own
+   * developers, such as documentation files bundled at build time. **Never** enable it for markdown
+   * that any user, tenant, contributor or remote service can influence, and never for markdown
+   * loaded at runtime. If you need to render untrusted markdown, leave this off (the default) or
+   * sanitize the HTML yourself before it reaches this component.
    */
   enableRenderHtmlBlock?: boolean;
 }
@@ -22,9 +32,18 @@ export const MarkdownPre: React.FunctionComponent<IMarkdownPreProps> = props => 
     enableRenderHtmlBlock &&
     typeof childrenDisplayName === 'string' &&
     childrenDisplayName.indexOf('MarkdownCode') !== -1 &&
-    childrenProps.className === 'lang-renderhtml' &&
+    childrenProps?.className === 'lang-renderhtml' &&
     typeof childrenProps?.children === 'string'
   ) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Markdown: a `renderhtml` code block was rendered as raw, unsanitized HTML because ' +
+          '`enableRenderHtmlBlock` is enabled. This executes any script in the block. Only use this ' +
+          'with markdown authored and reviewed by your own developers, never with content that a ' +
+          'user or remote service can influence.',
+      );
+    }
     // eslint-disable-next-line react/no-danger
     return <div dangerouslySetInnerHTML={{ __html: childrenProps.children }} />;
   }


### PR DESCRIPTION
## Previous Behavior

`Markdown`'s opt-in `enableRenderHtmlBlock` prop routes ` ```renderhtml ` fenced code blocks through `MarkdownPre`, which injects the block contents with `dangerouslySetInnerHTML` and no sanitization.

The prop was documented purely as a rendering workaround, with no indication that it is an unsafe-HTML sink:

> If true, using a code block with language name `renderhtml` will render the contents as HTML. This is to work around markdown-to-jsx's limited support for nested HTML elements.

Since `@fluentui/react-docsite-components` is published publicly and both `Markdown` and `MarkdownPre` are public exports, a consumer could reasonably enable this over markdown they do not fully control.

## New Behavior

Documentation-only hardening — no behavior change for existing callers:

- `enableRenderHtmlBlock` is marked `@deprecated` on both `IMarkdownPreProps` and the public `IMarkdownProps`, with an explicit warning that the contents are injected unsanitized and that it must only be used with markdown authored and reviewed by the application's own developers, never with content a user or remote service can influence.
- A dev-only `console.warn` is emitted when the raw-HTML branch is actually taken, so consumers who enable the flag are told what it does.
- Added tests covering the sink: no raw HTML when the flag is absent or explicitly `false`, raw HTML plus the warning only when opted into.

### Context

Raised via an MSRC report. The in-repo usage is not exploitable: the only caller is `LayoutPage`, whose markdown is inlined at build time by `raw-loader` from a repo-committed file, so influencing it requires landing a commit in this repository. No `<Markdown>` usage ingests markdown at runtime. This PR addresses the underlying issue — that the prop is a hazardous API with no warning attached.

The report's secondary `javascript:` link vector was reviewed and is already handled upstream: `markdown-to-jsx@7.4.7` rejects `javascript:`, `vbscript:` and non-image `data:` schemes before props reach `MarkdownLink`.

## Related Issue(s)

n/a
