### PR TITLE
Fix overflow menu teardown convergence

### DIFF
--- a/change/@fluentui-priority-overflow-7b5f4bd5-6726-4b0f-b54f-ff6cbeb538b4.json
+++ b/change/@fluentui-priority-overflow-7b5f4bd5-6726-4b0f-b54f-ff6cbeb538b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: avoid redundant overflow recomputation after conditional menu removal",
+  "packageName": "@fluentui/priority-overflow",
+  "email": "bsunderhus@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -224,6 +224,92 @@ describe('overflowManager', () => {
     expect(getClientWidth).toHaveBeenCalledTimes(1);
   });
 
+  it('should not recompute when the same overflow menu is added twice', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(100);
+    const menu = createElementWithSize('button', 30);
+
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
+    manager.observe(container);
+    manager.forceUpdate();
+    manager.addOverflowMenu(menu);
+
+    const listener = jest.fn();
+    manager.subscribe(listener);
+    manager.addOverflowMenu(menu);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not recompute when no overflow menu is registered', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(100);
+
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
+    manager.observe(container);
+    manager.forceUpdate();
+
+    const listener = jest.fn();
+    manager.subscribe(listener);
+    manager.removeOverflowMenu();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not recompute when the overflow menu is removed after all items become visible', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(110);
+    const menu = createElementWithSize('button', 30);
+    let menuAttached = false;
+
+    const createResponsiveItem = () => {
+      const item = document.createElement('button');
+      Object.defineProperty(item, 'offsetWidth', {
+        configurable: true,
+        get: () => (menuAttached ? 35 : 60),
+      });
+      return item;
+    };
+
+    manager.addItem({ element: createResponsiveItem(), id: 'a', priority: 1 });
+    manager.addItem({ element: createResponsiveItem(), id: 'b', priority: 0 });
+    manager.observe(container);
+    manager.forceUpdate();
+    expect(getInvisibleIds(manager)).toEqual(['b']);
+
+    menuAttached = true;
+    manager.addOverflowMenu(menu);
+    expect(getInvisibleIds(manager)).toEqual([]);
+
+    const listener = jest.fn();
+    manager.subscribe(listener);
+    menuAttached = false;
+    manager.removeOverflowMenu();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(getVisibleIds(manager)).toEqual(['a', 'b']);
+  });
+
+  it('should recompute when the overflow menu is removed with hidden items', () => {
+    const manager = createOverflowManager(createObserveOptions());
+    const container = createContainer(140);
+
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
+    manager.addItem({ element: createElementWithSize('button', 60), id: 'c', priority: -1 });
+    manager.addOverflowMenu(createElementWithSize('button', 30));
+    manager.observe(container);
+    manager.forceUpdate();
+    expect(getInvisibleIds(manager)).toHaveLength(2);
+
+    manager.removeOverflowMenu();
+
+    expect(getVisibleIds(manager)).toHaveLength(2);
+    expect(getInvisibleIds(manager)).toHaveLength(1);
+  });
+
   it('should remove items through removeItem', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);

