### PR TITLE
fix(react): warn in dev when DocumentCard onClickHref is a script URL

### DIFF
--- a/change/@fluentui-react-37b8b8d0-2866-4288-9f75-2a52fd8f764e.json
+++ b/change/@fluentui-react-37b8b8d0-2866-4288-9f75-2a52fd8f764e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: warn in development when DocumentCard onClickHref is given a script URL",
+  "packageName": "@fluentui/react",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -4,6 +4,7 @@ import {
   KeyCodes,
   getNativeProps,
   divProperties,
+  warn,
   warnDeprecations,
   initializeComponentRef,
 } from '../../Utilities';
@@ -18,6 +19,7 @@ import type {
 } from './DocumentCard.types';
 import { WindowContext } from '@fluentui/react-window-provider';
 import { getWindowEx } from '../../utilities/dom';
+import { isScriptUrl } from '../../utilities/isScriptUrl';
 
 import type { JSXElement } from '@fluentui/utilities';
 
@@ -121,6 +123,14 @@ export class DocumentCardBase extends React.Component<IDocumentCardProps, any> i
     if (onClick) {
       onClick(ev);
     } else if (!onClick && onClickHref) {
+      if (process.env.NODE_ENV !== 'production' && isScriptUrl(onClickHref)) {
+        warn(
+          `${COMPONENT_NAME}: 'onClickHref' was given a script URL ('${onClickHref}'), which executes code in your ` +
+            `app's origin when the card is activated. If this value can originate from user input or any other ` +
+            `untrusted source, validate its protocol before passing it to 'onClickHref'.`,
+        );
+      }
+
       // If no onClick Function was provided and we do have an onClickHref, redirect to the onClickHref
       if (onClickTarget) {
         win.open(onClickHref, onClickTarget, 'noreferrer noopener nofollow');

--- a/packages/react/src/components/DocumentCard/DocumentCard.test.tsx
+++ b/packages/react/src/components/DocumentCard/DocumentCard.test.tsx
@@ -1,10 +1,14 @@
+/* eslint-disable no-script-url */
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { WindowProvider } from '@fluentui/react-window-provider';
 
+import { setWarningCallback } from '../../Utilities';
 import { DocumentCard } from './DocumentCard';
 import { DocumentCardTitle } from './DocumentCardTitle';
 import { DocumentCardPreview } from './DocumentCardPreview';
 import { DocumentCardActivity } from './DocumentCardActivity';
+import type { IDocumentCardProps } from './DocumentCard.types';
 
 describe('DocumentCard', () => {
   it('renders DocumentCard correctly', () => {
@@ -16,5 +20,80 @@ describe('DocumentCard', () => {
       </DocumentCard>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('onClickHref', () => {
+    let warnings: string[];
+    let mockWindow: { open: jest.Mock; location: { href: string } };
+
+    const clickCard = (props: IDocumentCardProps) => {
+      const { getByRole } = render(
+        <WindowProvider window={mockWindow as unknown as Window}>
+          <DocumentCard {...props}>
+            <DocumentCardTitle title="Quarterly report.docx" />
+          </DocumentCard>
+        </WindowProvider>,
+      );
+
+      fireEvent.click(getByRole('group'));
+    };
+
+    beforeEach(() => {
+      warnings = [];
+      setWarningCallback(message => warnings.push(message));
+      mockWindow = { open: jest.fn(), location: { href: 'https://contoso.example/home' } };
+    });
+
+    afterEach(() => {
+      setWarningCallback(undefined);
+    });
+
+    it.each([
+      'https://contoso.example/doc.docx',
+      '/relative/doc.docx',
+      '#section',
+      '?page=2',
+      'mailto:someone@contoso.example',
+      'tel:+1234567890',
+      'ms-word:ofe|u|https://contoso.example/doc.docx',
+      'msteams:/l/chat',
+    ])('navigates to %s without warning', href => {
+      clickCard({ onClickHref: href });
+
+      expect(mockWindow.location.href).toBe(href);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it.each([
+      'javascript:alert(1)',
+      ' javascript:alert(1)',
+      'java\nscript:alert(1)',
+      '\0javascript:alert(1)',
+      'JaVaScRiPt:alert(1)',
+      'vbscript:msgbox(1)',
+    ])('warns about the script URL %j but still navigates', href => {
+      clickCard({ onClickHref: href });
+
+      expect(mockWindow.location.href).toBe(href);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/script URL/);
+    });
+
+    it('warns about script URLs opened in another browser context', () => {
+      clickCard({ onClickHref: 'javascript:alert(1)', onClickTarget: '_blank' });
+
+      expect(mockWindow.open).toHaveBeenCalledWith('javascript:alert(1)', '_blank', 'noreferrer noopener nofollow');
+      expect(warnings).toHaveLength(1);
+    });
+
+    it('does not navigate or warn when onClick takes precedence', () => {
+      const onClick = jest.fn();
+      clickCard({ onClick, onClickHref: 'javascript:alert(1)' });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(mockWindow.open).not.toHaveBeenCalled();
+      expect(mockWindow.location.href).toBe('https://contoso.example/home');
+      expect(warnings).toHaveLength(0);
+    });
   });
 });

--- a/packages/react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/react/src/components/DocumentCard/DocumentCard.types.ts
@@ -36,6 +36,10 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
   /**
    * A URL to navigate to when the card is clicked. If a function has also been provided,
    * it will be used instead of the URL.
+   *
+   * The URL is navigated to as-is, exactly like the `href` of an anchor, so script URLs such as
+   * `javascript:` execute in your app's origin. Never pass untrusted or user supplied values here
+   * without validating their protocol first.
    */
   onClickHref?: string;
 

--- a/packages/react/src/utilities/isScriptUrl.ts
+++ b/packages/react/src/utilities/isScriptUrl.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line no-script-url
+const scriptProtocols = new Set(['javascript:', 'vbscript:']);
+
+/**
+ * Checks whether navigating to a URL would execute script in the current origin.
+ *
+ * Parsing is delegated to the platform `URL` parser so the result always matches what the browser
+ * would do, including its normalization of leading control characters and embedded tabs/newlines.
+ *
+ * @internal
+ */
+export function isScriptUrl(href: string): boolean {
+  try {
+    return scriptProtocols.has(new URL(href).protocol.toLowerCase());
+  } catch {
+    // Anything unparsable as an absolute URL is navigated as a relative path and can't execute script.
+    return false;
+  }
+}


### PR DESCRIPTION
## Previous Behavior

`DocumentCard` navigates to `onClickHref` verbatim, via `window.location.href` or `window.open`, with no diagnostic of any kind. When an app forwards untrusted data into that prop, a `javascript:` or `vbscript:` URL executes in the app origin — and nothing in dev tells the developer that the value reached a navigation sink.

## New Behavior

In development builds only, activating a card whose `onClickHref` resolves to a `javascript:` or `vbscript:` URL logs a warning naming the component, the prop and the offending value, and pointing at protocol validation as the fix.

**Navigation behavior is unchanged** — every URL still navigates exactly as before, in both the `onClickTarget` (`window.open`) and default (`location.href`) branches. The new tests assert navigation still occurs for every case, including the blocked-looking ones.

Notes:

- Detection lives in a new internal `isScriptUrl` helper that delegates parsing to the platform `URL` constructor, so the check can never disagree with what the browser would actually do. Obfuscation handling comes free and correct from WHATWG normalization: `" javascript:"`, `java\nscript:`, `\0javascript:` and `JaVaScRiPt:` are all caught, while `\u200Bjavascript:` stays a relative path for both the check and the browser.
- Deliberately **not** a scheme allow-list. An allow-list would misclassify legitimate schemes DocumentCard consumers rely on — `ms-word:`, `onenote:`, `msteams:`, `sip:`, `blob:` and app-registered protocol handlers. The set of script-executing schemes is finite and known; the set of safe ones is not.
- `data:` is excluded: browsers already block top-level `data:` navigation, so warning on it would be noise.
- The helper is not re-exported from the package index or `Utilities`, so `react.api.md` is unchanged and no new public API is added.
- `warn()` itself is not dev-gated in `@fluentui/utilities`, so the call site carries the `process.env.NODE_ENV !== 'production'` guard, matching the convention used across v8 components.

Raised from an MSRC/ICM report against `onClickHref`. The report is being closed as By Design — `onClickHref` is a developer-authored prop whose documented contract is "a URL to navigate to", equivalent to `<a href={untrusted}>`, which React itself only dev-warns about. This PR is defense-in-depth plus documentation, not a security fix.

## Related Issue(s)

- n/a
