### PR TITLE
fix(web-components): support middle-click link navigation

### DIFF
--- a/change/@fluentui-web-components-7f2b5bb8-61b7-4d31-a7c8-dcd56ca6e38f.json
+++ b/change/@fluentui-web-components-7f2b5bb8-61b7-4d31-a7c8-dcd56ca6e38f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: support middle-click navigation for Link and AnchorButton",
+  "packageName": "@fluentui/web-components",
+  "email": "83942501+bhatmuneeb1@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/anchor-button/anchor-button.base.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.base.ts
@@ -184,6 +184,20 @@ export class BaseAnchor extends FASTElement {
   }
 
   /**
+   * Handles the anchor auxiliary click event.
+   *
+   * @param e - The event object
+   * @internal
+   */
+  public auxclickHandler(e: PointerEvent): boolean {
+    if (e.button === 1 && this.href) {
+      this.handleNavigation(true);
+    }
+
+    return true;
+  }
+
+  /**
    * Handles keydown events for the anchor.
    *
    * @param e - the keyboard event

--- a/packages/web-components/src/anchor-button/anchor-button.spec.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.spec.ts
@@ -222,6 +222,26 @@ test.describe('Anchor Button', () => {
     await newPage.close();
   });
 
+  test('should open the provided url in a new tab when middle-clicked', async ({ context, fastPage, page }) => {
+    const { element } = fastPage;
+
+    const expectedUrl = '#foo';
+
+    await fastPage.setTemplate({ attributes: { href: expectedUrl } });
+
+    const newPagePromise = context.waitForEvent('page');
+
+    await element.click({ button: 'middle' });
+
+    const newPage = await newPagePromise;
+
+    expect(page.url()).not.toMatch(expectedUrl);
+
+    expect(newPage.url()).toMatch(expectedUrl);
+
+    await newPage.close();
+  });
+
   test('should navigate to the provided url when `Enter` is pressed via keyboard', async ({ fastPage, page }) => {
     const { element } = fastPage;
 

--- a/packages/web-components/src/anchor-button/anchor-button.template.ts
+++ b/packages/web-components/src/anchor-button/anchor-button.template.ts
@@ -11,6 +11,7 @@ export function anchorTemplate<T extends AnchorButton>(options: AnchorOptions = 
     <template
       tabindex="0"
       @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"
+      @auxclick="${(x, c) => x.auxclickHandler(c.event as PointerEvent)}"
       @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
       ${startSlotTemplate(options)}

--- a/packages/web-components/src/link/link.spec.ts
+++ b/packages/web-components/src/link/link.spec.ts
@@ -109,4 +109,22 @@ test.describe('Link', () => {
 
     await expect(element).toHaveAttribute('data-click-count', '1');
   });
+
+  test('should open the provided url in a new tab when middle-clicked', async ({ context, fastPage, page }) => {
+    const { element } = fastPage;
+    const expectedUrl = '#foo';
+
+    await fastPage.setTemplate({ attributes: { href: expectedUrl } });
+
+    const newPagePromise = context.waitForEvent('page');
+
+    await element.click({ button: 'middle' });
+
+    const newPage = await newPagePromise;
+
+    expect(page.url()).not.toMatch(expectedUrl);
+    expect(newPage.url()).toMatch(expectedUrl);
+
+    await newPage.close();
+  });
 });

--- a/packages/web-components/src/link/link.template.ts
+++ b/packages/web-components/src/link/link.template.ts
@@ -10,6 +10,7 @@ export function anchorTemplate<T extends Link>(): ViewTemplate<T> {
     <template
       tabindex="0"
       @click="${(x, c) => x.clickHandler(c.event as PointerEvent)}"
+      @auxclick="${(x, c) => x.auxclickHandler(c.event as PointerEvent)}"
       @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
       <slot></slot>


### PR DESCRIPTION
## Previous Behavior

`fluent-link` and `fluent-anchor-button` handle primary clicks and Ctrl/Meta-clicks, but middle-clicking does not open the target in a new tab because the custom elements do not handle the `auxclick` event.

## New Behavior

Handle middle-button `auxclick` events in the shared `BaseAnchor` and route them through the existing new-tab navigation path.

Both `fluent-link` and `fluent-anchor-button` templates now bind `auxclick`, and Playwright regression coverage verifies that middle-click opens the configured `href` in a new page without navigating the current page.

A patch change file is included for `@fluentui/web-components`.

## Related Issue(s)

Fixes #36567