### PR TITLE
fix(web-components): submenu sizing in webkit

### DIFF
--- a/change/@fluentui-web-components-266fdefb-8790-4796-b020-9ab15da0c697.json
+++ b/change/@fluentui-web-components-266fdefb-8790-4796-b020-9ab15da0c697.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: correct submenu sizing in WebKit",
+  "packageName": "@fluentui/web-components",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/src/menu-list/menu-list.styles.css
+++ b/packages/web-components/src/menu-list/menu-list.styles.css
@@ -12,8 +12,8 @@
   --_col-end-width: 0px;
   --_col-submenu-width: 0px;
 
-  contain: content;
-  block-size: fit-content;
+  contain: layout style;
+  block-size: auto;
   max-inline-size: 300px;
   min-inline-size: 160px;
   inline-size: auto;
@@ -37,36 +37,36 @@
   grid-column: 1 / -1;
 }
 
-:host(:has([role='menuitemradio'], [role='menuitemcheckbox'])) {
+:host(:has(> [role='menuitemradio'], > [role='menuitemcheckbox'])) {
   --_col-indicator-width: 24px;
 }
 
-:host(:has([slot='start'])) {
+:host(:has(> * > [slot='start'])) {
   --_col-start-width: 24px;
 }
 
-:host(:has([slot='end'])) {
+:host(:has(> * > [slot='end'])) {
   --_col-end-width: 24px;
 }
 
-:host(:has([slot='submenu'])) {
+:host(:has(> * > [slot='submenu'])) {
   --_col-submenu-width: 24px;
 }
 
 @scope {
-  :scope:has([role='menuitemradio'], [role='menuitemcheckbox']) {
+  :scope:has(> [role='menuitemradio'], > [role='menuitemcheckbox']) {
     --_col-indicator-width: 24px;
   }
 
-  :scope:has([slot='start']) {
+  :scope:has(> * > [slot='start']) {
     --_col-start-width: 24px;
   }
 
-  :scope:has([slot='end']) {
+  :scope:has(> * > [slot='end']) {
     --_col-end-width: 24px;
   }
 
-  :scope:has([slot='submenu']) {
+  :scope:has(> * > [slot='submenu']) {
     --_col-submenu-width: 24px;
   }
 }

--- a/packages/web-components/src/menu-list/menu-list.styles.ts
+++ b/packages/web-components/src/menu-list/menu-list.styles.ts
@@ -45,36 +45,36 @@ export const styles = css`
     grid-column: 1 / -1;
   }
 
-  :host(:has([role='menuitemradio'], [role='menuitemcheckbox'])) {
+  :host(:has(> [role='menuitemradio'], > [role='menuitemcheckbox'])) {
     --_col-indicator-width: 24px;
   }
 
-  :host(:has([slot='start'])) {
+  :host(:has(> * > [slot='start'])) {
     --_col-start-width: 24px;
   }
 
-  :host(:has([slot='end'])) {
+  :host(:has(> * > [slot='end'])) {
     --_col-end-width: 24px;
   }
 
-  :host(:has([slot='submenu'])) {
+  :host(:has(> * > [slot='submenu'])) {
     --_col-submenu-width: 24px;
   }
 
   @scope {
-    :scope:has([role='menuitemradio'], [role='menuitemcheckbox']) {
+    :scope:has(> [role='menuitemradio'], > [role='menuitemcheckbox']) {
       --_col-indicator-width: 24px;
     }
 
-    :scope:has([slot='start']) {
+    :scope:has(> * > [slot='start']) {
       --_col-start-width: 24px;
     }
 
-    :scope:has([slot='end']) {
+    :scope:has(> * > [slot='end']) {
       --_col-end-width: 24px;
     }
 
-    :scope:has([slot='submenu']) {
+    :scope:has(> * > [slot='submenu']) {
       --_col-submenu-width: 24px;
     }
   }

--- a/packages/web-components/src/menu-list/menu-list.styles.ts
+++ b/packages/web-components/src/menu-list/menu-list.styles.ts
@@ -20,8 +20,8 @@ export const styles = css`
     --_col-end-width: 0px;
     --_col-submenu-width: 0px;
 
-    contain: content;
-    block-size: fit-content;
+    contain: layout style;
+    block-size: auto;
     max-inline-size: 300px;
     min-inline-size: 160px;
     inline-size: auto;

--- a/packages/web-components/src/message-bar/message-bar.styles.css
+++ b/packages/web-components/src/message-bar/message-bar.styles.css
@@ -89,7 +89,6 @@
 :host([layout='multiline']) ::slotted([slot='dismiss']) {
   align-items: start;
   height: 100%;
-  padding-block-start: var(--spacingVerticalS);
 }
 
 ::slotted(*) {


### PR DESCRIPTION
## Previous Behavior

Submenu had a very tall height in WebKit:

<img width="541" height="807" alt="image" src="https://github.com/user-attachments/assets/9ce122f9-4c0c-493c-a9c0-6f0cecfa038c" />


## New Behavior

Consistent with other browsers.
