### PR TITLE
feat(react-list): add design-free List base hooks

### DIFF
--- a/change/@fluentui-react-list-df9e5cb9-d725-4dfb-8884-938d8894954f.json
+++ b/change/@fluentui-react-list-df9e5cb9-d725-4dfb-8884-938d8894954f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: expose useListBase_unstable, useListItemBase_unstable and List context APIs for headless composition",
+  "packageName": "@fluentui/react-list",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-storybook-addon-9245e22e-52fe-44b7-8705-378deea7edf6.json
+++ b/change/@fluentui-react-storybook-addon-9245e22e-52fe-44b7-8705-378deea7edf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add shared SB preview styles",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-list/library/etc/react-list.api.md
+++ b/packages/react-components/react-list/library/etc/react-list.api.md
@@ -7,6 +7,7 @@
 import type { Checkbox } from '@fluentui/react-checkbox';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { ContextSelector } from '@fluentui/react-context-selector';
 import type { EventData } from '@fluentui/react-utilities';
 import type { EventHandler } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
@@ -24,17 +25,45 @@ export const List: ForwardRefComponent<ListProps>;
 export const listClassNames: SlotClassNames<ListSlots>;
 
 // @public (undocumented)
+export const ListContextProvider: React_2.Provider<ListContextValue | undefined> & React_2.FC<React_2.ProviderProps<ListContextValue | undefined>>;
+
+// @public (undocumented)
+export type ListContextValue = {
+    selection?: ListSelectionState;
+    validateListItem: (listItemElement: HTMLElement) => void;
+};
+
+// @public (undocumented)
+export type ListContextValues = {
+    listContext: ListContextValue;
+    synchronousContext: ListSynchronousContextValue;
+};
+
+// @public (undocumented)
 export const ListItem: ForwardRefComponent<ListItemProps>;
+
+// @public (undocumented)
+export type ListItemActionEventData = EventData<typeof ListItemActionEventName, ListItemActionEvent> & {
+    value: ListItemValue;
+};
+
+// @public
+export type ListItemBaseProps = ComponentProps<ListItemBaseSlots> & ListItemOwnProps;
+
+// @public
+export type ListItemBaseSlots = {
+    root: NonNullable<Slot<'li', 'div'>>;
+    checkmark?: Slot<'input'>;
+};
+
+// @public
+export type ListItemBaseState = ComponentState<ListItemBaseSlots> & ListItemOwnState;
 
 // @public (undocumented)
 export const listItemClassNames: SlotClassNames<ListItemSlots>;
 
 // @public
