### PR TITLE
Fix redundant Overflow update work

### DIFF
--- a/change/@fluentui-priority-overflow-2091bf95-b608-423e-9966-6e5b821c8cc6.json
+++ b/change/@fluentui-priority-overflow-2091bf95-b608-423e-9966-6e5b821c8cc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cancel redundant queued overflow measurements after synchronous updates",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-priority-overflow-2091bf95-b608-423e-9966-6e5b821c8cc6.json
+++ b/change/@fluentui-priority-overflow-2091bf95-b608-423e-9966-6e5b821c8cc6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: cancel redundant queued overflow measurements after synchronous updates",
+  "comment": "fix: synchronously measure overflowing managers when the overflow menu attaches",
   "packageName": "@fluentui/priority-overflow",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-overflow-02cd3dce-4bab-4722-ba1a-fd36e195d8af.json
+++ b/change/@fluentui-react-overflow-02cd3dce-4bab-4722-ba1a-fd36e195d8af.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: avoid synchronous overflow measurement when the overflow menu unmounts",
+  "comment": "fix: avoid redundant overflow work during menu teardown and unchanged visibility updates",
   "packageName": "@fluentui/react-overflow",
   "email": "bernardo.sunderhus@gmail.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-overflow-02cd3dce-4bab-4722-ba1a-fd36e195d8af.json
+++ b/change/@fluentui-react-overflow-02cd3dce-4bab-4722-ba1a-fd36e195d8af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid synchronous overflow measurement when the overflow menu unmounts",
+  "packageName": "@fluentui/react-overflow",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/src/debounce.test.ts
+++ b/packages/react-components/priority-overflow/src/debounce.test.ts
@@ -33,16 +33,4 @@ describe('debounce', () => {
 
     expect(count).toBe(2);
   });
-
-  it('cancels pending work without preventing a later update', async () => {
-    const callback = jest.fn();
-    const debounced = debounce(callback);
-
-    debounced();
-    debounced.cancel();
-    debounced();
-    await tick();
-
-    expect(callback).toHaveBeenCalledTimes(1);
-  });
 });

--- a/packages/react-components/priority-overflow/src/debounce.test.ts
+++ b/packages/react-components/priority-overflow/src/debounce.test.ts
@@ -33,4 +33,16 @@ describe('debounce', () => {
 
     expect(count).toBe(2);
   });
