### PR TITLE
feat(verify-bundle-isolation)!: select fixtures via per-fixture config

### DIFF
--- a/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
+++ b/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
@@ -4,8 +4,6 @@
   "externals": ["react", "react-dom", "react/jsx-runtime", "react/compiler-runtime"],
   "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons"],
   "fixtures": {
-    "AllComponents.fixture.js": {},
-    "TagPicker.fixture.js": {},
-    "TeachingPopover.fixture.js": {}
+    "AllComponents.fixture.js": {}
   }
 }

--- a/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
+++ b/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
@@ -3,5 +3,9 @@
   "fixturesRoot": "./bundle-size",
   "externals": ["react", "react-dom", "react/jsx-runtime", "react/compiler-runtime"],
   "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons"],
-  "allowedViolations": {}
+  "fixtures": {
+    "AllComponents.fixture.js": {},
+    "TagPicker.fixture.js": {},
+    "TeachingPopover.fixture.js": {}
+  }
 }

--- a/scripts/beachball/base.config.js
+++ b/scripts/beachball/base.config.js
@@ -22,6 +22,7 @@ const config = {
     '**/.storybook/**',
     '**/bundle-size/**',
     '**/monosize.config.mjs',
+    '**/bundle-isolation.config.json',
     '**/common/isConformant.ts',
     '**/src/testing/**',
     '**/src/e2e/**',

--- a/scripts/beachball/src/config.test.ts
+++ b/scripts/beachball/src/config.test.ts
@@ -51,6 +51,7 @@ describe(`beachball configs`, () => {
         '**/.storybook/**',
         '**/bundle-size/**',
         '**/monosize.config.mjs',
+        '**/bundle-isolation.config.json',
         '**/common/isConformant.ts',
         '**/src/testing/**',
         '**/src/e2e/**',

--- a/tools/verify-bundle-isolation/README.md
+++ b/tools/verify-bundle-isolation/README.md
@@ -67,25 +67,26 @@ changed module resolution in a way that makes these packages resolve to sources 
 
 ## Verdicts
 
-| Verdict          | Exit | Meaning                                                                                                                            |
-| ---------------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `PASS`           | 0    | No forbidden package survived bundling. Only this verdict claims a bundle is free of them.                                         |
-| `PASS WITH DEBT` | 0    | Every surviving forbidden package is on the allowlist. The leaks are listed with their module counts and entry points.             |
-| `FAIL`           | 1    | A regression, a stale or orphaned allowlist entry, a fixture that failed to bundle, or — under `--strict` — any allowed violation. |
+| Verdict          | Exit | Meaning                                                                                                                                           |
+| ---------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PASS`           | 0    | No forbidden package survived bundling. Only this verdict claims a bundle is free of them.                                                        |
+| `PASS WITH DEBT` | 0    | Every surviving forbidden package is on the allowlist. The leaks are listed with their module counts and entry points.                            |
+| `FAIL`           | 1    | A regression, a stale allowlist entry, an orphaned fixture entry, a fixture that failed to bundle, or — under `--strict` — any allowed violation. |
 
 Per fixture the report labels each finding `CLEAN`, `ALLOWED`, `REGRESSION`, `STALE` or `ERROR`; a single fixture can
-carry more than one label. Module and export counts come from a build with `minimize: false`, so they measure how much
-of a package is retained, not what it costs to ship — use monosize for bytes.
+carry more than one label. Fixtures found in `fixturesRoot` but not opted in are listed under `SKIPPED`. Module and
+export counts come from a build with `minimize: false`, so they measure how much of a package is retained, not what it
+costs to ship — use monosize for bytes.
 
 ## Output
 
 `dist/bundle-isolation/` is wiped on every run, so it only ever contains the fixtures that currently exist.
 
-| Path                    | Written          | Contents                                                                                                                                                               |
-| ----------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `summary.json`          | always           | The console verdict in structured form — overall `status`, and per fixture its `status`, `allowedViolations`, `tolerated`, `regressions`, `stale` and full `leaks` map |
-| `<Fixture>/report.html` | with `--analyze` | webpack-bundle-analyzer treemap                                                                                                                                        |
-| `<Fixture>/report.json` | with `--analyze` | The same data the treemap renders from — module tree with `statSize`, `parsedSize` and `gzipSize`                                                                      |
+| Path                    | Written          | Contents                                                                                                                                                                                                                                           |
+| ----------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `summary.json`          | always           | The console verdict in structured form — overall `status`, `skippedFixtures`, `orphanedFixtureEntries`, and per fixture its `status`, effective `forbiddenPackages`, `allowedViolations`, `tolerated`, `regressions`, `stale` and full `leaks` map |
+| `<Fixture>/report.html` | with `--analyze` | webpack-bundle-analyzer treemap                                                                                                                                                                                                                    |
+| `<Fixture>/report.json` | with `--analyze` | The same data the treemap renders from — module tree with `statSize`, `parsedSize` and `gzipSize`                                                                                                                                                  |
 
 `leaks` maps a forbidden package to the exports that survived tree shaking and the modules importing them, so the
 summary answers _what_ leaked and _why_, while the analyzer output answers _how much_ it costs.
@@ -100,8 +101,10 @@ summary answers _what_ leaked and _why_, while the analyzer output answers _how 
   "fixturesRoot": "./bundle-size",
   "externals": ["react", "react-dom", "react/jsx-runtime", "react/compiler-runtime"],
   "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons"],
-  "allowedViolations": {
-    "AllComponents.fixture.js": ["@fluentui/react-icons"]
+  "fixtures": {
+    "AllComponents.fixture.js": { "allowedViolations": ["@fluentui/react-icons"] },
+    "TagPicker.fixture.js": {},
+    "Headless.fixture.js": { "forbiddenPackages": ["@griffel/*"] }
   }
 }
 ```
@@ -111,13 +114,16 @@ All configured paths are resolved relative to the package root:
 - `fixturesRoot` is the directory containing bundle-size fixtures.
 - `externals` lists host-provided modules excluded from the bundle.
 - `forbiddenPackages` lists exact package names or scoped globs such as `@griffel/*`.
-- `allowedViolations` maps fixture paths, relative to `fixturesRoot` and always with forward slashes, to tolerated
-  forbidden packages.
+- `fixtures` selects which fixtures to verify, keyed by path relative to `fixturesRoot` and always with forward slashes.
 
-The two lists do not take the same values. `forbiddenPackages` declares intent, so it accepts globs. `allowedViolations`
-records what actually leaked, so it takes **exact resolved package names** and rejects globs - `@griffel/*` there would
-let a newly leaked `@griffel/anything` hide behind an entry approved for something else. The debt has to name what it
-is: `@griffel/core` and `@griffel/react`, separately.
+A fixture entry takes two optional keys. `allowedViolations` records tolerated forbidden packages for that fixture.
+`forbiddenPackages` **replaces** the package-level list for that fixture — it overrides rather than extends, because
+otherwise a fixture could only ever widen the intent, never narrow it.
+
+The two package lists do not take the same values. `forbiddenPackages` declares intent, so it accepts globs.
+`allowedViolations` records what actually leaked, so it takes **exact resolved package names** and rejects globs -
+`@griffel/*` there would let a newly leaked `@griffel/anything` hide behind an entry approved for something else. The
+debt has to name what it is: `@griffel/core` and `@griffel/react`, separately.
 
 `$schema` has to be a workspace-relative path. Editors resolve it against the config file and do not apply Node package
 resolution, so `@fluentui/verify-bundle-isolation/schema.json` will not work there despite the export map. The export
@@ -142,13 +148,26 @@ export default {
 
 Sharing fixtures keeps isolation checks and bundle-size measurements aligned.
 
+## Selecting fixtures
+
+`fixturesRoot` is usually shared with monosize, whose fixtures exist to measure bytes and legitimately bundle styling
+engines and icons. Verifying everything found there would force every such fixture onto the allowlist, turning tracked
+debt into permanent noise and adding churn to an unrelated workflow every time a bundle-size fixture is added.
+
+So the check is opt-in: only the fixtures named in `fixtures` are bundled. The rest are reported as `SKIPPED` rather
+than dropped quietly, so what is left unguarded stays visible in CI output and in `summary.json`.
+
+The trade-off is that a newly added fixture is not covered until someone lists it. A key naming a fixture that does not
+exist fails the run as an orphan, and a configuration where no listed fixture exists fails rather than reporting a clean
+run over nothing.
+
 ## Allowed violations
 
 `allowedViolations` is tracked debt, not an exemption. It is shrink-only:
 
 - A newly retained forbidden package fails the check.
 - A package that no longer survives bundling also fails the check until its entry is removed.
-- An entry for a missing fixture fails the check.
+- A fixture entry naming a fixture that does not exist fails the check.
 
 This prevents fixed leaks from being silently reintroduced. Deleting an entry is the goal; adding one is a regression.
 

--- a/tools/verify-bundle-isolation/schema.json
+++ b/tools/verify-bundle-isolation/schema.json
@@ -32,20 +32,38 @@
         "minLength": 1
       }
     },
-    "allowedViolations": {
-      "description": "Bundle-size fixture paths mapped to forbidden packages tolerated as tracked debt. Fixture paths use forward slashes and are relative to fixturesRoot.",
+    "fixtures": {
+      "description": "Fixtures to verify, keyed by path relative to fixturesRoot using forward slashes. A fixture present in fixturesRoot but absent here is skipped, which is how a directory shared with monosize is narrowed to the entry points that carry an isolation guarantee.",
       "type": "object",
+      "minProperties": 1,
       "additionalProperties": {
-        "type": "array",
-        "uniqueItems": true,
-        "items": {
-          "description": "Exact resolved package name. Globs are rejected so a tolerated leak cannot silently cover a new one.",
-          "type": "string",
-          "minLength": 1,
-          "pattern": "^[^*]+$"
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "forbiddenPackages": {
+            "description": "Replaces the top-level list for this fixture. Narrowing has to be possible, so this overrides rather than extends.",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "allowedViolations": {
+            "description": "Forbidden packages tolerated as tracked debt for this fixture.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "description": "Exact resolved package name. Globs are rejected so a tolerated leak cannot silently cover a new one.",
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[^*]+$"
+            }
+          }
         }
       }
     }
   },
-  "required": ["fixturesRoot", "externals", "forbiddenPackages", "allowedViolations"]
+  "required": ["fixturesRoot", "externals", "forbiddenPackages", "fixtures"]
 }

--- a/tools/verify-bundle-isolation/src/cli.ts
+++ b/tools/verify-bundle-isolation/src/cli.ts
@@ -14,7 +14,17 @@ import { parseArgs } from 'node:util';
 import webpack, { type Configuration, type Stats, type WebpackPluginInstance } from 'webpack';
 
 import { BundleIsolationPlugin, type BundleIsolationReport } from './bundle-isolation-plugin';
-import { findFixtures, findWorkspaceRoot, fixtureOutputPath, loadConfig, outputRoot, readJson } from './config';
+import {
+  findFixtures,
+  findWorkspaceRoot,
+  fixtureOutputPath,
+  forbiddenFor,
+  loadConfig,
+  outputRoot,
+  readJson,
+  relativeToWorkspace,
+  selectFixtures,
+} from './config';
 import {
   type FixtureResult,
   type Report,
@@ -37,10 +47,21 @@ export async function cli(): Promise<void> {
   const config = loadConfig(args.configPath, workspaceRoot);
   const packageJson = readJson(join(packageRoot, 'package.json'));
   const fixturesRoot = resolve(packageRoot, config.fixturesRoot);
-  const fixtures = findFixtures(fixturesRoot);
+  const discovered = findFixtures(fixturesRoot);
 
-  if (fixtures.length === 0) {
+  if (discovered.length === 0) {
     console.error(`No bundle-size fixtures found in ${packageJson.name} - nothing to verify.`);
+    process.exit(1);
+  }
+
+  const selection = selectFixtures(discovered, config);
+
+  // An all-orphan configuration would otherwise report a clean run without bundling anything.
+  if (selection.verified.length === 0) {
+    console.error(
+      `None of the ${discovered.length} fixtures in ${packageJson.name} are listed under "fixtures" in ` +
+        `${relativeToWorkspace(args.configPath, workspaceRoot)} - nothing to verify.`,
+    );
     process.exit(1);
   }
 
@@ -49,8 +70,8 @@ export async function cli(): Promise<void> {
   // Fixtures come and go; a stale output directory would otherwise be mistaken for a fresh report.
   rmSync(outputRoot(packageRoot), { recursive: true, force: true });
 
-  const results = await Promise.all(fixtures.map(fixture => verifyFixture(fixture, options)));
-  const report = createReport({ packageName: packageJson.name, results, fixtures, options });
+  const results = await Promise.all(selection.verified.map(fixture => verifyFixture(fixture, options)));
+  const report = createReport({ packageName: packageJson.name, results, selection, options });
   const summaryPath = writeSummary(report);
 
   // One stream for the whole report - splitting it would let the shell interleave the verdict.
@@ -155,7 +176,7 @@ function createWebpackConfig(
     optimization: { concatenateModules: false, minimize: false },
     plugins: [
       new BundleIsolationPlugin({
-        forbiddenPackages: options.config.forbiddenPackages,
+        forbiddenPackages: forbiddenFor(fixture, options.config),
         workspaceRoot: options.workspaceRoot,
         packageRoot: options.packageRoot,
         onReport,

--- a/tools/verify-bundle-isolation/src/config.spec.ts
+++ b/tools/verify-bundle-isolation/src/config.spec.ts
@@ -2,7 +2,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { findFixtures, fixtureOutputPath, loadConfig, outputRoot, relativeToWorkspace } from './config';
+import {
+  allowedFor,
+  findFixtures,
+  fixtureOutputPath,
+  forbiddenFor,
+  loadConfig,
+  outputRoot,
+  relativeToWorkspace,
+  selectFixtures,
+} from './config';
 
 describe('loadConfig', () => {
   let root: string;
@@ -19,7 +28,7 @@ describe('loadConfig', () => {
     fixturesRoot: './bundle-size',
     externals: ['react'],
     forbiddenPackages: ['tabster'],
-    allowedViolations: {},
+    fixtures: { 'A.fixture.js': {} },
   };
 
   const load = (config: object) => {
@@ -40,20 +49,36 @@ describe('loadConfig', () => {
     expect(() => load({ ...valid, forbiddenPackages: [] })).toThrow(/must NOT have fewer than 1 items/);
   });
 
+  it('rejects an empty fixture list, which would leave nothing to verify', () => {
+    expect(() => load({ ...valid, fixtures: {} })).toThrow(/must NOT have fewer than 1 properties/);
+  });
+
   it('rejects unknown fields, so a typo cannot be mistaken for configuration', () => {
     expect(() => load({ ...valid, knownViolations: {} })).toThrow(/must NOT have additional properties/);
   });
 
+  it('rejects an unknown field inside a fixture entry', () => {
+    expect(() => load({ ...valid, fixtures: { 'A.fixture.js': { allowed: [] } } })).toThrow(
+      /must NOT have additional properties/,
+    );
+  });
+
   it('rejects a glob in allowedViolations, which would silently absorb an unrelated leak', () => {
-    expect(() => load({ ...valid, allowedViolations: { 'A.fixture.js': ['@griffel/*'] } })).toThrow(
+    expect(() => load({ ...valid, fixtures: { 'A.fixture.js': { allowedViolations: ['@griffel/*'] } } })).toThrow(
       /must match pattern/,
     );
   });
 
   it('accepts an exact package name in allowedViolations', () => {
-    expect(load({ ...valid, allowedViolations: { 'A.fixture.js': ['@griffel/core'] } }).allowedViolations).toEqual({
-      'A.fixture.js': ['@griffel/core'],
-    });
+    const config = load({ ...valid, fixtures: { 'A.fixture.js': { allowedViolations: ['@griffel/core'] } } });
+
+    expect(config.fixtures).toEqual({ 'A.fixture.js': { allowedViolations: ['@griffel/core'] } });
+  });
+
+  it('accepts a per-fixture forbidden list, so a fixture can narrow the package-level intent', () => {
+    const config = load({ ...valid, fixtures: { 'A.fixture.js': { forbiddenPackages: ['@griffel/*'] } } });
+
+    expect(config.fixtures['A.fixture.js'].forbiddenPackages).toEqual(['@griffel/*']);
   });
 
   it('reports the offending path relative to the workspace', () => {
@@ -85,6 +110,54 @@ describe('findFixtures', () => {
 
     // Asserted as a literal rather than via join(), because these become config keys on every platform.
     expect(findFixtures(root)).toEqual(['A.fixture.js', 'B.fixture.js', 'nested/C.fixture.js']);
+  });
+});
+
+describe('selectFixtures', () => {
+  const config = {
+    fixturesRoot: './bundle-size',
+    externals: [],
+    forbiddenPackages: ['tabster'],
+    fixtures: { 'A.fixture.js': {}, 'nested/C.fixture.js': {}, 'Gone.fixture.js': {} },
+  };
+
+  it('verifies only what the configuration opted in to', () => {
+    const selection = selectFixtures(['A.fixture.js', 'B.fixture.js', 'nested/C.fixture.js'], config);
+
+    expect(selection.verified).toEqual(['A.fixture.js', 'nested/C.fixture.js']);
+  });
+
+  it('reports a discovered but unlisted fixture as skipped rather than dropping it silently', () => {
+    const selection = selectFixtures(['A.fixture.js', 'B.fixture.js', 'nested/C.fixture.js'], config);
+
+    expect(selection.skipped).toEqual(['B.fixture.js']);
+  });
+
+  it('reports a listed fixture that no longer exists as an orphan', () => {
+    const selection = selectFixtures(['A.fixture.js', 'B.fixture.js', 'nested/C.fixture.js'], config);
+
+    expect(selection.orphans).toEqual(['Gone.fixture.js']);
+  });
+});
+
+describe('forbiddenFor', () => {
+  const config = {
+    fixturesRoot: './bundle-size',
+    externals: [],
+    forbiddenPackages: ['tabster', '@griffel/*'],
+    fixtures: { 'A.fixture.js': {}, 'B.fixture.js': { forbiddenPackages: ['@griffel/*'] } },
+  };
+
+  it('falls back to the package-level list', () => {
+    expect(forbiddenFor('A.fixture.js', config)).toEqual(['tabster', '@griffel/*']);
+  });
+
+  it('replaces rather than extends, so a fixture can narrow the list', () => {
+    expect(forbiddenFor('B.fixture.js', config)).toEqual(['@griffel/*']);
+  });
+
+  it('treats a fixture with no allowlist as carrying no debt', () => {
+    expect(allowedFor('A.fixture.js', config)).toEqual([]);
   });
 });
 

--- a/tools/verify-bundle-isolation/src/config.ts
+++ b/tools/verify-bundle-isolation/src/config.ts
@@ -7,11 +7,23 @@ import { dirname, isAbsolute, join, sep } from 'node:path';
 
 import Ajv, { type ErrorObject } from 'ajv';
 
+export interface FixtureConfig {
+  forbiddenPackages?: string[];
+  allowedViolations?: string[];
+}
+
 export interface Config {
   fixturesRoot: string;
   externals: string[];
   forbiddenPackages: string[];
-  allowedViolations: Record<string, string[]>;
+  fixtures: Record<string, FixtureConfig>;
+}
+
+/** Discovered fixtures split against the ones the configuration opted in to. */
+export interface FixtureSelection {
+  verified: string[];
+  skipped: string[];
+  orphans: string[];
 }
 
 const schemaPath = join(__dirname, '..', 'schema.json');
@@ -51,6 +63,29 @@ export function findFixtures(fixturesRoot: string): string[] {
       )
       .sort()
   );
+}
+
+/**
+ * Fixture directories are shared with monosize, so discovery alone would drag in fixtures that were
+ * never meant to carry an isolation guarantee. Only what the configuration names is verified.
+ */
+export function selectFixtures(discovered: string[], config: Config): FixtureSelection {
+  const listed = Object.keys(config.fixtures);
+
+  return {
+    verified: discovered.filter(fixture => listed.includes(fixture)),
+    skipped: discovered.filter(fixture => !listed.includes(fixture)),
+    orphans: listed.filter(fixture => !discovered.includes(fixture)).sort(),
+  };
+}
+
+/** Overrides rather than extends, so a fixture can narrow the forbidden set and not only widen it. */
+export function forbiddenFor(fixture: string, config: Config): string[] {
+  return config.fixtures[fixture]?.forbiddenPackages ?? config.forbiddenPackages;
+}
+
+export function allowedFor(fixture: string, config: Config): string[] {
+  return config.fixtures[fixture]?.allowedViolations ?? [];
 }
 
 export function findWorkspaceRoot(startDir: string): string {

--- a/tools/verify-bundle-isolation/src/report.spec.ts
+++ b/tools/verify-bundle-isolation/src/report.spec.ts
@@ -1,3 +1,4 @@
+import { type Config, type FixtureConfig, selectFixtures } from './config';
 import {
   type FixtureResult,
   type RuntimeOptions,
@@ -57,7 +58,7 @@ describe('createReport', () => {
     const report = createReport(
       input({
         results: [fixtureResult({ found: ['allowed-pkg'] })],
-        allowedViolations: { 'A.fixture.js': ['allowed-pkg'] },
+        fixtures: { 'A.fixture.js': { allowedViolations: ['allowed-pkg'] } },
       }),
     );
 
@@ -68,7 +69,7 @@ describe('createReport', () => {
     const report = createReport(
       input({
         results: [fixtureResult({ found: ['allowed-pkg'] })],
-        allowedViolations: { 'A.fixture.js': ['allowed-pkg'] },
+        fixtures: { 'A.fixture.js': { allowedViolations: ['allowed-pkg'] } },
         strict: true,
       }),
     );
@@ -76,18 +77,33 @@ describe('createReport', () => {
     expect(report).toMatchObject({ failed: true, status: 'failed' });
   });
 
-  it('fails on an allowlist entry for a fixture that does not exist', () => {
-    const report = createReport(input({ results: [fixtureResult()], allowedViolations: { 'Gone.fixture.js': ['x'] } }));
+  it('fails on a fixture entry for a fixture that does not exist', () => {
+    const report = createReport(
+      input({
+        results: [fixtureResult()],
+        fixtures: { 'A.fixture.js': {}, 'Gone.fixture.js': { allowedViolations: ['x'] } },
+      }),
+    );
 
     expect(report.orphans).toEqual([{ fixture: 'Gone.fixture.js', packages: ['x'] }]);
     expect(report.failed).toBe(true);
+  });
+
+  it('reports a discovered fixture that was not opted in as skipped rather than verified', () => {
+    const report = createReport(
+      input({ results: [fixtureResult()], discovered: ['A.fixture.js', 'Monosize.fixture.js'] }),
+    );
+
+    expect(report.skipped).toEqual(['Monosize.fixture.js']);
+    expect(report.failed).toBe(false);
   });
 
   it('totals findings across fixtures', () => {
     const report = createReport(
       input({
         results: [fixtureResult({ found: ['a-pkg'] }), fixtureResult({ fixture: 'B.fixture.js', found: ['b-pkg'] })],
-        fixtures: ['A.fixture.js', 'B.fixture.js'],
+        discovered: ['A.fixture.js', 'B.fixture.js'],
+        fixtures: { 'A.fixture.js': {}, 'B.fixture.js': {} },
       }),
     );
 
@@ -107,7 +123,7 @@ describe('formatReport', () => {
       createReport(
         input({
           results: [fixtureResult({ found: ['forbidden-pkg'], leaks: { 'forbidden-pkg': leak() } })],
-          allowedViolations: { 'A.fixture.js': ['forbidden-pkg'] },
+          fixtures: { 'A.fixture.js': { allowedViolations: ['forbidden-pkg'] } },
         }),
       ),
       '/ws/summary.json',
@@ -115,6 +131,34 @@ describe('formatReport', () => {
 
     expect(text).not.toContain('free of');
     expect(text).toContain('PASS WITH DEBT - 1 fixture, 0 regressions, 1 allowed violation');
+  });
+
+  it('names the fixtures it skipped, so an opted-out fixture is never silently unguarded', () => {
+    const text = formatReport(
+      createReport(input({ results: [fixtureResult()], discovered: ['A.fixture.js', 'Monosize.fixture.js'] })),
+      '/ws/summary.json',
+    );
+
+    expect(text).toContain('  SKIPPED     1 fixture not listed under "fixtures" in packages/thing/config.json');
+    expect(text).toContain('    Monosize.fixture.js');
+    expect(text).toContain('PASS - 1 fixture, 1 skipped free of');
+  });
+
+  it('shows the forbidden list only for a fixture that overrides it', () => {
+    const text = formatReport(
+      createReport(
+        input({
+          results: [fixtureResult(), fixtureResult({ fixture: 'B.fixture.js' })],
+          discovered: ['A.fixture.js', 'B.fixture.js'],
+          fixtures: { 'A.fixture.js': {}, 'B.fixture.js': { forbiddenPackages: ['@scope/*'] } },
+        }),
+      ),
+      '/ws/summary.json',
+    );
+
+    expect(text).toContain('  CLEAN       B.fixture.js\n    forbidden: @scope/*');
+    expect(text).toContain('  CLEAN       A.fixture.js\n');
+    expect(text).not.toContain('  CLEAN       A.fixture.js\n    forbidden:');
   });
 
   it('lists allowlisted leaks with their size and entry points, ordered by cost', () => {
@@ -130,7 +174,7 @@ describe('formatReport', () => {
               },
             }),
           ],
-          allowedViolations: { 'A.fixture.js': ['forbidden-pkg', '@scope/styles'] },
+          fixtures: { 'A.fixture.js': { allowedViolations: ['forbidden-pkg', '@scope/styles'] } },
         }),
       ),
       '/ws/summary.json',
@@ -148,7 +192,7 @@ describe('formatReport', () => {
       createReport(
         input({
           results: [fixtureResult({ found: ['@scope/styles'], leaks: { '@scope/styles': leak() } })],
-          allowedViolations: { 'A.fixture.js': ['@scope/styles'] },
+          fixtures: { 'A.fixture.js': { allowedViolations: ['@scope/styles'] } },
         }),
       ),
       '/ws/summary.json',
@@ -178,7 +222,9 @@ describe('formatReport', () => {
 
   it('tells the reader how to lock in a fix rather than reporting it as a plain failure', () => {
     const text = formatReport(
-      createReport(input({ results: [fixtureResult()], allowedViolations: { 'A.fixture.js': ['fixed-pkg'] } })),
+      createReport(
+        input({ results: [fixtureResult()], fixtures: { 'A.fixture.js': { allowedViolations: ['fixed-pkg'] } } }),
+      ),
       '/ws/summary.json',
     );
 
@@ -191,7 +237,7 @@ describe('formatReport', () => {
       createReport(
         input({
           results: [fixtureResult({ found: ['forbidden-pkg'], leaks: { 'forbidden-pkg': leak() } })],
-          allowedViolations: { 'A.fixture.js': ['forbidden-pkg'] },
+          fixtures: { 'A.fixture.js': { allowedViolations: ['forbidden-pkg'] } },
           strict: true,
         }),
       ),
@@ -221,7 +267,7 @@ describe('createSummary', () => {
           results: [
             fixtureResult({ found: ['forbidden-pkg'], leaks: { 'forbidden-pkg': leak({ via: 'lib/entry.js' }) } }),
           ],
-          allowedViolations: { 'A.fixture.js': ['forbidden-pkg'] },
+          fixtures: { 'A.fixture.js': { allowedViolations: ['forbidden-pkg'] } },
         }),
       ),
     );
@@ -303,17 +349,24 @@ function leak({ modules = 2, via = null }: { modules?: number; via?: string | nu
 
 function input({
   results,
-  fixtures = ['A.fixture.js'],
-  allowedViolations = {},
+  discovered = ['A.fixture.js'],
+  fixtures = { 'A.fixture.js': {} },
   strict = false,
   analyze = false,
 }: {
   results: FixtureResult[];
-  fixtures?: string[];
-  allowedViolations?: Record<string, string[]>;
+  discovered?: string[];
+  fixtures?: Record<string, FixtureConfig>;
   strict?: boolean;
   analyze?: boolean;
 }) {
+  const config: Config = {
+    fixturesRoot: './bundle-size',
+    externals: [],
+    forbiddenPackages: ['forbidden-pkg', '@scope/*'],
+    fixtures,
+  };
+
   const options: RuntimeOptions = {
     configPath: '/ws/packages/thing/config.json',
     analyze,
@@ -321,13 +374,8 @@ function input({
     fixturesRoot: '/ws/packages/thing/bundle-size',
     packageRoot,
     workspaceRoot,
-    config: {
-      fixturesRoot: './bundle-size',
-      externals: [],
-      forbiddenPackages: ['forbidden-pkg', '@scope/*'],
-      allowedViolations,
-    },
+    config,
   };
 
-  return { packageName: '@fluentui/thing', results, fixtures, options };
+  return { packageName: '@fluentui/thing', results, selection: selectFixtures(discovered, config), options };
 }

--- a/tools/verify-bundle-isolation/src/report.ts
+++ b/tools/verify-bundle-isolation/src/report.ts
@@ -5,7 +5,14 @@
 import { join } from 'node:path';
 
 import type { Leak } from './bundle-isolation-plugin';
-import { type Config, fixtureOutputPath, relativeToWorkspace } from './config';
+import {
+  type Config,
+  type FixtureSelection,
+  allowedFor,
+  fixtureOutputPath,
+  forbiddenFor,
+  relativeToWorkspace,
+} from './config';
 
 export interface RuntimeOptions {
   configPath: string;
@@ -29,6 +36,7 @@ export type FixtureStatus = 'error' | 'regression' | 'stale' | 'allowed' | 'clea
 
 export interface Outcome extends FixtureResult {
   status: FixtureStatus;
+  forbidden: string[];
   allowed: string[];
   tolerated: string[];
   regressions: string[];
@@ -51,6 +59,7 @@ export interface Report {
   packageName: string;
   options: RuntimeOptions;
   outcomes: Outcome[];
+  skipped: string[];
   orphans: Orphan[];
   totals: Totals;
   failed: boolean;
@@ -66,16 +75,21 @@ const MAX_IMPORTERS = 2;
 export function createReport({
   packageName,
   results,
-  fixtures,
+  selection,
   options,
 }: {
   packageName: string;
   results: FixtureResult[];
-  fixtures: string[];
+  selection: FixtureSelection;
   options: RuntimeOptions;
 }): Report {
-  const outcomes = results.map(result => classify(result, options.config.allowedViolations[result.fixture] ?? []));
-  const orphans = orphanedAllowlistEntries(fixtures, options.config.allowedViolations);
+  const outcomes = results.map(result =>
+    classify(result, allowedFor(result.fixture, options.config), forbiddenFor(result.fixture, options.config)),
+  );
+  const orphans = selection.orphans.map(fixture => ({
+    fixture,
+    packages: allowedFor(fixture, options.config),
+  }));
   const totals: Totals = {
     errors: outcomes.filter(outcome => outcome.status === 'error').length,
     regressions: sumBy(outcomes, outcome => outcome.regressions.length),
@@ -94,6 +108,7 @@ export function createReport({
     packageName,
     options,
     outcomes,
+    skipped: selection.skipped,
     orphans,
     totals,
     failed,
@@ -101,7 +116,7 @@ export function createReport({
   };
 }
 
-export function classify(result: FixtureResult, allowed: string[]): Outcome {
+export function classify(result: FixtureResult, allowed: string[], forbidden: string[] = []): Outcome {
   const regressions = result.found.filter(name => !allowed.includes(name));
   const stale = allowed.filter(name => !result.found.includes(name));
   const tolerated = allowed.filter(name => result.found.includes(name));
@@ -117,13 +132,7 @@ export function classify(result: FixtureResult, allowed: string[]): Outcome {
     status = 'allowed';
   }
 
-  return { ...result, status, allowed, tolerated, regressions, stale };
-}
-
-export function orphanedAllowlistEntries(fixtures: string[], allowedViolations: Record<string, string[]>): Orphan[] {
-  return Object.entries(allowedViolations)
-    .filter(([fixture]) => !fixtures.includes(fixture))
-    .map(([fixture, packages]) => ({ fixture, packages }));
+  return { ...result, status, forbidden, allowed, tolerated, regressions, stale };
 }
 
 export function formatReport(report: Report, summaryPath: string): string {
@@ -138,10 +147,23 @@ export function formatReport(report: Report, summaryPath: string): string {
     lines.push(...formatFixture(outcome, options), '');
   }
 
+  if (report.skipped.length > 0) {
+    lines.push(
+      `${badge('SKIPPED')}${count(report.skipped.length, 'fixture')} not listed under "fixtures" in ${configLabel(
+        options,
+      )}`,
+      ...report.skipped.map(fixture => `    ${fixture}`),
+      '',
+    );
+  }
+
   for (const orphan of report.orphans) {
     lines.push(
-      `${badge('ORPHAN')}${orphan.fixture} - allowlisted (${orphan.packages.join(', ')}) but not a bundle-size fixture`,
-      `    remove the entry from allowedViolations in ${configLabel(options)}`,
+      `${badge('ORPHAN')}${orphan.fixture} - listed under "fixtures" but not found in ${relativeToWorkspace(
+        options.fixturesRoot,
+        options.workspaceRoot,
+      )}`,
+      `    remove the entry from ${configLabel(options)}`,
       '',
     );
   }
@@ -152,12 +174,18 @@ export function formatReport(report: Report, summaryPath: string): string {
 }
 
 function formatFixture(outcome: Outcome, options: RuntimeOptions): string[] {
+  // Only worth printing when the fixture narrowed or widened the package-level intent.
+  const override =
+    outcome.forbidden.join() === options.config.forbiddenPackages.join()
+      ? []
+      : [`    forbidden: ${outcome.forbidden.join(', ')}`];
+
   if (outcome.status === 'error') {
-    return [`${badge('ERROR')}${outcome.fixture}`, ...formatError(outcome, options.workspaceRoot)];
+    return [`${badge('ERROR')}${outcome.fixture}`, ...override, ...formatError(outcome, options.workspaceRoot)];
   }
 
   if (outcome.status === 'clean') {
-    return [`${badge('CLEAN')}${outcome.fixture}`];
+    return [`${badge('CLEAN')}${outcome.fixture}`, ...override];
   }
 
   const lines: string[] = [];
@@ -270,14 +298,15 @@ function originsOf(leak: Leak, workspaceRoot: string): string[] {
 
 function formatVerdict(report: Report): string[] {
   const { options, totals, orphans } = report;
-  const fixtures = count(report.outcomes.length, 'fixture');
+  const verified = count(report.outcomes.length, 'fixture');
+  const fixtures = report.skipped.length > 0 ? `${verified}, ${report.skipped.length} skipped` : verified;
 
   if (report.failed) {
     const parts = [
       totals.errors > 0 && `${count(totals.errors, 'fixture')} failed to bundle`,
       totals.regressions > 0 && count(totals.regressions, 'regression'),
       totals.stale > 0 && count(totals.stale, 'stale allowlist entry', 'stale allowlist entries'),
-      orphans.length > 0 && count(orphans.length, 'orphaned allowlist entry', 'orphaned allowlist entries'),
+      orphans.length > 0 && count(orphans.length, 'orphaned fixture entry', 'orphaned fixture entries'),
       options.strict && totals.tolerated > 0 && `${count(totals.tolerated, 'allowed violation')} rejected by --strict`,
     ].filter(Boolean);
 
@@ -324,10 +353,12 @@ export function createSummary(report: Report) {
     strict: options.strict,
     status: report.status,
     forbiddenPackages: options.config.forbiddenPackages,
-    orphanedAllowlistEntries: report.orphans,
+    skippedFixtures: report.skipped,
+    orphanedFixtureEntries: report.orphans,
     fixtures: report.outcomes.map(outcome => ({
       fixture: outcome.fixture,
       status: outcome.status,
+      forbiddenPackages: outcome.forbidden,
       analyzerReport: options.analyze
         ? toWorkspacePath(join(fixtureOutputPath(outcome.fixture, options.packageRoot), 'report.json'))
         : null,


### PR DESCRIPTION
## Previous Behavior

`verify-bundle-isolation` verified **every** `*.fixture.js` found under `fixturesRoot`.

That directory is shared with monosize, whose fixtures exist to measure bytes and legitimately bundle styling engines and icons. So every one of them had to be added to `allowedViolations` just to keep the run green — turning "tracked debt that should shrink to zero" into permanent noise, and adding churn to an unrelated workflow every time a bundle-size fixture was added.

## New Behavior

The flat `allowedViolations` map is replaced by a `fixtures` object that also **selects** what gets verified:

```jsonc
{
  "fixturesRoot": "./bundle-size",
  "externals": ["react", "react-dom", "react/jsx-runtime", "react/compiler-runtime"],
  "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons"],
  "fixtures": {
    "AllComponents.fixture.js": { "allowedViolations": ["@fluentui/react-icons"] },
    "TagPicker.fixture.js": {},
    "Headless.fixture.js": { "forbiddenPackages": ["@griffel/*"] }
  }
}
```

- Only fixtures named in `fixtures` are bundled.
- Unlisted fixtures are reported under a `SKIPPED` block and recorded in `summary.json` as `skippedFixtures`. Filtering is opt-in, but never silent — what is left unguarded stays visible in CI output.
- A fixture entry may override `forbiddenPackages`. It **replaces** the package-level list rather than extending it, so a fixture can narrow the intent and not only widen it.
- New failure mode: a configuration where none of the listed fixtures exist now fails, instead of reporting a clean run over nothing.
- Orphan detection is unchanged in spirit — a key naming a fixture that does not exist still fails.

Example output:

```
  ALLOWED     BaseHooks.fixture.js - 4 forbidden packages, 45 modules
    tabster                 16 modules  2 exports
    ...

  SKIPPED     4 fixtures not listed under "fixtures" in .../bundle-isolation.config.json
    ButtonProviderAndTheme.fixture.js
    MultipleComponents.fixture.js
    ProviderAndTheme.fixture.js
    ReactComponents.fixture.js

PASS WITH DEBT - 1 fixture, 4 skipped, 0 regressions, 4 allowed violations
```

### Breaking change

The config schema is breaking, but the tool is `private` with two in-repo consumers. `react-headless-components-preview` is migrated in this PR; `react-components` is introduced already in the new format in the stacked PR below.

### Tests

`selectFixtures`, `forbiddenFor` and `allowedFor` are pure and unit-tested. Coverage added for: skipped vs verified vs orphan split, override replacing rather than extending, empty `fixtures` rejected by the schema, unknown key inside a fixture entry rejected, and the `SKIPPED` block appearing in the rendered report.

## Related Issue(s)

- n/a
