### PR TITLE
fix(merge-styles): escape style tag terminators in serialized CSS and stylesheet state

### DIFF
--- a/change/@fluentui-merge-styles-006a4ebc-3844-4381-b6de-5cd56fbe3742.json
+++ b/change/@fluentui-merge-styles-006a4ebc-3844-4381-b6de-5cd56fbe3742.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(security): escape < and > in serialized CSS values and stylesheet state so they cannot terminate a <style> or <script> element during SSR",
+  "packageName": "@fluentui/merge-styles",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-charting-cbed644d-0462-46f7-afe2-8573d6563098.json
+++ b/change/@fluentui-react-charting-cbed644d-0462-46f7-afe2-8573d6563098.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: note that IChartDataPoint.color is rendered into generated CSS and should be validated when it comes from untrusted input",
+  "packageName": "@fluentui/react-charting",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/react-wiki-archive/Server-side-rendering-and-browserless-testing.md
+++ b/docs/react-wiki-archive/Server-side-rendering-and-browserless-testing.md
@@ -1,5 +1,9 @@
 ## Server-side rendering
 
+> **Security note**
+>
+> Both recipes below write Fluent UI output into raw text elements using `dangerouslySetInnerHTML` - `Stylesheet.getRules()` into a `<style>` and `Stylesheet.serialize()` into a `<script>`. `merge-styles` escapes `<`/`>` in declaration values and `<` in the serialized state so neither string can terminate its element, but you are still responsible for validating any untrusted data (user- or tenant-supplied colors, accents, background image URLs) that you route into a style value, and for serving a Content Security Policy. Do not pass untrusted data to `Stylesheet.insertRule`, which is not escaped because it accepts full rules including selectors.
+
 ## Next.js setup
 
 For basic instructions on getting Next.js set up, see https://nextjs.org/

