### PR TITLE
test(react-list): lock down ListItem behavior contract

### DIFF
--- a/packages/react-components/react-list/library/src/components/List/useList.test.tsx
+++ b/packages/react-components/react-list/library/src/components/List/useList.test.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import type { TabsterDOMAttribute } from '@fluentui/react-tabster';
+import { useList_unstable } from './useList';
+
+describe('useList_unstable', () => {
+  it('applies Tabster navigation to the list', () => {
+    const { result } = renderHook(() =>
+      useList_unstable({ navigationMode: 'items' }, React.createRef<HTMLUListElement>()),
+    );
+
+    expect((result.current.root as Partial<TabsterDOMAttribute>)['data-tabster']).toContain('mover');
+  });
+});

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
@@ -23,9 +23,9 @@ describe('ListItem behavior contract', () => {
       </List>,
     );
 
-    expect(getByRole('list')).toHaveAttribute('data-tabster');
+    expect(getByRole('list').hasAttribute('data-tabster')).toBe(true);
     for (const item of getAllByRole('listitem')) {
-      expect(item).toHaveAttribute('data-tabster');
+      expect(item.hasAttribute('data-tabster')).toBe(true);
     }
   });
 
@@ -49,7 +49,7 @@ describe('ListItem behavior contract', () => {
     const checkbox = getAllByRole('checkbox')[0];
 
     expect(checkbox.tagName).toBe('INPUT');
-    expect(checkbox).toHaveAttribute('tabindex', '-1');
+    expect(checkbox.getAttribute('tabindex')).toBe('-1');
     // The Fluent Checkbox wraps its input in a labelled root, unlike a bare native checkbox.
     expect(checkbox.closest('.fui-Checkbox')).not.toBeNull();
   });
@@ -98,7 +98,7 @@ describe('ListItem behavior contract', () => {
     );
 
     const item = getByText('First');
-    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item.getAttribute('aria-disabled')).toBe('true');
 
     fireEvent.keyDown(item, { key: ' ' });
     expect(onSelectionChange).not.toHaveBeenCalled();

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
@@ -1,106 +1,34 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Checkbox } from '@fluentui/react-checkbox';
+import type { TabsterDOMAttribute } from '@fluentui/react-tabster';
 import { List } from '../List/List';
-import { ListItem } from './ListItem';
+import { useListItem_unstable } from './useListItem';
 
