### PR TITLE
fix(skills): make release-recovery PRs pass beachball check

### DIFF
--- a/.agents/skills/release-recovery/SKILL.md
+++ b/.agents/skills/release-recovery/SKILL.md
@@ -138,7 +138,8 @@ Only `npm-ahead` requires recovery.
 
 1. Regenerate bumps + changelogs from the pending change files
 2. Verify the result matches npm exactly
-3. Open a recovery PR
+3. Add `type: none` change files so the PR passes `beachball check`
+4. Open a recovery PR
 
 Release tags are not recreated - see the skill's Scope section.
 ```
@@ -202,10 +203,37 @@ Every previously `npm-ahead` package must now be `in-sync`. If any version overs
 change files landed after the failed release, so a plain replay is not correct — stop, report the
 mismatch, and let the user decide. Never hand-edit versions to force a match.
 
-Commit and open a PR:
+**Satisfy `beachball check`.** A real release pushes straight to `master` and never faces PR
+validation, but a recovery PR does. The `change-files` job in
+[.github/workflows/check-packages.yml](../../../.github/workflows/check-packages.yml) runs
+`beachball check`, sees the bumped `package.json` files as changed packages, and fails with
+`ERROR: Change files are needed!` — because the replay just consumed every change file that covered
+them.
+
+Generate `type: none` change files to cover exactly those packages:
 
 ```bash
-git add -A
+yarn beachball change --type none --no-commit \
+  --message "release recovery: versions already published to npm by the failed pipeline"
+yarn beachball check
+```
+
+`--type none` is the correct type: the next release consumes these files without bumping a version
+or writing a `CHANGELOG.md` entry. They leave only a `"none"` entry in `CHANGELOG.json`, which is a
+useful audit trail of the recovery. Verified empirically on `3.0.0-alpha.7`: a follow-up `bump` with
+38 such files produced 0 `package.json` and 0 `CHANGELOG.md` changes.
+
+Do not skip this because a past recovery PR passed without it. [PR #36364](https://github.com/microsoft/fluentui/pull/36364)
+did, but only by coincidence — unrelated change files had accumulated for the same packages in the
+meantime, and beachball reported `Your local repository already has change files for these packages`.
+That is not a property you can rely on.
+
+Commit and open a PR. Stage explicitly rather than with `git add -A`, so unrelated untracked files in
+the user's tree are not swept into a release commit:
+
+```bash
+git add -u          # bumps, changelogs, lockfile, consumed change files
+git add change/     # the new type:none change files
 git commit -m "release: applying package updates (manual recovery)"
 git push "$PUSH_REMOTE" HEAD
 gh pr create --repo microsoft/fluentui --base master \
@@ -213,13 +241,20 @@ gh pr create --repo microsoft/fluentui --base master \
   --body-file "$PR_BODY_FILE"
 ```
 
+Let the `precommit` git hook run — do not pass `--no-verify`. The manual fixups above replace
+beachball's `precommit` hook, not the repository's.
+
 The PR body must state which pipeline failed and that the packages are already on npm.
 
 ### Step 6 — Restore and report
 
 ```bash
 git switch "$START_REF"
+yarn install
 ```
+
+The reinstall matters: the recovery branch rewrote `yarn.lock`, so the restored branch is left with
+out-of-date `node_modules` otherwise.
 
 Report:
 
@@ -237,6 +272,10 @@ Report:
 - Never hand-edit versions to force agreement with npm. Regenerate with beachball so changelogs and
   dependency ranges stay consistent, and stop if the result disagrees.
 - Never commit directly to `master`; always go through a PR.
+- Never bypass PR validation to land a recovery. Make `beachball check` pass with `type: none` change
+  files rather than merging with an admin override or weakening the `change-files` job.
+- Never `git add -A`. The user's tree may hold unrelated untracked work, and a release commit must not
+  carry it.
 - Never create or push release tags as part of recovery. They would point at a commit the release was
   not built from, and a single release spans dozens of packages.
 - Never assume `origin` points at `microsoft/fluentui` — resolve the remote explicitly.


### PR DESCRIPTION
## Problem

The `/release-recovery` skill produces a PR that **cannot pass CI as written**.

A real release commit is pushed straight to `master` by the pipeline and never faces PR validation. A recovery PR does. The `change-files` job runs `beachball check`, sees the bumped `package.json` files as changed packages, and fails — because the recovery replay just consumed every change file that covered them.

Observed on the first PR produced by the skill, [#36619](https://github.com/microsoft/fluentui/pull/36619) ([failing run](https://github.com/microsoft/fluentui/actions/runs/32752638253/job/97512906895)):

```
Found changes in the following packages:
  • @fluentui/priority-overflow
  • @fluentui/react-accordion
  ... (38 packages)
Run 'yarn change' to generate a change file
ERROR: Change files are needed!
```

### Why this wasn't caught earlier

The previous manual recovery, [#36364](https://github.com/microsoft/fluentui/pull/36364), passed `change-files` — but only by **coincidence**. Unrelated change files had accumulated for the same packages between the failed release and the recovery, so beachball reported:

```
Your local repository already has change files for these packages:
  @fluentui/react
  ...
No change files are needed
```

That is timing luck, not a property of recovery PRs.

## Fix

Add a step to the recovery workflow that generates `type: none` change files covering exactly the affected packages:

```bash
yarn beachball change --type none --no-commit \
  --message "release recovery: versions already published to npm by the failed pipeline"
yarn beachball check
```

`--type none` is the right type — the next release consumes these files without bumping a version or writing a `CHANGELOG.md` entry. They leave only a `"none"` entry in `CHANGELOG.json`, which doubles as an audit trail that a recovery happened.

Verified empirically on `3.0.0-alpha.7`: a follow-up `bump` with 38 such files produced **0 `package.json` changes and 0 `CHANGELOG.md` changes**.

This keeps CI honest — no admin override, no weakening of the `change-files` job.

## Other fixes in this PR

Both are papercuts hit while running the skill for real:

- **`git add -A` → explicit staging.** The original instruction would sweep unrelated untracked files from the user's tree into a release commit. Now `git add -u && git add change/`, with a matching guardrail.
- **`yarn install` after restoring the start ref.** The recovery branch rewrites `yarn.lock`, so switching back leaves stale `node_modules`.
- Added guardrails against bypassing PR validation and against `git add -A`.

## Validation

The fix is already applied to [#36619](https://github.com/microsoft/fluentui/pull/36619), where `beachball check` now reports `No change files are needed`.

Docs-only change — no package code affected.