--- a/packages/react-components/priority-overflow/src/overflowManager.test.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.test.ts
@@ -227,6 +227,8 @@ describe('overflowManager', () => {
   it('should not recompute when the same overflow menu is added twice', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
+    const getClientWidth = jest.fn(() => 100);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
     const menu = createElementWithSize('button', 30);
 
     manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
@@ -234,33 +236,41 @@ describe('overflowManager', () => {
     manager.observe(container);
     manager.forceUpdate();
     manager.addOverflowMenu(menu);
+    getClientWidth.mockClear();
 
     const listener = jest.fn();
     manager.subscribe(listener);
     manager.addOverflowMenu(menu);
 
     expect(listener).not.toHaveBeenCalled();
+    expect(getClientWidth).not.toHaveBeenCalled();
   });
 
   it('should not recompute when no overflow menu is registered', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(100);
+    const getClientWidth = jest.fn(() => 100);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
 
     manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
     manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
     manager.observe(container);
     manager.forceUpdate();
+    getClientWidth.mockClear();
 
     const listener = jest.fn();
     manager.subscribe(listener);
     manager.removeOverflowMenu();
 
     expect(listener).not.toHaveBeenCalled();
+    expect(getClientWidth).not.toHaveBeenCalled();
   });
 
   it('should not recompute when the overflow menu is removed after all items become visible', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(110);
+    const getClientWidth = jest.fn(() => 110);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
     const menu = createElementWithSize('button', 30);
     let menuAttached = false;
 
@@ -282,6 +292,7 @@ describe('overflowManager', () => {
     menuAttached = true;
     manager.addOverflowMenu(menu);
     expect(getInvisibleIds(manager)).toEqual([]);
+    getClientWidth.mockClear();
 
     const listener = jest.fn();
     manager.subscribe(listener);
@@ -289,12 +300,15 @@ describe('overflowManager', () => {
     manager.removeOverflowMenu();
 
     expect(listener).not.toHaveBeenCalled();
+    expect(getClientWidth).not.toHaveBeenCalled();
     expect(getVisibleIds(manager)).toEqual(['a', 'b']);
   });
 
   it('should recompute when the overflow menu is removed with hidden items', () => {
     const manager = createOverflowManager(createObserveOptions());
     const container = createContainer(140);
+    const getClientWidth = jest.fn(() => 140);
+    Object.defineProperty(container, 'clientWidth', { configurable: true, get: getClientWidth });
 
     manager.addItem({ element: createElementWithSize('button', 60), id: 'a', priority: 1 });
     manager.addItem({ element: createElementWithSize('button', 60), id: 'b', priority: 0 });
@@ -303,9 +317,11 @@ describe('overflowManager', () => {
     manager.observe(container);
     manager.forceUpdate();
     expect(getInvisibleIds(manager)).toHaveLength(2);
+    getClientWidth.mockClear();
 
     manager.removeOverflowMenu();
 
+    expect(getClientWidth).toHaveBeenCalledTimes(1);
     expect(getVisibleIds(manager)).toHaveLength(2);
     expect(getInvisibleIds(manager)).toHaveLength(1);
   });

--- a/packages/react-components/priority-overflow/src/overflowManager.ts
+++ b/packages/react-components/priority-overflow/src/overflowManager.ts
@@ -335,6 +335,10 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const addOverflowMenu: OverflowManager['addOverflowMenu'] = el => {
+    if (overflowMenu === el) {
+      return;
+    }
+
     overflowMenu = el;
 
     if (observing) {
@@ -357,9 +361,14 @@ export function createOverflowManager(initialOptions: Partial<OverflowOptions> =
   };
 
   const removeOverflowMenu: OverflowManager['removeOverflowMenu'] = () => {
+    if (!overflowMenu) {
+      return;
+    }
+
+    const hasInvisibleItems = invisibleItemQueue.size() > 0;
     overflowMenu = undefined;
 
-    if (observing) {
+    if (observing && hasInvisibleItems) {
       forceDispatch = true;
       update();
     }


### PR DESCRIPTION
## Summary

- avoid recomputing overflow when a conditional menu is removed after all items have become visible
- make overflow menu registration and removal idempotent
- retain recomputation when a removed menu still has hidden items that may now fit
- add focused manager coverage for each lifecycle path

## Why

`@fluentui/priority-overflow` can enter a menu mount/unmount feedback cycle near a layout boundary: attaching the menu changes item measurements, all items become visible, the menu unmounts, and teardown schedules another measurement without the menu. Skipping that teardown measurement when there are no hidden items breaks the cycle while preserving meaningful updates.

Related to #36601. The external Outlook scenario is not reproducible in isolation, so this PR deliberately does not auto-close the issue.

## Validation

- `yarn nx run priority-overflow:test --skip-nx-cache` (25 tests)
- `yarn nx run priority-overflow:lint --skip-nx-cache`
- `yarn nx run priority-overflow:type-check --skip-nx-cache`
- `yarn nx run react-overflow:e2e --skip-nx-cache --spec src/Overflow.cy.tsx` (32 tests)
- `yarn check:change`