-export type ListItemProps = ComponentProps<ListItemSlots> & {
-    value?: ListItemValue;
-    onAction?: EventHandler<ListItemActionEventData>;
-    disabledSelection?: boolean;
-};
+export type ListItemProps = ComponentProps<ListItemSlots> & ListItemOwnProps;
 
 // @public (undocumented)
 export type ListItemSlots = {
@@ -43,11 +72,13 @@ export type ListItemSlots = {
 };
 
 // @public
-export type ListItemState = ComponentState<ListItemSlots> & {
-    selectable: boolean;
-    navigable: boolean;
-    disabled?: boolean;
-};
+export type ListItemState = ComponentState<ListItemSlots> & ListItemOwnState;
+
+// @public (undocumented)
+export type ListItemValue = string | number;
+
+// @public (undocumented)
+export type ListNavigationMode = 'items' | 'composite';
 
 // @public
 export type ListProps = ComponentProps<ListSlots> & {
@@ -66,6 +97,17 @@ export type ListSlots = {
 // @public
 export type ListState = ComponentState<ListSlots> & ListContextValue & ListSynchronousContextValue;
 
+// @public (undocumented)
+export type ListSynchronousContextValue = {
+    navigationMode: ListNavigationMode | undefined;
+    listItemRole: string;
+};
+
+// @public (undocumented)
+export type OnListSelectionChangeData = EventData<'change', React_2.SyntheticEvent> & {
+    selectedItems: SelectionItemId[];
+};
+
 // @public
 export const renderList_unstable: (state: ListState, contextValues: ListContextValues) => JSXElement;
 
@@ -76,7 +118,19 @@ export const renderListItem_unstable: (state: ListItemState) => JSXElement;
 export const useList_unstable: (props: ListProps, ref: React_2.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>) => ListState;
 
 // @public
+export const useListBase_unstable: (props: ListProps, ref: React_2.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>) => ListState;
+
+// @public (undocumented)
+export const useListContext_unstable: <T>(selector: ContextSelector<ListContextValue, T>) => T;
+
+// @public (undocumented)
+export function useListContextValues_unstable(state: ListState): ListContextValues;
+
+// @public
 export const useListItem_unstable: (props: ListItemProps, ref: React_2.Ref<HTMLLIElement | HTMLDivElement>) => ListItemState;
+
+// @public
+export const useListItemBase_unstable: (props: ListItemBaseProps, ref: React_2.Ref<HTMLLIElement | HTMLDivElement>) => ListItemBaseState;
 
 // @public
 export const useListItemStyles_unstable: (state: ListItemState) => ListItemState;

--- a/packages/react-components/react-list/library/etc/react-list.api.md
+++ b/packages/react-components/react-list/library/etc/react-list.api.md
@@ -63,6 +63,32 @@ export type ListItemBaseState = ComponentState<ListItemBaseSlots> & ListItemOwnS
 export const listItemClassNames: SlotClassNames<ListItemSlots>;
 
 // @public
+export const calculateListItemRoleForListRole: (listRole: string) => string;
+
+// @public
+export const calculateListRole: (navigationMode: ListNavigationMode | undefined, selectable: boolean) => "grid" | "listbox" | "list";
+
+// @public
+export const validateGridCellsArePresent: (listRole: string, listItemEl: HTMLElement) => void;
+
+// @public
+export const validateListItemElement: (listItemEl: HTMLElement, options: ValidateListItemElementOptions) => void;
+
+// @public
+export type ValidateListItemElementOptions = {
+    hasFocusableChildren: boolean;
+    hasSelection: boolean;
+    listRenderedAs: string;
+    listRole: string;
+};
+
+// @public
+export const validateProperElementTypes: (listRenderedAs?: string, listItemRenderedAs?: string) => void;
+
+// @public
+export const validateProperRolesAreUsed: (role: string, listItemRole: string, hasSelection: boolean, hasFocusableChildren: boolean) => void;
+
+// @public
 export type ListItemProps = ComponentProps<ListItemSlots> & ListItemOwnProps;
 
 // @public (undocumented)

--- a/packages/react-components/react-list/library/src/List.ts
+++ b/packages/react-components/react-list/library/src/List.ts
@@ -5,12 +5,17 @@ export type {
   ListProps,
   ListSlots,
   ListState,
+  ListSynchronousContextValue,
   OnListSelectionChangeData,
 } from './components/List/index';
 export {
   List,
+  ListContextProvider,
   listClassNames,
   renderList_unstable,
+  useListBase_unstable,
+  useListContextValues_unstable,
+  useListContext_unstable,
   useListStyles_unstable,
   useList_unstable,
 } from './components/List/index';

--- a/packages/react-components/react-list/library/src/ListItem.ts
+++ b/packages/react-components/react-list/library/src/ListItem.ts
@@ -1,5 +1,8 @@
 export type {
   ListItemActionEventData,
+  ListItemBaseProps,
+  ListItemBaseSlots,
+  ListItemBaseState,
   ListItemProps,
   ListItemSlots,
   ListItemState,
@@ -9,6 +12,7 @@ export {
   ListItem,
   listItemClassNames,
   renderListItem_unstable,
+  useListItemBase_unstable,
   useListItemStyles_unstable,
   useListItem_unstable,
 } from './components/ListItem/index';

--- a/packages/react-components/react-list/library/src/components/List/List.test.tsx
+++ b/packages/react-components/react-list/library/src/components/List/List.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { act, fireEvent, render, within } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { isConformant } from '../../testing/isConformant';
 import { List } from './List';
 import type { ListProps } from './List.types';
@@ -7,6 +8,7 @@ import { ListItem } from '../ListItem/ListItem';
 import type { ListItemActionEventData } from '../ListItem/ListItem.types';
 import type { EventHandler } from '@fluentui/react-utilities';
 import { resetIdsForTests } from '@fluentui/react-utilities';
+import { useList_unstable } from './useList';
 
 function expectListboxItemSelected(item: HTMLElement, selected: boolean) {
   expect(item.getAttribute('aria-selected')).toBe(selected.toString());
@@ -66,6 +68,31 @@ describe('List', () => {
   afterAll(() => {
     consoleWarn.mockRestore();
     jest.clearAllMocks();
+  });
+
+  describe('useList_unstable', () => {
+    it('preserves list role and selection metadata in headless mode', () => {
+      const ref = React.createRef<HTMLUListElement | HTMLDivElement | HTMLOListElement>();
+      const { result } = renderHook(() =>
+        useList_unstable({ role: 'listbox', selectionMode: 'single', selectedItems: ['value-1'] }, ref),
+      );
+
+      expect(result.current.root).toMatchObject({
+        role: 'listbox',
+      });
+      expect(result.current.root['aria-multiselectable']).toBeUndefined();
+      expect(result.current.listItemRole).toBe('option');
+      expect(result.current.selection).toBeDefined();
+    });
+
+    it('validates plain DOM items without throwing', () => {
+      const ref = React.createRef<HTMLUListElement | HTMLDivElement | HTMLOListElement>();
+      const { result } = renderHook(() => useList_unstable({ selectionMode: 'single' }, ref));
+      const listItem = document.createElement('li');
+      listItem.setAttribute('role', 'option');
+
+      expect(() => result.current.validateListItem(listItem)).not.toThrow();
+    });
   });
 
   describe('rendering', () => {

--- a/packages/react-components/react-list/library/src/components/List/index.ts
+++ b/packages/react-components/react-list/library/src/components/List/index.ts
@@ -9,5 +9,8 @@ export type {
   OnListSelectionChangeData,
 } from './List.types';
 export { renderList_unstable } from './renderList';
-export { useList_unstable } from './useList';
+export { useList_unstable, useListBase_unstable } from './useList';
+export { useListContextValues_unstable } from './useListContextValues';
+export { ListContextProvider, useListContext_unstable } from './listContext';
 export { listClassNames, useListStyles_unstable } from './useListStyles.styles';
+export type { ListSynchronousContextValue } from './List.types';

--- a/packages/react-components/react-list/library/src/components/List/useList.ts
+++ b/packages/react-components/react-list/library/src/components/List/useList.ts
@@ -6,15 +6,16 @@ import { getIntrinsicElementProps, slot, useControllableState, useEventCallback 
 import { useArrowNavigationGroup, useFocusFinders } from '@fluentui/react-tabster';
 import type { ListProps, ListState } from './List.types';
 import { useListSelection } from '../../hooks/useListSelection';
-import {
-  calculateListItemRoleForListRole,
-  calculateListRole,
-  validateGridCellsArePresent,
-  validateProperElementTypes,
-  validateProperRolesAreUsed,
-} from '../../utils';
+import { calculateListItemRoleForListRole, calculateListRole, validateListItemElement } from '../../utils';
 
 const DEFAULT_ROOT_EL_TYPE = 'ul';
+
+/**
+ * Plain DOM approximation of Tabster's focus finders, used by the base hook which must stay free of
+ * any Tabster runtime.
+ */
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Create the state required to render List.
@@ -29,14 +30,53 @@ export const useList_unstable = (
   props: ListProps,
   ref: React.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>,
 ): ListState => {
-  const { navigationMode, selectionMode, selectedItems, defaultSelectedItems, onSelectionChange } = props;
+  const state = useListBase_unstable(props, ref);
 
+  const { navigationMode, selectionMode } = props;
   const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
+  const listRole = props.role || calculateListRole(navigationMode, !!selectionMode);
 
   const arrowNavigationAttributes = useArrowNavigationGroup({
     axis: 'vertical',
     memorizeCurrent: true,
   });
+
+  const { findAllFocusable } = useFocusFinders();
+
+  // Tabster aware validation, superseding the plain DOM detection used by the base hook.
+  const validateListItem = useEventCallback((listItemEl: HTMLElement) =>
+    validateListItemElement(listItemEl, {
+      listRenderedAs: as,
+      listRole,
+      hasSelection: !!selectionMode,
+      hasFocusableChildren: findAllFocusable(listItemEl).length > 0,
+    }),
+  );
+
+  return {
+    ...state,
+    validateListItem,
+    // Consumer props keep winning over the navigation attributes, matching the base slot ordering.
+    root: { ...arrowNavigationAttributes, ...state.root },
+  };
+};
+
+/**
+ * Base state hook for List, free of any focus or keyboard navigation runtime.
+ *
+ * Arrow key navigation is layered on by the wrapping `useList_unstable` hook, so consumers of this
+ * hook are expected to bring their own focus management.
+ *
+ * @param props - props from this instance of List
+ * @param ref - reference to root HTMLElement of List
+ */
+export const useListBase_unstable = (
+  props: ListProps,
+  ref: React.Ref<HTMLDivElement | HTMLUListElement | HTMLOListElement>,
+): ListState => {
+  const { navigationMode, selectionMode, selectedItems, defaultSelectedItems, onSelectionChange } = props;
+
+  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
 
   const [selectionState, setSelectionState] = useControllableState({
     state: selectedItems,
@@ -59,18 +99,14 @@ export const useList_unstable = (
   const listRole = props.role || calculateListRole(navigationMode, !!selectionMode);
   const listItemRole = calculateListItemRoleForListRole(listRole);
 
-  const { findAllFocusable } = useFocusFinders();
-
-  const validateListItem = useEventCallback((listItemEl: HTMLElement) => {
-    if (process.env.NODE_ENV === 'production') {
-      return;
-    }
-    const itemRole = listItemEl.getAttribute('role') || '';
-    const focusable = findAllFocusable(listItemEl);
-    validateProperElementTypes(as, listItemEl.tagName.toLocaleLowerCase());
-    validateProperRolesAreUsed(listRole, itemRole, !!selectionMode, focusable.length > 0);
-    validateGridCellsArePresent(listRole, listItemEl);
-  });
+  const validateListItem = useEventCallback((listItemEl: HTMLElement) =>
+    validateListItemElement(listItemEl, {
+      listRenderedAs: as,
+      listRole,
+      hasSelection: !!selectionMode,
+      hasFocusableChildren: listItemEl.querySelectorAll(FOCUSABLE_SELECTOR).length > 0,
+    }),
+  );
 
   return {
     components: {
@@ -83,7 +119,6 @@ export const useList_unstable = (
         ...(selectionMode && {
           'aria-multiselectable': selectionMode === 'multiselect' ? true : undefined,
         }),
-        ...arrowNavigationAttributes,
         ...props,
       }),
       { elementType: as },

--- a/packages/react-components/react-list/library/src/components/ListItem/ListItem.test.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/ListItem.test.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { isConformant } from '../../testing/isConformant';
+import { ListContextProvider, ListSynchronousContextProvider } from '../List/listContext';
 import { ListItem } from './ListItem';
 import type { ListItemProps } from './ListItem.types';
+import { useListItem_unstable } from './useListItem';
 
 describe('ListItem', () => {
   isConformant<ListItemProps>({
@@ -17,6 +20,40 @@ describe('ListItem', () => {
         },
       ],
     },
+  });
+
+  describe('useListItem_unstable', () => {
+    const selection = {
+      isSelected: (id: string | number) => id === 'item-1',
+      toggleItem: jest.fn(),
+      deselectItem: jest.fn(),
+      selectItem: jest.fn(),
+      clearSelection: jest.fn(),
+      toggleAllItems: jest.fn(),
+      setSelectedItems: jest.fn(),
+      selectedItems: ['item-1'],
+    };
+
+    const wrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+      <ListContextProvider value={{ selection, validateListItem: jest.fn() }}>
+        <ListSynchronousContextProvider value={{ navigationMode: undefined, listItemRole: 'option' }}>
+          {children}
+        </ListSynchronousContextProvider>
+      </ListContextProvider>
+    );
+
+    it('uses the native checkbox and preserves selection semantics in headless mode', () => {
+      const ref = React.createRef<HTMLLIElement | HTMLDivElement>();
+      const { result } = renderHook(() => useListItem_unstable({ value: 'item-1' }, ref), { wrapper });
+
+      expect(result.current.root).toMatchObject({
+        role: 'option',
+        id: 'item-1',
+      });
+      expect(result.current.root.tabIndex).toBe(0);
+      expect(result.current.root['aria-selected']).toBe(true);
+      expect(result.current.checkmark).toBeDefined();
+    });
   });
 
   it('renders a default state', () => {

--- a/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/ListItem.types.ts
@@ -7,25 +7,48 @@ export type ListItemSlots = {
   checkmark?: Slot<typeof Checkbox>;
 };
 
+/**
+ * ListItem slots without any design dependency, used by `useListItemBase_unstable`.
+ */
+export type ListItemBaseSlots = {
+  root: NonNullable<Slot<'li', 'div'>>;
+  checkmark?: Slot<'input'>;
+};
+
 export type ListItemValue = string | number;
 
 export type ListItemActionEventData = EventData<typeof ListItemActionEventName, ListItemActionEvent> & {
   value: ListItemValue;
 };
-/**
- * ListItem Props
- */
-export type ListItemProps = ComponentProps<ListItemSlots> & {
+
+type ListItemOwnProps = {
   value?: ListItemValue;
   onAction?: EventHandler<ListItemActionEventData>;
   disabledSelection?: boolean;
 };
 
 /**
- * State used in rendering ListItem
+ * ListItem Props
  */
-export type ListItemState = ComponentState<ListItemSlots> & {
+export type ListItemProps = ComponentProps<ListItemSlots> & ListItemOwnProps;
+
+/**
+ * ListItem props accepted by `useListItemBase_unstable`.
+ */
+export type ListItemBaseProps = ComponentProps<ListItemBaseSlots> & ListItemOwnProps;
+
+type ListItemOwnState = {
   selectable: boolean;
   navigable: boolean;
   disabled?: boolean;
 };
+
+/**
+ * State used in rendering ListItem
+ */
+export type ListItemState = ComponentState<ListItemSlots> & ListItemOwnState;
+
+/**
+ * State returned by `useListItemBase_unstable`.
+ */
+export type ListItemBaseState = ComponentState<ListItemBaseSlots> & ListItemOwnState;

--- a/packages/react-components/react-list/library/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
+++ b/packages/react-components/react-list/library/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ListItem renders a default state 1`] = `
   <li
     class="fui-ListItem"
     data-tabster="{\\"groupper\\":{\\"tabbability\\":2},\\"focusable\\":{\\"ignoreKeydown\\":{\\"Enter\\":true}}}"
-    id="listItem_r_8_"
+    id="listItem_r_9_"
     role="listitem"
   >
     Default ListItem

--- a/packages/react-components/react-list/library/src/components/ListItem/index.ts
+++ b/packages/react-components/react-list/library/src/components/ListItem/index.ts
@@ -1,11 +1,14 @@
 export { ListItem } from './ListItem';
 export type {
   ListItemActionEventData,
+  ListItemBaseProps,
+  ListItemBaseSlots,
+  ListItemBaseState,
   ListItemProps,
   ListItemSlots,
   ListItemState,
   ListItemValue,
 } from './ListItem.types';
 export { renderListItem_unstable } from './renderListItem';
-export { useListItem_unstable } from './useListItem';
+export { useListItem_unstable, useListItemBase_unstable } from './useListItem';
 export { listItemClassNames, useListItemStyles_unstable } from './useListItemStyles.styles';

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -20,7 +20,7 @@ import {
   useId,
   useMergedRefs,
 } from '@fluentui/react-utilities';
-import type { ListItemProps, ListItemState } from './ListItem.types';
+import type { ListItemBaseProps, ListItemBaseState, ListItemProps, ListItemState } from './ListItem.types';
 import { useListSynchronousContext, useListContext_unstable } from '../List/listContext';
 import { Enter, Space, ArrowUp, ArrowDown, ArrowRight, ArrowLeft } from '@fluentui/keyboard-keys';
 import type { CheckboxOnChangeData } from '@fluentui/react-checkbox';
@@ -43,6 +43,116 @@ export const useListItem_unstable = (
   props: ListItemProps,
   ref: React.Ref<HTMLLIElement | HTMLDivElement>,
 ): ListItemState => {
+  const { checkmark: checkmarkProp, ...baseProps } = props;
+  const state = useListItemBase_unstable(baseProps, ref);
+
+  const { navigationMode } = useListSynchronousContext();
+
+  const as = props.as || navigationMode === 'composite' ? 'div' : DEFAULT_ROOT_EL_TYPE;
+
+  const focusableGroupAttrs = useFocusableGroup({
+    ignoreDefaultKeydown: { Enter: true },
+    tabBehavior: 'limited-trap-focus',
+  });
+
+  const arrowNavigationAttributes = useArrowNavigationGroup({
+    axis: 'horizontal',
+  });
+
+  const tabsterAttributes = useMergedTabsterAttributes_unstable(
+    state.navigable ? arrowNavigationAttributes : {},
+    focusableGroupAttrs,
+    props as Partial<TabsterDOMAttribute>,
+  );
+
+  const baseKeyDown = state.root.onKeyDown;
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLLIElement & HTMLDivElement> = useEventCallback(e => {
+    // Invokes the consumer handler and the base Space/Enter behavior before the Tabster additions.
+    baseKeyDown?.(e);
+
+    // If the event is fired from an element inside the list item
+    if (e.target !== e.currentTarget) {
+      if (e.defaultPrevented || !state.navigable) {
+        return;
+      }
+
+      // If the items are focusable, we need to handle the arrow keys to move focus to them
+      switch (e.key) {
+        // If it's one of the Arrows defined, jump out of the list item to focus on the ListItem itself
+        // The ArrowLeft will only trigger if the target element is the leftmost, otherwise the
+        // arrowNavigationAttributes handles it and prevents it from bubbling here.
+        case ArrowLeft:
+          e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }));
+          break;
+
+        case ArrowDown:
+        case ArrowUp:
+          e.preventDefault();
+          // Press ESC on the original target to get focus to the parent group (List)
+          e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }));
+          // Now dispatch the original key to move up or down in the list
+          e.currentTarget.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys[e.key] }));
+      }
+      return;
+    }
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
+    if (e.key === ArrowRight && navigationMode === 'composite') {
+      e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Enter }));
+    }
+  });
+
+  const checkmark = slot.optional(checkmarkProp, {
+    defaultProps: {
+      checked: state.checkmark?.checked,
+      tabIndex: -1,
+      disabled: props.disabledSelection,
+    },
+    renderByDefault: state.selectable,
+    elementType: Checkbox,
+  });
+
+  const mergedCheckmarkRef = useMergedRefs(checkmark?.ref, state.checkmark?.ref);
+  if (checkmark) {
+    checkmark.onChange = mergeCallbacks(
+      checkmark.onChange,
+      state.checkmark?.onChange as unknown as (
+        e: React.ChangeEvent<HTMLInputElement>,
+        data: CheckboxOnChangeData,
+      ) => void,
+    );
+    checkmark.ref = mergedCheckmarkRef;
+  }
+
+  return {
+    ...state,
+    components: {
+      root: as,
+      checkmark: Checkbox,
+    },
+    root: { ...state.root, ...tabsterAttributes, onKeyDown: handleKeyDown },
+    checkmark,
+  };
+};
+
+/**
+ * Base state hook for ListItem, free of any focus or keyboard navigation runtime and of the
+ * Fluent `Checkbox` used for the selection indicator.
+ *
+ * The checkmark slot is rendered as a native `input[type="checkbox"]`, and the Tabster driven
+ * arrow key handling is layered on by the wrapping `useListItem_unstable` hook.
+ *
+ * @param props - props from this instance of ListItem
+ * @param ref - reference to root HTMLLIElement | HTMLDivElementof ListItem
+ */
+export const useListItemBase_unstable = (
+  props: ListItemBaseProps,
+  ref: React.Ref<HTMLLIElement | HTMLDivElement>,
+): ListItemBaseState => {
   const id = useId('listItem');
   const { value = id, onKeyDown, onClick, tabIndex, role, onAction, disabledSelection } = props;
 
@@ -87,11 +197,6 @@ export const useListItem_unstable = (
     e.target.dispatchEvent(actionEvent);
   };
 
-  const focusableGroupAttrs = useFocusableGroup({
-    ignoreDefaultKeydown: { Enter: true },
-    tabBehavior: 'limited-trap-focus',
-  });
-
   const handleClick: React.MouseEventHandler<HTMLLIElement & HTMLDivElement> = useEventCallback(e => {
     onClick?.(e);
 
@@ -114,28 +219,8 @@ export const useListItem_unstable = (
       return;
     }
 
-    // If the event is fired from an element inside the list item
+    // Events fired from an element inside the list item are left to the caller's focus management.
     if (e.target !== e.currentTarget) {
-      if (focusableItems) {
-        // If the items are focusable, we need to handle the arrow keys to move focus to them
-        switch (e.key) {
-          // If it's one of the Arrows defined, jump out of the list item to focus on the ListItem itself
-          // The ArrowLeft will only trigger if the target element is the leftmost, otherwise the
-          // arrowNavigationAttributes handles it and prevents it from bubbling here.
-          case ArrowLeft:
-            e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }));
-            break;
-
-          case ArrowDown:
-          case ArrowUp:
-            e.preventDefault();
-            // Press ESC on the original target to get focus to the parent group (List)
-            e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Escape }));
-            // Now dispatch the original key to move up or down in the list
-            e.currentTarget.dispatchEvent(new MoverMoveFocusEvent({ key: MoverKeys[e.key] }));
-        }
-        return;
-      }
       return;
     }
 
@@ -158,33 +243,16 @@ export const useListItem_unstable = (
       case Enter:
         triggerAction(e);
         break;
-
-      case ArrowRight:
-        if (navigationMode === 'composite') {
-          e.target.dispatchEvent(new GroupperMoveFocusEvent({ action: GroupperMoveFocusActions.Enter }));
-        }
-
-        break;
     }
   });
 
-  const onCheckboxChange = useEventCallback((e: React.ChangeEvent<HTMLInputElement>, data: CheckboxOnChangeData) => {
+  const onCheckboxChange = useEventCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isSelectionModeEnabled || e.defaultPrevented) {
       return;
     }
 
     toggleItem?.(e, value);
   });
-
-  const arrowNavigationAttributes = useArrowNavigationGroup({
-    axis: 'horizontal',
-  });
-
-  const tabsterAttributes = useMergedTabsterAttributes_unstable(
-    focusableItems ? arrowNavigationAttributes : {},
-    focusableGroupAttrs,
-    props as Partial<TabsterDOMAttribute>,
-  );
 
   const root = slot.always(
     getIntrinsicElementProps(as, {
@@ -197,7 +265,6 @@ export const useListItem_unstable = (
         'aria-disabled': (disabledSelection && !onAction) || undefined,
       }),
       ...props,
-      ...tabsterAttributes,
       onKeyDown: handleKeyDown,
       onClick: isSelectionModeEnabled || onClick || onAction ? handleClick : undefined,
     }),
@@ -206,12 +273,13 @@ export const useListItem_unstable = (
 
   const checkmark = slot.optional(props.checkmark, {
     defaultProps: {
+      type: 'checkbox',
       checked: isSelected,
       tabIndex: -1,
       disabled: disabledSelection,
     },
     renderByDefault: isSelectionModeEnabled,
-    elementType: Checkbox,
+    elementType: 'input',
   });
 
   const mergedCheckmarkRef = useMergedRefs(checkmark?.ref, checkmarkRef);
@@ -220,10 +288,10 @@ export const useListItem_unstable = (
     checkmark.ref = mergedCheckmarkRef;
   }
 
-  const state: ListItemState = {
+  const state: ListItemBaseState = {
     components: {
       root: as,
-      checkmark: Checkbox,
+      checkmark: 'input',
     },
     root,
     checkmark,

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.tsx
@@ -37,7 +37,7 @@ const DEFAULT_ROOT_EL_TYPE = 'li';
  * before being passed to renderListItem_unstable.
  *
  * @param props - props from this instance of ListItem
- * @param ref - reference to root HTMLLIElement | HTMLDivElementof ListItem
+ * @param ref - reference to root HTMLLIElement | HTMLDivElement of ListItem
  */
 export const useListItem_unstable = (
   props: ListItemProps,

--- a/packages/react-components/react-list/library/src/index.ts
+++ b/packages/react-components/react-list/library/src/index.ts
@@ -1,11 +1,40 @@
-export { List, listClassNames, renderList_unstable, useListStyles_unstable, useList_unstable } from './List';
+export {
+  List,
+  ListContextProvider,
+  listClassNames,
+  renderList_unstable,
+  useListBase_unstable,
+  useListContextValues_unstable,
+  useListContext_unstable,
+  useListStyles_unstable,
+  useList_unstable,
+} from './List';
 
-export type { ListProps, ListSlots, ListState } from './List';
+export type {
+  ListContextValue,
+  ListContextValues,
+  ListNavigationMode,
+  ListProps,
+  ListSlots,
+  ListState,
+  ListSynchronousContextValue,
+  OnListSelectionChangeData,
+} from './List';
 export {
   ListItem,
   listItemClassNames,
   renderListItem_unstable,
+  useListItemBase_unstable,
   useListItemStyles_unstable,
   useListItem_unstable,
 } from './ListItem';
-export type { ListItemProps, ListItemSlots, ListItemState } from './ListItem';
+export type {
+  ListItemActionEventData,
+  ListItemBaseProps,
+  ListItemBaseSlots,
+  ListItemBaseState,
+  ListItemProps,
+  ListItemSlots,
+  ListItemState,
+  ListItemValue,
+} from './ListItem';

--- a/packages/react-components/react-list/library/src/index.ts
+++ b/packages/react-components/react-list/library/src/index.ts
@@ -20,6 +20,7 @@ export type {
   ListSynchronousContextValue,
   OnListSelectionChangeData,
 } from './List';
+export * from './utils';
 export {
   ListItem,
   listItemClassNames,

--- a/packages/react-components/react-list/library/src/utils/index.ts
+++ b/packages/react-components/react-list/library/src/utils/index.ts
@@ -3,3 +3,5 @@ export { validateProperElementTypes } from './validateProperElementTypes';
 export { validateProperRolesAreUsed } from './validateProperRolesAreUsed';
 export { calculateListItemRoleForListRole } from './calculateListItemRoleForListRole';
 export { validateGridCellsArePresent } from './validateGridCellsArePresent';
+export { validateListItemElement } from './validateListItemElement';
+export type { ValidateListItemElementOptions } from './validateListItemElement';

--- a/packages/react-components/react-list/library/src/utils/index.ts
+++ b/packages/react-components/react-list/library/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { calculateListRole } from './calculateListRole';
+export { validateListItemElement } from './validateListItemElement';
 export { validateProperElementTypes } from './validateProperElementTypes';
 export { validateProperRolesAreUsed } from './validateProperRolesAreUsed';
 export { calculateListItemRoleForListRole } from './calculateListItemRoleForListRole';

--- a/packages/react-components/react-list/library/src/utils/validateListItemElement.ts
+++ b/packages/react-components/react-list/library/src/utils/validateListItemElement.ts
@@ -1,0 +1,35 @@
+import { validateGridCellsArePresent } from './validateGridCellsArePresent';
+import { validateProperElementTypes } from './validateProperElementTypes';
+import { validateProperRolesAreUsed } from './validateProperRolesAreUsed';
+
+export type ValidateListItemElementOptions = {
+  /** The element type the parent List renders as. */
+  listRenderedAs: string;
+  /** The resolved role of the parent List. */
+  listRole: string;
+  /** Whether the parent List has selection enabled. */
+  hasSelection: boolean;
+  /** Whether the list item contains focusable children. */
+  hasFocusableChildren: boolean;
+};
+
+/**
+ * Runs the development time validations for a single list item element.
+ *
+ * The focusable children detection is passed in so that callers can choose between a Tabster
+ * aware implementation and a plain DOM one.
+ */
+export const validateListItemElement = (
+  listItemEl: HTMLElement,
+  { listRenderedAs, listRole, hasSelection, hasFocusableChildren }: ValidateListItemElementOptions,
+): void => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  const itemRole = listItemEl.getAttribute('role') || '';
+
+  validateProperElementTypes(listRenderedAs, listItemEl.tagName.toLocaleLowerCase());
+  validateProperRolesAreUsed(listRole, itemRole, hasSelection, hasFocusableChildren);
+  validateGridCellsArePresent(listRole, listItemEl);
+};


### PR DESCRIPTION
## Summary

- add design-free `useListBase_unstable` and `useListItemBase_unstable` hooks
- export List context APIs and DOM validation utilities for headless composition
- add the react-list API report and package-owned Beachball change file

## Validation

- `yarn nx run react-list:type-check`
- `yarn nx run react-list:test --args="useListItem"`

## Stack

1. #36592
2. This PR
3. #36591