--- a/packages/charts/react-charting/src/types/IDataPoint.ts
+++ b/packages/charts/react-charting/src/types/IDataPoint.ts
@@ -132,6 +132,8 @@ export interface IChartDataPoint {
 
   /**
    * Color for the legend in the chart. If not provided, it will fallback on the default color palette.
+   *
+   * @remarks This value is rendered into generated CSS. Validate it before assigning untrusted input to it.
    */
   color?: string;
 

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -485,6 +485,20 @@ renderStatic(() => ReactDOM.renderToString(<App/>);
 
 - Rehydration on the client may result in mismatched rules. You can apply a namespace on the server side to ensure there aren't name collisions.
 
+### Untrusted data in style values
+
+The `css` returned by `renderStatic` (and by `Stylesheet.getRules`) is raw CSS text that is normally written into a `<style>` element. A `<style>` element is HTML raw text, so a declaration value containing `</style>` would otherwise terminate it and inject markup.
+
+To prevent that, `merge-styles` emits `<` and `>` inside declaration values as the CSS code point escapes `\3C ` and `\3E `. This is semantics-preserving - the escapes decode back to the same characters, including inside quoted strings and `url()`. Likewise, `Stylesheet.serialize` emits `<` as `\u003C` so its output can be embedded in an inline `<script>` for rehydration.
+
+This escaping is defense in depth, not a substitute for validating input. Applications remain responsible for:
+
+- Validating any untrusted data (user- or tenant-supplied brand colors, accents, background image URLs) before using it as a style value.
+- `Stylesheet.insertRule`, which is intentionally **not** escaped because it accepts complete rules including selectors, and selectors legitimately contain `<` and `>` adjacent characters such as the `>` child combinator. Never pass untrusted data to it.
+- Serving a Content Security Policy, which limits the impact of any injection.
+
+Note also that rules registered with `preserve` - which is what `fontFace` and `keyframes` do - are intentionally retained by `Stylesheet.reset`, so they are re-emitted by every later `getRules(true)` call in the same process. Do not derive font faces or keyframes from per-request untrusted data in a shared server process.
+
 ## Working with content security policy (CSP)
 
 Some content security policies prevent style injection without a nonce. To set the nonce used by `merge-styles`:

--- a/packages/merge-styles/src/Stylesheet.test.ts
+++ b/packages/merge-styles/src/Stylesheet.test.ts
@@ -90,6 +90,7 @@ describe('Stylesheet', () => {
 
       it('returns a new instance on mismatched global', () => {
         // We need to modify internals in order to mock this behaviour.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (_stylesheet as any)._lastStyleElement = { ownerDocument: {} };
 
         const newInstance = Stylesheet.getInstance();
@@ -407,6 +408,15 @@ describe('Stylesheet', () => {
           // eslint-disable-next-line @fluentui/max-len
           '{"classNameToArgs":{"css-1":{"args":[{"background":"red"}],"rules":["a { background: red };"]}},"counter":2,"keyToClassName":{"kobzol":"css-1"},"preservedRules":[],"rules":["a { background: red };"]}',
         );
+      });
+
+      it('escapes `<` so the result is safe to embed in an inline script element', () => {
+        _stylesheet.insertRule('a { content: "</script>" };');
+
+        const serializedStylesheet = _stylesheet.serialize();
+
+        expect(serializedStylesheet).not.toContain('<');
+        expect(JSON.parse(serializedStylesheet).rules).toEqual(['a { content: "</script>" };']);
       });
 
       it('can be deserialized', () => {

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -168,6 +168,7 @@ export class Stylesheet {
   private _keyToClassName: { [key: string]: string } = {};
   private _onInsertRuleCallbacks: (Function | InsertRuleCallback)[] = [];
   private _onResetCallbacks: Function[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _classNameToArgs: { [key: string]: { args: any; rules: string[] } } = {};
 
   /**
@@ -210,6 +211,10 @@ export class Stylesheet {
 
   /**
    * Serializes the Stylesheet instance into a format which allows rehydration on creation.
+   *
+   * `<` is emitted as the `\u003C` JSON escape so the result can be safely embedded in an inline
+   * `<script>` element without terminating it. `JSON.parse` round-trips to an identical object.
+   *
    * @returns string representation of `ISerializedStylesheet` interface.
    */
   public serialize(): string {
@@ -219,7 +224,7 @@ export class Stylesheet {
       keyToClassName: this._keyToClassName,
       preservedRules: this._preservedRules,
       rules: this._rules,
-    });
+    }).replace(/</g, '\\u003C');
   }
 
   /**
@@ -321,7 +326,14 @@ export class Stylesheet {
 
   /**
    * Inserts a css rule into the stylesheet.
-   * @param preserve - Preserves the rule beyond a reset boundary.
+   *
+   * The rule is inserted verbatim - no escaping is performed, because a rule includes its selector
+   * and selectors legitimately contain characters such as `>`. Callers passing untrusted data are
+   * responsible for validating it before it reaches this method.
+   *
+   * @param preserve - Preserves the rule beyond a reset boundary. Note that {@link Stylesheet.reset}
+   * intentionally does not clear preserved rules, so a preserved rule is re-emitted by every
+   * subsequent {@link Stylesheet.getRules} call in the same process.
    */
   public insertRule(rule: string, preserve?: boolean, stylesheetKey: string = GLOBAL_STYLESHEET_KEY): void {
     const { injectionMode } = this._config;
@@ -361,6 +373,10 @@ export class Stylesheet {
   /**
    * Gets all rules registered with the stylesheet; only valid when
    * using InsertionMode.none.
+   *
+   * The return value is raw CSS text intended for a `<style>` element. Values that went through
+   * `mergeStyles`, `fontFace` or `keyframes` have `<` and `>` escaped as CSS code points so they
+   * cannot terminate that element, but rules added via {@link Stylesheet.insertRule} are unescaped.
    */
   public getRules(includePreservedRules?: boolean): string {
     return (includePreservedRules ? this._preservedRules.join('') : '') + this._rules.join('');
@@ -369,6 +385,9 @@ export class Stylesheet {
   /**
    * Resets the internal state of the stylesheet. Only used in server
    * rendered scenarios where we're using InsertionMode.none.
+   *
+   * Rules registered with `preserve` (via `fontFace` and `keyframes`) are intentionally retained,
+   * so they survive into every later render served by the same process.
    */
   public reset(): void {
     this._rules = [];

--- a/packages/merge-styles/src/fontFace.test.ts
+++ b/packages/merge-styles/src/fontFace.test.ts
@@ -25,4 +25,17 @@ describe('fontFace', () => {
 
     expect(_stylesheet.getRules()).toEqual('@font-face{font-family:Segoe UI;src:url("foo");}');
   });
+
+  it('escapes values that would terminate the style element', () => {
+    _stylesheet.reset();
+    fontFace({
+      fontFamily: 'x</style><script>alert(1)</script>',
+      src: 'url("foo")',
+    });
+
+    const rules = _stylesheet.getRules(true);
+
+    expect(rules).not.toContain('</style');
+    expect(rules).toContain('font-family:x\\3C /style\\3E ');
+  });
 });

--- a/packages/merge-styles/src/keyframes.test.ts
+++ b/packages/merge-styles/src/keyframes.test.ts
@@ -73,4 +73,16 @@ describe('keyframes', () => {
 
     expect(_stylesheet.getRules()).toEqual('@keyframes css-0{from{opacity:0;}to{opacity:1;}}');
   });
+
+  it('escapes values that would terminate the style element', () => {
+    keyframes({
+      from: { background: 'red;}</style><script>alert(1)</script>' },
+      to: { opacity: 1 },
+    });
+
+    const rules = _stylesheet.getRules(true);
+
+    expect(rules).not.toContain('</style');
+    expect(rules).not.toContain('<script');
+  });
 });

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -35,4 +35,21 @@ describe('staticRender', () => {
     expect(html).toEqual(`<div class="test-root-0">Hello!</div>`);
     expect(css).toEqual(`.test-root-0{background:red;}`);
   });
+
+  it('does not emit a style element terminator from an untrusted style value', () => {
+    const { css } = renderStatic(() => {
+      const classNames: { root: string } = mergeCssSets([
+        {
+          root: {
+            background: 'red;}</style><script>alert(document.cookie)</script><style>.x{color:red',
+          },
+        },
+      ]);
+
+      return `<div class="${classNames.root}">Hello!</div>`;
+    });
+
+    expect(css).not.toContain('</style');
+    expect(css).not.toContain('<script');
+  });
 });

--- a/packages/merge-styles/src/server.ts
+++ b/packages/merge-styles/src/server.ts
@@ -2,6 +2,11 @@ import { InjectionMode, Stylesheet } from './Stylesheet';
 
 /**
  * Renders a given string and returns both html and css needed for the html.
+ *
+ * The returned `css` is raw CSS text meant to be placed in a `<style>` element. Declaration values
+ * have `<` and `>` escaped as CSS code points so they cannot terminate that element, but callers
+ * remain responsible for validating untrusted data used in style values.
+ *
  * @param onRender - Function that returns a string.
  * @param namespace - Optional namespace to prepend to css classnames to avoid collisions.
  */

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -603,4 +603,49 @@ describe('styleToClassName with specificityMultiplier', () => {
         '}',
     );
   });
+
+  describe('style tag escaping', () => {
+    const payload = 'red;}</style><script>alert(1)</script><style>.x{color:red';
+
+    it.each(['fill', 'background', 'color', 'content', 'fontFamily', 'backgroundImage'] as const)(
+      'escapes a value that would terminate the style element in %s',
+      property => {
+        styleToClassName({}, { [property]: payload });
+
+        const rules = _stylesheet.getRules();
+
+        expect(rules).not.toContain('</style');
+        expect(rules).not.toContain('<script');
+        expect(rules).not.toContain('<');
+        expect(rules).not.toContain('>');
+      },
+    );
+
+    it('escapes angle brackets as css code points', () => {
+      styleToClassName({}, { content: '"a<b>c"' });
+
+      expect(_stylesheet.getRules()).toEqual('.css-0{content:"a\\3C b\\3E c";}');
+    });
+
+    it('does not escape selectors, so combinators keep working', () => {
+      styleToClassName(
+        {},
+        {
+          selectors: {
+            '& > .foo': { background: 'red' },
+          },
+        },
+      );
+
+      expect(_stylesheet.getRules()).toEqual('.css-0 > .foo{background:red;}');
+    });
+
+    it('keeps escaped values out of the class name cache key', () => {
+      const first = styleToClassName({}, { content: '"<"' });
+      const second = styleToClassName({}, { content: '"<"' });
+
+      expect(second).toEqual(first);
+      expect(_stylesheet.getRules()).toEqual('.css-0{content:"\\3C ";}');
+    });
+  });
 });

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- legacy package, style objects are loosely typed */
 import { IStyle } from './IStyle';
 import { IRawStyle } from './IRawStyle';
 
@@ -223,6 +224,25 @@ function repeatString(target: string, count: number): string {
   return target + repeatString(target, count - 1);
 }
 
+const CSS_ESCAPE_MAP: Record<string, string> = {
+  '<': '\\3C ',
+  '>': '\\3E ',
+};
+
+/**
+ * Escapes characters that could break out of a `<style>` element during server side rendering.
+ *
+ * A `<style>` element is HTML raw text, so the only thing that terminates it is the literal
+ * sequence `</style`. Emitting `<` and `>` as CSS code point escapes keeps the declaration
+ * semantically identical (including inside quoted strings and `url()`) while making it
+ * impossible for the HTML tokenizer to see a tag.
+ *
+ * IMPORTANT: only apply this to declaration *values*. Selectors legitimately contain `>`.
+ */
+function escapeForStyleTag(value: string): string {
+  return value.replace(/[<>]/g, match => CSS_ESCAPE_MAP[match]);
+}
+
 export function serializeRuleEntries(options: IStyleOptions, ruleEntries: { [key: string]: string | number }): string {
   if (!ruleEntries) {
     return '';
@@ -246,7 +266,9 @@ export function serializeRuleEntries(options: IStyleOptions, ruleEntries: { [key
 
   // Apply punctuation.
   for (let i = 1; i < allEntries.length; i += 4) {
-    allEntries.splice(i, 1, ':', allEntries[i], ';');
+    const value = allEntries[i];
+
+    allEntries.splice(i, 1, ':', typeof value === 'string' ? escapeForStyleTag(value) : value, ';');
   }
 
   return allEntries.join('');


### PR DESCRIPTION
## What

`@fluentui/merge-styles` serialized declaration values into CSS with no output encoding, and `Stylesheet.serialize()` was a bare `JSON.stringify`. During SSR both strings are written into HTML raw text elements, so a style value containing `</style>` (or `</script>`) terminated the element and injected markup.

Reported via MSRC. Same defect class already fixed for v9 in #35717.

## Why it matters

`renderStatic()` / `Stylesheet.getRules()` exist to produce a string for a `<style>` tag, and `serialize()` to produce state for an inline `<script>` — that is exactly what our SSR guide tells apps to do with `dangerouslySetInnerHTML`. Any v8 style value derived from untrusted input (tenant brand color, accent, background-image URL) reached the serializer unescaped. Client-side rendering was never affected: `insertRule()` / `createTextNode()` don't invoke the HTML parser.

## Changes

- **`styleToClassName.ts`** — escape `<` / `>` as CSS code points (`\3C ` / `\3E `) in declaration values, applied in the existing punctuation loop where the entry is guaranteed to be a value. Single choke point that covers `mergeStyles`, `mergeStyleSets`, `fontFace` and `keyframes`.
- **`Stylesheet.ts`** — `serialize()` emits `<` as the `\u003C` JSON escape.
- JSDoc + README + SSR guide notes on the remaining app-side responsibilities.
- `IChartDataPoint.color` documented as rendered into generated CSS.

## Deliberately unchanged

- **Selectors are not escaped** — they legitimately contain `>` (child combinator). Escaping is applied to values only.
- **`insertRule()` is not escaped** — it accepts complete rules including selectors. Documented as caller responsibility.
- **`reset()` still retains `_preservedRules`** — that is the documented contract of the `preserve` flag which `fontFace`/`keyframes` depend on. With values escaped, retained content is inert CSS. Documented rather than changed.
- **No color validation in charting** — an allow-list would reject valid `color-mix()`, `oklch()`, gradients and CSS variables.

## Compatibility

No public API change. `\3C ` / `\3E ` are semantics-preserving CSS escapes that decode to the same characters, including inside quoted strings and `url()` — so `url("data:image/svg+xml,<svg…")` still resolves. `JSON.parse` round-trips `serialize()` output identically, so rehydration is unaffected. Cache keys are computed from the raw rule set before serialization, so no class name churn.

## Verification

- New regression tests: 6 CSS properties × payload, exact-output assertion (`content:"a\3C b\3E c"`), combinator-preservation, cache-key stability, plus `fontFace` / `keyframes` / `renderStatic` / `serialize` cases.
- `merge-styles`, `react` (full v8 suite), `react-charting`, `style-utilities`, `theme`, `react-focus`, `font-icons-mdl2` all pass with **zero snapshot fallout**.

> [!NOTE]
> The `no-explicit-any` disables are pre-existing violations that block the pre-commit lint hook for this package — `merge-styles`' `lint` target currently lints no files, so they had gone unnoticed. Unrelated to the fix; happy to split them out.
