### PR TITLE
chore: scope docsite tsconfig types so ambient typings don't leak into Storybook props tables

### DIFF
--- a/apps/chart-docsite/tsconfig.json
+++ b/apps/chart-docsite/tsconfig.json
@@ -5,7 +5,8 @@
     "allowJs": false,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "types": ["static-assets", "environment"]
   },
   "files": [],
   "include": [],

--- a/apps/public-docsite-v9-headless/tsconfig.json
+++ b/apps/public-docsite-v9-headless/tsconfig.json
@@ -7,7 +7,8 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "types": ["static-assets", "environment"]
   },
   "include": [],
   "files": [],

--- a/apps/public-docsite-v9/tsconfig.json
+++ b/apps/public-docsite-v9/tsconfig.json
@@ -7,7 +7,8 @@
     "experimentalDecorators": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "types": ["static-assets", "environment"]
   },
   "include": [],
   "files": [],


### PR DESCRIPTION
## Description

`focusgroup` and `focusgroupstart` were showing up in the props table of **every** component documented in `public-docsite-v9` and `public-docsite-v9-headless`.

### Root cause

`react-docgen-typescript` resolves `./tsconfig.json` relative to the Storybook cwd — the docsite project root. Those are solution-style configs (`include: []`, `files: []`) that extend `tsconfig.base.all.json` and inherit:

```jsonc
"typeRoots": ["node_modules/@types", "./typings"]
```

Because they declared no `types` array, TypeScript auto-included *every* package folder under `typeRoots` — including `typings/focusgroup`, which does a global `declare module 'react'` augmentation adding `focusgroup`/`focusgroupstart` to `HTMLAttributes`. Storybook's default docgen `propFilter` only excludes props declared under `node_modules`, and this typing lives in the repo, so it passed straight through onto every component.

https://storybooks.fluentui.dev/react/?path=/docs/components-accordion--docs

<img width="1465" height="822" alt="Screenshot 2026-08-22 at 15 58 15" src="https://github.com/user-attachments/assets/be65a242-fc7d-4d0d-bf29-2fe453b2fb6e" />



### Fix

Declare the types the docsites actually need, mirroring what the `library`/`stories` tsconfigs already use:

```jsonc
"types": ["static-assets", "environment"]
```

This is a no-op for type-checking (the configs contain no files) and stops the ambient auto-inclusion that docgen was picking up.

Note: published `.d.ts` files were **not** affected — verified there is no `/// <reference types=\"focusgroup\" />` in `dist`, since no public API references a symbol declared by that typing.

https://fluentuipr.z22.web.core.windows.net/pull/36607/public-docsite-v9/react/index.html?path=/docs/components-accordion--docs

<img width="2930" height="1644" alt="image" src="https://github.com/user-attachments/assets/7dff43eb-21cd-4182-a248-f21fb6be65d0" />

## Verification

- [x] Props tables no longer list `focusgroup` / `focusgroupstart`
- [x] Real props (including components that declare their own `focusgroup` prop) still render