### PR TITLE
fix(react-headless-components-preview): use global focusgroup typing for MenuListState

### DIFF
--- a/change/@fluentui-react-headless-components-preview-menulist-focusgroup-typing.json
+++ b/change/@fluentui-react-headless-components-preview-menulist-focusgroup-typing.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use global focusgroup typing for MenuListState instead of a local intersection",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/menu.api.md
@@ -35,7 +35,7 @@ import { MenuItemSwitchState } from '@fluentui/react-menu';
 import type { MenuListContextValues } from '@fluentui/react-menu';
 import { MenuListProps } from '@fluentui/react-menu';
 import { MenuListSlots } from '@fluentui/react-menu';
-import type { MenuListState as MenuListState_2 } from '@fluentui/react-menu';
+import { MenuListState } from '@fluentui/react-menu';
 import { MenuOpenChangeData } from '@fluentui/react-menu';
 import { MenuOpenEvent } from '@fluentui/react-menu';
 import { MenuPopoverProps } from '@fluentui/react-menu';
@@ -166,12 +166,7 @@ export { MenuListProps }
 
 export { MenuListSlots }
 
-// @public (undocumented)
-export type MenuListState = MenuListState_2 & {
-    root: {
-        focusgroup?: string;
-    };
-};
+export { MenuListState }
 
 export { MenuOpenChangeData }
 
@@ -228,7 +223,7 @@ export { renderMenuItemRadio }
 export { renderMenuItemSwitch }
 
 // @public (undocumented)
-export const renderMenuList: (state: MenuListState_2, contextValues: MenuListContextValues) => JSXElement;
+export const renderMenuList: (state: MenuListState, contextValues: MenuListContextValues) => JSXElement;
 
 // @public (undocumented)
 export const renderMenuPopover: (state: MenuPopoverState) => JSXElement;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuList/MenuList.types.ts
@@ -1,14 +1,7 @@
-import type { MenuListState as MenuListBaseState } from '@fluentui/react-menu';
-
 export type {
+  MenuListState,
   MenuListProps,
   MenuListSlots,
   MenuCheckedValueChangeData,
   MenuCheckedValueChangeEvent,
 } from '@fluentui/react-menu';
-
-export type MenuListState = MenuListBaseState & {
-  root: {
-    focusgroup?: string;
-  };
-};


### PR DESCRIPTION
## Description

`MenuListState` locally intersected the base state with a hand-rolled `focusgroup` declaration:

```ts
export type MenuListState = MenuListBaseState & {
  root: {
    focusgroup?: string;
  };
};
```

This existed only to type the attribute assigned in `useMenuList`. But the repo-wide `typings/focusgroup` augmentation already adds `focusgroup` to React's `HTMLAttributes`, so the local override was:

- **redundant** — the property is already available on `root`
- **weaker** — `string` instead of the constrained `FocusgroupAttribute` union, so invalid values like `focusgroup=\"tree\"` wouldn't be caught
- **noisy in the public API** — it forced the base type to be re-exported under a `MenuListState_2` alias

Now `MenuListState` is re-exported directly from `@fluentui/react-menu`, and `useMenuList` relies on the global typing.

## Verification

- [x] `yarn nx run react-headless-components-preview:type-check` passes
- [x] `etc/menu.api.md` regenerated — the alias and the local intersection are gone
- [x] Change file added