+
+  it('cancels pending work without preventing a later update', async () => {
+    const callback = jest.fn();
+    const debounced = debounce(callback);
+
+    debounced();
+    debounced.cancel();
+    debounced();
+    await tick();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-components/priority-overflow/src/debounce.ts
+++ b/packages/react-components/priority-overflow/src/debounce.ts
@@ -4,19 +4,25 @@
  * @param fn - Function to debounce
  * @returns debounced function
  */
-export function debounce(fn: Function): () => void {
+export function debounce(fn: () => void): Debounced {
   let pending: boolean;
+  let version = 0;
 
   // React testing platforms will often output errors when state updates happen outside `act`
   // Since there is nothing obvious to wait for we just avoid debouncing in unit test environments
   if (process.env.NODE_ENV === 'test') {
-    return fn as () => void;
+    return Object.assign(() => fn(), { cancel: () => undefined });
   }
 
-  return () => {
+  const debounced = () => {
     if (!pending) {
       pending = true;
+      const scheduledVersion = ++version;
       queueMicrotask(() => {
+        if (scheduledVersion !== version) {
+          return;
+        }
+
         // Need to set pending to `false` before the debounced function is run.
         // React can actually interrupt the function while it's running!
         pending = false;
@@ -24,4 +30,15 @@ export function debounce(fn: Function): () => void {
       });
     }
   };
+
+  debounced.cancel = () => {
+    pending = false;
+    version++;
+  };
+
+  return debounced;
 }
+
+export type Debounced = (() => void) & {
+  cancel: () => void;
+};

--- a/packages/react-components/priority-overflow/src/debounce.ts
+++ b/packages/react-components/priority-overflow/src/debounce.ts
@@ -4,25 +4,19 @@
  * @param fn - Function to debounce
  * @returns debounced function
  */
-export function debounce(fn: () => void): Debounced {
+export function debounce(fn: () => void): () => void {
   let pending: boolean;
-  let version = 0;
 
   // React testing platforms will often output errors when state updates happen outside `act`
   // Since there is nothing obvious to wait for we just avoid debouncing in unit test environments
   if (process.env.NODE_ENV === 'test') {
-    return Object.assign(() => fn(), { cancel: () => undefined });
+    return fn;
   }
 
-  const debounced = () => {
+  return () => {
     if (!pending) {
       pending = true;
-      const scheduledVersion = ++version;
       queueMicrotask(() => {
-        if (scheduledVersion !== version) {
-          return;
-        }
-
         // Need to set pending to `false` before the debounced function is run.
         // React can actually interrupt the function while it's running!
         pending = false;
@@ -30,15 +24,4 @@ export function debounce(fn: () => void): Debounced {
       });
     }
   };
-
-  debounced.cancel = () => {
-    pending = false;
-    version++;
-  };
-
-  return debounced;
 }
-
-export type Debounced = (() => void) & {
-  cancel: () => void;
-};

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -177,7 +177,7 @@ describe('overflowManager', () => {
     expect(onUpdateOverflow).toHaveBeenCalled();
   });
 
-  it('should cancel a pending update when overflow is synchronously forced', async () => {
+  it('should synchronously update once when the overflow menu attaches to an overflowing manager', async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
     const manager = createOverflowManager(createObserveOptions());
@@ -194,7 +194,31 @@ describe('overflowManager', () => {
     getClientWidth.mockClear();
 
     manager.addOverflowMenu(createElementWithSize('button', 30));
+    expect(getClientWidth).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+
+    expect(getClientWidth).toHaveBeenCalledTimes(1);
+  });
+
+  it('should batch the update when the overflow menu attaches without hidden items', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const manager = createOverflowManager(createObserveOptions());
+    process.env.NODE_ENV = previousNodeEnv;
+
+    const container = createContainer(100);
+    const getClientWidth = jest.fn(() => 100);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
+
+    manager.addItem({ element: createElementWithSize('button', 40), id: 'a', priority: 1 });
+    manager.observe(container);
     manager.forceUpdate();
+    getClientWidth.mockClear();
+
+    manager.addOverflowMenu(createElementWithSize('button', 30));
+    expect(getClientWidth).not.toHaveBeenCalled();
+
     await Promise.resolve();
 
     expect(getClientWidth).toHaveBeenCalledTimes(1);

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -177,6 +177,29 @@ describe('overflowManager', () => {
     expect(onUpdateOverflow).toHaveBeenCalled();
   });
 
+  it('should cancel a pending update when overflow is synchronously forced', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const manager = createOverflowManager(createObserveOptions());
+    process.env.NODE_ENV = previousNodeEnv;
+
+    const container = createContainer(100);
+    const getClientWidth = jest.fn(() => 100);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
+
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
+    manager.observe(container);
+    manager.forceUpdate();
+    getClientWidth.mockClear();
+
+    manager.addOverflowMenu(createElementWithSize('button', 30));
+    manager.forceUpdate();
+    await Promise.resolve();
+
+    expect(getClientWidth).toHaveBeenCalledTimes(1);
+  });
+
   it('should remove items through removeItem', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -236,14 +236,13 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
-    update.cancel();
     if (processOverflowItems() || forceDispatch) {
       forceDispatch = false;
       dispatchOverflowUpdate();
     }
   };
 
-  const update = debounce(forceUpdate);
+  const update: OverflowManager['update'] = debounce(forceUpdate);
 
   const setOptions: OverflowManager['setOptions'] = nextOptions => {
     if (options === nextOptions) {
@@ -340,7 +339,11 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
 
     if (observing) {
       forceDispatch = true;
-      update();
+      if (invisibleItemQueue.size() > 0) {
+        forceUpdate();
+      } else {
+        update();
+      }
     }
   };
 

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -236,13 +236,14 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const forceUpdate: OverflowManager['forceUpdate'] = () => {
+    update.cancel();
     if (processOverflowItems() || forceDispatch) {
       forceDispatch = false;
       dispatchOverflowUpdate();
     }
   };
 
-  const update: OverflowManager['update'] = debounce(forceUpdate);
+  const update = debounce(forceUpdate);
 
   const setOptions: OverflowManager['setOptions'] = nextOptions => {
     if (options === nextOptions) {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.test.tsx
@@ -3,6 +3,7 @@ import type { OverflowAxis, OverflowManager } from '@fluentui/priority-overflow'
 import { createOverflowManager } from '@fluentui/priority-overflow';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
+import { DATA_OVERFLOW_MENU } from './constants';
 import { useOverflowContainer } from './useOverflowContainer';
 
 jest.mock('@fluentui/priority-overflow');
@@ -75,6 +76,21 @@ describe('useOverflowContainer', () => {
     deregister();
     expect(removeItemMock).toHaveBeenCalledTimes(1);
     expect(removeItemMock).toHaveBeenCalledWith(overflowItem.id);
+  });
+
+  it('should mark the overflow menu before registering it with the manager', () => {
+    const addOverflowMenuMock = jest.fn((element: HTMLElement) => {
+      expect(element.hasAttribute(DATA_OVERFLOW_MENU)).toBe(true);
+    });
+    mockOverflowManager({ addOverflowMenu: addOverflowMenuMock });
+    const { result } = renderHook(() =>
+      useOverflowContainer(() => undefined, { onUpdateItemVisibility: () => undefined }),
+    );
+    const menu = document.createElement('button');
+
+    result.current.registerOverflowMenu(menu);
+
+    expect(addOverflowMenuMock).toHaveBeenCalledWith(menu);
   });
 
   it('should call observe with the container element', () => {

--- a/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowContainer.ts
@@ -96,8 +96,8 @@ export const useOverflowContainer = <TElement extends HTMLElement>(
   }, []);
 
   const registerOverflowMenu = React.useCallback((el: HTMLElement) => {
-    managerRef.current?.addOverflowMenu(el);
     el.setAttribute(DATA_OVERFLOW_MENU, '');
+    managerRef.current?.addOverflowMenu(el);
 
     return () => {
       managerRef.current?.removeOverflowMenu();

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.test.tsx
@@ -74,15 +74,16 @@ describe('useOverflowMenu', () => {
     ).not.toThrow();
   });
 
-  it('does not force an overflow update while the menu unmounts', () => {
+  it('delegates menu updates to registration without forcing another update', () => {
     const unregisterOverflowMenu = jest.fn();
+    const registerOverflowMenu = jest.fn(() => unregisterOverflowMenu);
     const forceUpdateOverflow = jest.fn();
     const contextValue: OverflowContextValue = {
       hasOverflow: true,
       itemVisibility: { item: false },
       groupVisibility: {},
       registerItem: () => jest.fn(),
-      registerOverflowMenu: () => unregisterOverflowMenu,
+      registerOverflowMenu,
       registerDivider: () => jest.fn(),
       updateOverflow: jest.fn(),
       forceUpdateOverflow,
@@ -96,11 +97,12 @@ describe('useOverflowMenu', () => {
       </OverflowProvider>,
     );
 
-    expect(forceUpdateOverflow).toHaveBeenCalledTimes(1);
+    expect(registerOverflowMenu).toHaveBeenCalledTimes(1);
+    expect(forceUpdateOverflow).not.toHaveBeenCalled();
 
     unmount();
 
     expect(unregisterOverflowMenu).toHaveBeenCalledTimes(1);
-    expect(forceUpdateOverflow).toHaveBeenCalledTimes(1);
+    expect(forceUpdateOverflow).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.test.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import type { OverflowContextValue } from './overflowContext';
+import { OverflowProvider } from './overflowContext';
 import { Overflow } from './components/Overflow';
 import { OverflowItem } from './components/OverflowItem/OverflowItem';
 import { useOverflowMenu } from './useOverflowMenu';
@@ -70,5 +72,35 @@ describe('useOverflowMenu', () => {
         </Overflow>,
       ),
     ).not.toThrow();
+  });
+
+  it('does not force an overflow update while the menu unmounts', () => {
+    const unregisterOverflowMenu = jest.fn();
+    const forceUpdateOverflow = jest.fn();
+    const contextValue: OverflowContextValue = {
+      hasOverflow: true,
+      itemVisibility: { item: false },
+      groupVisibility: {},
+      registerItem: () => jest.fn(),
+      registerOverflowMenu: () => unregisterOverflowMenu,
+      registerDivider: () => jest.fn(),
+      updateOverflow: jest.fn(),
+      forceUpdateOverflow,
+      getSnapshot: () => ({ itemVisibility: { item: false }, groupVisibility: {}, invisibleItemCount: 1 }),
+      subscribe: () => jest.fn(),
+    };
+
+    const { unmount } = render(
+      <OverflowProvider value={contextValue}>
+        <Menu />
+      </OverflowProvider>,
+    );
+
+    expect(forceUpdateOverflow).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(unregisterOverflowMenu).toHaveBeenCalledTimes(1);
+    expect(forceUpdateOverflow).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
@@ -21,10 +21,7 @@ export function useOverflowMenu<TElement extends HTMLElement>(
       if (isOverflowing) {
         forceUpdateOverflow();
       }
-      return () => {
-        unregister();
-        forceUpdateOverflow();
-      };
+      return unregister;
     }
   }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId]);
 

--- a/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowMenu.ts
@@ -11,19 +11,15 @@ export function useOverflowMenu<TElement extends HTMLElement>(
 ): { ref: React.MutableRefObject<TElement | null>; overflowCount: number; isOverflowing: boolean } {
   const elementId = useId('overflow-menu', id);
   const overflowCount = useOverflowCount();
-  const { registerOverflowMenu, forceUpdateOverflow } = useOverflowContext();
+  const { registerOverflowMenu } = useOverflowContext();
   const ref = React.useRef<TElement | null>(null);
   const isOverflowing = overflowCount > 0;
 
   useIsomorphicLayoutEffect(() => {
     if (ref.current) {
-      const unregister = registerOverflowMenu(ref.current);
-      if (isOverflowing) {
-        forceUpdateOverflow();
-      }
-      return unregister;
+      return registerOverflowMenu(ref.current);
     }
-  }, [registerOverflowMenu, forceUpdateOverflow, isOverflowing, elementId]);
+  }, [registerOverflowMenu, isOverflowing, elementId]);
 
   return { ref, overflowCount, isOverflowing };
 }

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { useOverflowVisibility } from './useOverflowVisibility';
 import type { OverflowContextValue } from './overflowContext';
 import { OverflowContext } from './overflowContext';
@@ -34,5 +34,39 @@ describe('useOverflowVisibility', () => {
     const { result } = renderHook(useOverflowVisibility, { wrapper: Wrapper });
     expect(result.current.groupVisibility).toEqual(groupVisibility);
     expect(result.current.itemVisibility).toEqual({ foo: true, bar: true, baz: false });
+  });
+
+  it('does not render again when the snapshot is unchanged during subscription', () => {
+    const snapshot = {
+      itemVisibility: { foo: true },
+      groupVisibility: {},
+      invisibleItemCount: 0,
+    };
+    let notify: () => void = () => undefined;
+    const contextValue = {
+      getSnapshot: () => snapshot,
+      subscribe: (listener: () => void) => {
+        notify = listener;
+        return () => null;
+      },
+    } as unknown as OverflowContextValue;
+    const Wrapper = (props: { children?: React.ReactNode }) => (
+      <OverflowContext.Provider {...props} value={contextValue} />
+    );
+    let renderCount = 0;
+
+    renderHook(
+      () => {
+        renderCount++;
+        return useOverflowVisibility();
+      },
+      { wrapper: Wrapper },
+    );
+
+    expect(renderCount).toBe(1);
+
+    act(() => notify());
+
+    expect(renderCount).toBe(1);
   });
 });

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
@@ -16,12 +16,12 @@ export function useOverflowVisibility(): {
   itemVisibility: Record<string, boolean>;
   groupVisibility: Record<string, OverflowGroupState>;
 } {
-  return useOverflowSnapshot(selectVisibility);
+  const snapshot = useOverflowSnapshot(selectSnapshot);
+
+  return {
+    itemVisibility: snapshot.itemVisibility,
+    groupVisibility: snapshot.groupVisibility,
+  };
 }
 
-const selectVisibility = (
-  snapshot: OverflowSnapshot,
-): {
-  itemVisibility: Record<string, boolean>;
-  groupVisibility: Record<string, OverflowGroupState>;
-} => snapshot;
+const selectSnapshot = (snapshot: OverflowSnapshot): OverflowSnapshot => snapshot;

--- a/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
+++ b/packages/react-components/react-overflow/library/src/useOverflowVisibility.ts
@@ -24,7 +24,4 @@ const selectVisibility = (
 ): {
   itemVisibility: Record<string, boolean>;
   groupVisibility: Record<string, OverflowGroupState>;
-} => ({
-  itemVisibility: snapshot.itemVisibility,
-  groupVisibility: snapshot.groupVisibility,
-});
+} => snapshot;


### PR DESCRIPTION
## Previous Behavior

The lifecycle and subscription changes in [#36263](https://github.com/microsoft/fluentui/pull/36263) and [#36264](https://github.com/microsoft/fluentui/pull/36264) introduced three paths that can perform redundant work during Overflow mount, updates, and navigation teardown:

1. **Menu teardown forced synchronous measurement.** `useOverflowMenu` unregistered the menu and then called `forceUpdateOverflow()` from its layout-effect cleanup. During unmount there is no consumer for the resulting layout work, and menu unregistration already schedules the manager update needed when the menu is removed without unmounting the Overflow root. This is a remaining teardown path complementary to the disconnect notification addressed by [#36401](https://github.com/microsoft/fluentui/pull/36401).

2. **Menu attachment issued two update commands.** Registering an overflow menu scheduled the manager’s batched `update()`. When the menu was already overflowing, `useOverflowMenu` then called `forceUpdateOverflow()` to preserve the first-paint behavior added in #36264. One menu attachment therefore requested both asynchronous and synchronous measurement.

3. **Unchanged visibility snapshots caused an extra render.** The subscription model added in #36263 calls selectors once for initial state and again when subscribing to catch changes between render and layout effect. `useOverflowVisibility` created a new wrapper object on each selector call, so React rendered the consumer again even when `getSnapshot()` returned the same snapshot.

These paths are relevant to the channel-navigation performance investigation in [#36584](https://github.com/microsoft/fluentui/issues/36584), where repeated Overflow mount and teardown work is visible.

## New Behavior

- `useOverflowMenu` only registers and unregisters the menu. It no longer issues a separate imperative force update.
- Menu registration applies `data-overflow-menu` before handing the element to the manager, ensuring the menu’s `flex-shrink: 0` styling is active before any synchronous measurement.
- `addOverflowMenu()` owns update timing. If the manager already has hidden items, it recomputes synchronously so the menu width is included before paint. Otherwise it retains the normal batched update. Each attachment chooses exactly one update path.
- Menu cleanup only unregisters the menu. Dynamic removal still schedules the manager update through `removeOverflowMenu()`, without forcing synchronous measurement during teardown.
- `useOverflowVisibility` selects the stable `OverflowSnapshot` internally, then returns only its documented `itemVisibility` and `groupVisibility` fields. Unchanged snapshots retain identity and avoid the extra render, while real visibility changes still publish a new snapshot and render consumers.

Focused regression tests cover menu cleanup, registration-before-measurement ordering, synchronous attachment with hidden items, batched attachment without hidden items, single-pass container measurement, and unchanged-snapshot render counts.

## Validation

- `yarn nx run priority-overflow:test --runInBand` (20 tests)
- `yarn nx run react-overflow:test --runInBand` (20 tests)
- `yarn nx run priority-overflow:lint`
- `yarn nx run react-overflow:lint`
- `yarn nx run-many -t type-check -p priority-overflow react-overflow --parallel=2 --skip-nx-cache`
- `yarn nx run react-overflow:e2e --skip-nx-cache` (36 tests, including all first-paint probes)

## Related Issue(s)

- Related to [#36584](https://github.com/microsoft/fluentui/issues/36584)