-/**
- * Behavior that must survive the split between `useListItem_unstable` and the design free
- * `useListItemBase_unstable`: Tabster wiring, the Fluent `Checkbox` checkmark, and the exact
- * ordering between the consumer `onKeyDown` handler and the built in key handling.
- */
-describe('ListItem behavior contract', () => {
-  const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+describe('useListItem_unstable', () => {
+  it('applies Tabster navigation to focusable list items', () => {
+    const { result } = renderHook(() => useListItem_unstable({}, React.createRef()), {
+      wrapper: ({ children }: React.PropsWithChildren) => <List navigationMode="items">{children}</List>,
+    });
 
-  afterAll(() => {
-    consoleWarn.mockRestore();
-  });
-
-  it('applies Tabster attributes to the list and to focusable list items', () => {
-    const { getByRole, getAllByRole } = render(
-      <List navigationMode="items">
-        <ListItem value="one">First</ListItem>
-        <ListItem value="two">Second</ListItem>
-      </List>,
-    );
-
-    expect(getByRole('list').hasAttribute('data-tabster')).toBe(true);
-    for (const item of getAllByRole('listitem')) {
-      expect(item.hasAttribute('data-tabster')).toBe(true);
-    }
+    expect((result.current.root as Partial<TabsterDOMAttribute>)['data-tabster']).toContain('mover');
   });
 
   it('does not apply arrow navigation to non focusable list items', () => {
-    const { getAllByRole } = render(
-      <List>
-        <ListItem value="one">First</ListItem>
-      </List>,
-    );
+    const { result } = renderHook(() => useListItem_unstable({}, React.createRef()), {
+      wrapper: ({ children }: React.PropsWithChildren) => <List>{children}</List>,
+    });
 
-    expect(getAllByRole('listitem')[0].getAttribute('data-tabster')).not.toContain('mover');
+    expect((result.current.root as Partial<TabsterDOMAttribute>)['data-tabster']).not.toContain('mover');
   });
 
-  it('renders the checkmark as a Fluent Checkbox', () => {
-    const { getAllByRole } = render(
-      <List selectionMode="multiselect">
-        <ListItem value="one">First</ListItem>
-      </List>,
-    );
+  it('uses a Fluent Checkbox for the checkmark', () => {
+    const { result } = renderHook(() => useListItem_unstable({}, React.createRef()), {
+      wrapper: ({ children }: React.PropsWithChildren) => <List selectionMode="single">{children}</List>,
+    });
 
-    const checkbox = getAllByRole('checkbox')[0];
-
-    expect(checkbox.tagName).toBe('INPUT');
-    expect(checkbox.getAttribute('tabindex')).toBe('-1');
-    // The Fluent Checkbox wraps its input in a labelled root, unlike a bare native checkbox.
-    expect(checkbox.closest('.fui-Checkbox')).not.toBeNull();
-  });
-
-  it('lets the consumer onKeyDown handler opt out of the built in Space handling', () => {
-    const onSelectionChange = jest.fn();
-
-    const { getByText } = render(
-      <List selectionMode="multiselect" onSelectionChange={onSelectionChange}>
-        <ListItem value="one" onKeyDown={e => e.preventDefault()}>
-          First
-        </ListItem>
-      </List>,
-    );
-
-    fireEvent.keyDown(getByText('First'), { key: ' ' });
-
-    expect(onSelectionChange).not.toHaveBeenCalled();
-  });
-
-  it('forwards the checkmark ref so clicking the checkbox does not trigger the item action', () => {
-    const onAction = jest.fn();
-
-    const { getAllByRole } = render(
-      <List selectionMode="multiselect">
-        <ListItem value="one" onAction={onAction}>
-          First
-        </ListItem>
-      </List>,
-    );
-
-    fireEvent.click(getAllByRole('checkbox')[0]);
-
-    expect(onAction).not.toHaveBeenCalled();
-  });
-
-  it('keeps the item non actionable for selection when disabledSelection is set', () => {
-    const onSelectionChange = jest.fn();
-
-    const { getByText } = render(
-      <List selectionMode="multiselect" onSelectionChange={onSelectionChange}>
-        <ListItem value="one" disabledSelection>
-          First
-        </ListItem>
-      </List>,
-    );
-
-    const item = getByText('First');
-    expect(item.getAttribute('aria-disabled')).toBe('true');
-
-    fireEvent.keyDown(item, { key: ' ' });
-    expect(onSelectionChange).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.current.components.checkmark).toBe(Checkbox);
+    expect(result.current.checkmark?.tabIndex).toBe(-1);
   });
 });

--- a/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
+++ b/packages/react-components/react-list/library/src/components/ListItem/useListItem.test.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { List } from '../List/List';
+import { ListItem } from './ListItem';
+
+/**
+ * Behavior that must survive the split between `useListItem_unstable` and the design free
+ * `useListItemBase_unstable`: Tabster wiring, the Fluent `Checkbox` checkmark, and the exact
+ * ordering between the consumer `onKeyDown` handler and the built in key handling.
+ */
+describe('ListItem behavior contract', () => {
+  const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+
+  afterAll(() => {
+    consoleWarn.mockRestore();
+  });
+
+  it('applies Tabster attributes to the list and to focusable list items', () => {
+    const { getByRole, getAllByRole } = render(
+      <List navigationMode="items">
+        <ListItem value="one">First</ListItem>
+        <ListItem value="two">Second</ListItem>
+      </List>,
+    );
+
+    expect(getByRole('list')).toHaveAttribute('data-tabster');
+    for (const item of getAllByRole('listitem')) {
+      expect(item).toHaveAttribute('data-tabster');
+    }
+  });
+
+  it('does not apply arrow navigation to non focusable list items', () => {
+    const { getAllByRole } = render(
+      <List>
+        <ListItem value="one">First</ListItem>
+      </List>,
+    );
+
+    expect(getAllByRole('listitem')[0].getAttribute('data-tabster')).not.toContain('mover');
+  });
+
+  it('renders the checkmark as a Fluent Checkbox', () => {
+    const { getAllByRole } = render(
+      <List selectionMode="multiselect">
+        <ListItem value="one">First</ListItem>
+      </List>,
+    );
+
+    const checkbox = getAllByRole('checkbox')[0];
+
+    expect(checkbox.tagName).toBe('INPUT');
+    expect(checkbox).toHaveAttribute('tabindex', '-1');
+    // The Fluent Checkbox wraps its input in a labelled root, unlike a bare native checkbox.
+    expect(checkbox.closest('.fui-Checkbox')).not.toBeNull();
+  });
+
+  it('lets the consumer onKeyDown handler opt out of the built in Space handling', () => {
+    const onSelectionChange = jest.fn();
+
+    const { getByText } = render(
+      <List selectionMode="multiselect" onSelectionChange={onSelectionChange}>
+        <ListItem value="one" onKeyDown={e => e.preventDefault()}>
+          First
+        </ListItem>
+      </List>,
+    );
+
+    fireEvent.keyDown(getByText('First'), { key: ' ' });
+
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  it('forwards the checkmark ref so clicking the checkbox does not trigger the item action', () => {
+    const onAction = jest.fn();
+
+    const { getAllByRole } = render(
+      <List selectionMode="multiselect">
+        <ListItem value="one" onAction={onAction}>
+          First
+        </ListItem>
+      </List>,
+    );
+
+    fireEvent.click(getAllByRole('checkbox')[0]);
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('keeps the item non actionable for selection when disabledSelection is set', () => {
+    const onSelectionChange = jest.fn();
+
+    const { getByText } = render(
+      <List selectionMode="multiselect" onSelectionChange={onSelectionChange}>
+        <ListItem value="one" disabledSelection>
+          First
+        </ListItem>
+      </List>,
+    );
+
+    const item = getByText('First');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.keyDown(item, { key: ' ' });
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add regression tests for existing ListItem focus and keyboard behavior
- lock down Fluent Checkbox rendering and disabled selection semantics
- use native DOM attribute assertions supported by the package test types

## Validation

- `yarn nx run react-list:test --args="useListItem"`

## Stack

1. This PR
2. #36590
3. #36591