### PR TITLE
fix: correct headless component subpath exports

### DIFF
--- a/change/@fluentui-react-headless-components-preview-fix-subpath-exports.json
+++ b/change/@fluentui-react-headless-components-preview-fix-subpath-exports.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: correct avatar-group, overflow, and menu-button subpath exports",
+  "comment": "fix: correct component subpath exports",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "dmytrokirpa@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@fluentui-react-headless-components-preview-fix-subpath-exports.json
+++ b/change/@fluentui-react-headless-components-preview-fix-subpath-exports.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: correct avatar-group, overflow, and menu-button subpath exports",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -100,10 +100,14 @@
       }
     },
     "./avatar-group": {
-      "types": "./dist/avatar-group.d.ts",
-      "node": "./lib-commonjs/avatar-group.js",
-      "import": "./lib/avatar-group.js",
-      "require": "./lib-commonjs/avatar-group.js"
+      "import": {
+        "types": "./dist/avatar-group.d.ts",
+        "default": "./lib/avatar-group.js"
+      },
+      "require": {
+        "types": "./dist/avatar-group.d.cts",
+        "default": "./lib-commonjs/avatar-group.cjs"
+      }
     },
     "./badge": {
       "import": {
@@ -298,10 +302,14 @@
       }
     },
     "./menu-button": {
-      "types": "./dist/menu-button.d.ts",
-      "node": "./lib-commonjs/menu-button.js",
-      "import": "./lib/menu-button.js",
-      "require": "./lib-commonjs/menu-button.js"
+      "import": {
+        "types": "./dist/menu-button.d.ts",
+        "default": "./lib/menu-button.js"
+      },
+      "require": {
+        "types": "./dist/menu-button.d.cts",
+        "default": "./lib-commonjs/menu-button.cjs"
+      }
     },
     "./message-bar": {
       "import": {
@@ -324,10 +332,14 @@
       }
     },
     "./overflow": {
-      "types": "./dist/overflow.d.ts",
-      "node": "./lib-commonjs/overflow.js",
-      "import": "./lib/overflow.js",
-      "require": "./lib-commonjs/overflow.js"
+      "import": {
+        "types": "./dist/overflow.d.ts",
+        "default": "./lib/overflow.js"
+      },
+      "require": {
+        "types": "./dist/overflow.d.cts",
+        "default": "./lib-commonjs/overflow.cjs"
+      }
     },
     "./persona": {
       "import": {

--- a/packages/react-components/react-headless-components-preview/library/package.json
+++ b/packages/react-components/react-headless-components-preview/library/package.json
@@ -160,10 +160,14 @@
       }
     },
     "./color-picker": {
-      "types": "./dist/color-picker.d.ts",
-      "node": "./lib-commonjs/color-picker.js",
-      "import": "./lib/color-picker.js",
-      "require": "./lib-commonjs/color-picker.js"
+      "import": {
+        "types": "./dist/color-picker.d.ts",
+        "default": "./lib/color-picker.js"
+      },
+      "require": {
+        "types": "./dist/color-picker.d.cts",
+        "default": "./lib-commonjs/color-picker.cjs"
+      }
     },
     "./combobox": {
       "import": {
@@ -176,10 +180,14 @@
       }
     },
     "./compound-button": {
-      "types": "./dist/compound-button.d.ts",
-      "node": "./lib-commonjs/compound-button.js",
-      "import": "./lib/compound-button.js",
-      "require": "./lib-commonjs/compound-button.js"
+      "import": {
+        "types": "./dist/compound-button.d.ts",
+        "default": "./lib/compound-button.js"
+      },
+      "require": {
+        "types": "./dist/compound-button.d.cts",
+        "default": "./lib-commonjs/compound-button.cjs"
+      }
     },
     "./dialog": {
       "import": {
@@ -482,16 +490,24 @@
       }
     },
     "./split-button": {
-      "types": "./dist/split-button.d.ts",
-      "node": "./lib-commonjs/split-button.js",
-      "import": "./lib/split-button.js",
-      "require": "./lib-commonjs/split-button.js"
+      "import": {
+        "types": "./dist/split-button.d.ts",
+        "default": "./lib/split-button.js"
+      },
+      "require": {
+        "types": "./dist/split-button.d.cts",
+        "default": "./lib-commonjs/split-button.cjs"
+      }
     },
     "./swatch-picker": {
-      "types": "./dist/swatch-picker.d.ts",
-      "node": "./lib-commonjs/swatch-picker.js",
-      "import": "./lib/swatch-picker.js",
-      "require": "./lib-commonjs/swatch-picker.js"
+      "import": {
+        "types": "./dist/swatch-picker.d.ts",
+        "default": "./lib/swatch-picker.js"
+      },
+      "require": {
+        "types": "./dist/swatch-picker.d.cts",
+        "default": "./lib-commonjs/swatch-picker.cjs"
+      }
     },
     "./switch": {
       "import": {
@@ -534,10 +550,14 @@
       }
     },
     "./tag-picker": {
-      "types": "./dist/tag-picker.d.ts",
-      "node": "./lib-commonjs/tag-picker.js",
-      "import": "./lib/tag-picker.js",
-      "require": "./lib-commonjs/tag-picker.js"
+      "import": {
+        "types": "./dist/tag-picker.d.ts",
+        "default": "./lib/tag-picker.js"
+      },
+      "require": {
+        "types": "./dist/tag-picker.d.cts",
+        "default": "./lib-commonjs/tag-picker.cjs"
+      }
     },
     "./teaching-popover": {
       "import": {

--- a/packages/react-components/react-headless-components-preview/library/src/testing/isConformant.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/testing/isConformant.ts
@@ -13,6 +13,9 @@ export function isConformant<TProps = {}>(
 ): void {
   const name = kebabCase(testInfo.displayName);
 
+  // Subcomponents have no top-level entry file and therefore no export map entry of their own.
+  const isSubcomponent = Boolean(testInfo.disabledTests?.includes('has-top-level-file-extra'));
+
   const defaultOptions: Partial<IsConformantOptions<TProps>> = {
     tsConfig: { configName: 'tsconfig.spec.json' },
     componentPath: require.main?.filename.replace('.test', ''),
@@ -23,6 +26,7 @@ export function isConformant<TProps = {}>(
       'has-top-level-file',
       // Headless components don't have static classnames, so we need to disable this test
       'component-has-static-classnames-object',
+      ...(isSubcomponent ? ['export-map-entry-exists'] : []),
     ],
     disableTypeTests: true,
     extraTests: {
@@ -36,17 +40,23 @@ export function isConformant<TProps = {}>(
 
       // This test ensures that the component has an export map entry in the package.json file,
       // which is required for proper module resolution and type definitions.
-      'export-map-entry-exists': () => {
+      // Note: the single parameter is required - react-conformance only runs extra tests with arity 1
+      // when `disableTypeTests` is enabled.
+      'export-map-entry-exists': (_options: IsConformantOptions<TProps>) => {
         const packageJSON = require('../../package.json');
 
         it('component has export map entry in package.json', () => {
           const exportEntry = `./${name}`;
 
           expect(packageJSON.exports[exportEntry]).toEqual({
-            types: `./dist/${name}.d.ts`,
-            node: `./lib-commonjs/${name}.js`,
-            require: `./lib-commonjs/${name}.js`,
-            import: `./lib/${name}.js`,
+            import: {
+              types: `./dist/${name}.d.ts`,
+              default: `./lib/${name}.js`,
+            },
+            require: {
+              types: `./dist/${name}.d.cts`,
+              default: `./lib-commonjs/${name}.cjs`,
+            },
           });
         });
       },


### PR DESCRIPTION
## Summary

- update the `avatar-group`, `overflow`, `menu-button`, and `tag-picker` subpath exports to use the package's nested `import` and `require` conditions
- point CommonJS runtime and type conditions to the emitted `.cjs` and `.d.cts` files
- fix the `export-map-entry-exists` conformance test so it actually runs — it declared zero parameters, and `react-conformance` skips extra tests whose arity is not 1 when `disableTypeTests` is enabled
- update that test's expected shape to the nested `import`/`require` conditions, and disable it for subcomponents (they have no top-level entry file, so no export map entry of their own)
- add a patch change file for `@fluentui/react-headless-components-preview`

## Validation

- `yarn nx run react-headless-components-preview:build`
- `yarn nx run react-headless-components-preview:lint`
- `yarn nx test react-headless-components-preview --skip-nx-cache` — 77 suites / 1030 tests passing, including the now-executing export map conformance test
- verified native ESM and CommonJS resolution for all affected subpaths
- verified CommonJS module evaluation for all affected subpaths
- `git diff --check`