### PR TITLE
fix(web-component): sanitize token values in set theme

### DIFF
--- a/change/@fluentui-web-components-786aaeb9-9222-4019-b392-cf304c916b30.json
+++ b/change/@fluentui-web-components-786aaeb9-9222-4019-b392-cf304c916b30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(web-components): prevent unsafe theme token values from injecting CSS",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/theme/set-theme.spec.ts
+++ b/packages/web-components/src/theme/set-theme.spec.ts
@@ -182,4 +182,19 @@ test.describe('setTheme()', () => {
     await expect(span).toHaveCSS('--foo', 'foo2');
     await expect(span).toHaveCSS('--bar', 'bar2');
   });
+
+  test('sanitizes token values', async ({ fastPage, page }) => {
+    const body = page.locator('body');
+
+    await fastPage.setTemplate();
+
+    await page.evaluate(() => {
+      window.setTheme({
+        foo: 'red; } body { font-size: 10px; } /* ',
+      });
+    });
+
+    await expect(body).not.toHaveCSS('--foo', 'red');
+    await expect(body).not.toHaveCSS('font-size', '10px');
+  });
 });

--- a/packages/web-components/src/theme/set-theme.spec.ts
+++ b/packages/web-components/src/theme/set-theme.spec.ts
@@ -191,10 +191,12 @@ test.describe('setTheme()', () => {
     await page.evaluate(() => {
       window.setTheme({
         foo: 'red; } body { font-size: 10px; } /* ',
+        'bar: blue;} body { font-size': '10px',
       });
     });
 
     await expect(body).not.toHaveCSS('--foo', 'red');
+    await expect(body).not.toHaveCSS('--bar', 'blue');
     await expect(body).not.toHaveCSS('font-size', '10px');
   });
 });

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -68,7 +68,7 @@ export function setTheme(theme: Theme | null, node: Document | HTMLElement = doc
   }
 }
 
-const TOKEN_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+const TOKEN_NAME_REGEX = /^[a-zA-Z_-][a-zA-Z0-9_-]*$/;
 function sanitizeTokenName(name: string): string {
   return TOKEN_NAME_REGEX.test(name) ? name : '';
 }

--- a/packages/web-components/src/theme/set-theme.ts
+++ b/packages/web-components/src/theme/set-theme.ts
@@ -68,15 +68,26 @@ export function setTheme(theme: Theme | null, node: Document | HTMLElement = doc
   }
 }
 
+const TOKEN_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+function sanitizeTokenName(name: string): string {
+  return TOKEN_NAME_REGEX.test(name) ? name : '';
+}
+
+const TOKEN_VALUE_BLOCK_REGEX = /(;|{|}|\/\*|\*\/|@import|url\s*\(|expression\s*\(|javascript:)/i;
+function sanitizeTokenValue(value: string): string {
+  return TOKEN_VALUE_BLOCK_REGEX.test(value) ? '' : value;
+}
+
 function getThemeStyleText(theme: Theme): string {
   if (!themeStyleTextMap.has(theme)) {
-    const tokenDeclarations: string[] = [];
-
-    for (const [tokenName, tokenValue] of Object.entries(theme)) {
-      tokenDeclarations.push(`--${tokenName}:${tokenValue.toString()};`);
-    }
-
-    themeStyleTextMap.set(theme, tokenDeclarations.join(''));
+    themeStyleTextMap.set(
+      theme,
+      Object.keys(theme).reduce((acc, token) => {
+        const tokenName = sanitizeTokenName(token);
+        const tokenValue = sanitizeTokenValue(theme[token].toString());
+        return tokenName && tokenValue ? `${acc}--${tokenName}:${tokenValue};` : acc;
+      }, ''),
+    );
   }
 
   return themeStyleTextMap.get(theme)!;


### PR DESCRIPTION
## Previous Behavior

The JSON passed into the `setTheme()` function was unsanitized, which could lead to abuse.

## New Behavior

Token names and values are not sanitized for CSS Custom Properties.