### PR TITLE
fix(deprecated): keep deprecated packages on their named prerelease line

### DIFF
--- a/change/@fluentui-react-alert-8ae42c85-2e61-4174-9454-a0873418cdf1.json
+++ b/change/@fluentui-react-alert-8ae42c85-2e61-4174-9454-a0873418cdf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: restore named beta prerelease line (9.0.x-0 was published by mistake)",
+  "packageName": "@fluentui/react-alert",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-components-992f38ce-2b79-440d-9139-ceb7b064bb6d.json
+++ b/change/@fluentui-react-components-992f38ce-2b79-440d-9139-ceb7b064bb6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: update pinned versions of deprecated packages moved back onto their beta line",
+  "packageName": "@fluentui/react-components",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@fluentui-react-infobutton-4a2df57e-b7e6-461e-b6f7-7f3b75c24a65.json
+++ b/change/@fluentui-react-infobutton-4a2df57e-b7e6-461e-b6f7-7f3b75c24a65.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: restore named beta prerelease line (9.0.x-0 was published by mistake)",
+  "packageName": "@fluentui/react-infobutton",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-virtualizer-5d72db95-585d-4e69-b5fe-b0f974add35e.json
+++ b/change/@fluentui-react-virtualizer-5d72db95-585d-4e69-b5fe-b0f974add35e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "chore: disallow prepatch/preminor/premajor so dependent bumps stay on the alpha line",
+  "packageName": "@fluentui/react-virtualizer",
+  "email": "martinhochel@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/deprecated/react-alert/package.json
+++ b/packages/react-components/deprecated/react-alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-alert",
-  "version": "9.0.2-0",
+  "version": "9.0.2-beta.0",
   "description": "An alert component to display brief messages",
   "main": "lib-commonjs/index.cjs",
   "module": "lib/index.js",
@@ -32,7 +32,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "exports": {

--- a/packages/react-components/deprecated/react-infobutton/package.json
+++ b/packages/react-components/deprecated/react-infobutton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-infobutton",
-  "version": "9.0.1-0",
+  "version": "9.0.1-beta.0",
   "description": "React components for building web experiences",
   "main": "lib-commonjs/index.cjs",
   "module": "lib/index.js",
@@ -32,7 +32,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "exports": {

--- a/packages/react-components/deprecated/react-virtualizer/package.json
+++ b/packages/react-components/deprecated/react-virtualizer/package.json
@@ -28,7 +28,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "exports": {

--- a/packages/react-components/react-components/package.json
+++ b/packages/react-components/react-components/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/react-accordion": "^9.12.3",
-    "@fluentui/react-alert": "9.0.2-0",
+    "@fluentui/react-alert": "9.0.2-beta.0",
     "@fluentui/react-aria": "^9.17.14",
     "@fluentui/react-avatar": "^9.11.6",
     "@fluentui/react-badge": "^9.5.5",
@@ -29,7 +29,7 @@
     "@fluentui/react-drawer": "^9.13.3",
     "@fluentui/react-field": "^9.5.4",
     "@fluentui/react-image": "^9.4.4",
-    "@fluentui/react-infobutton": "9.0.1-0",
+    "@fluentui/react-infobutton": "9.0.1-beta.0",
     "@fluentui/react-infolabel": "^9.4.25",
     "@fluentui/react-input": "^9.8.6",
     "@fluentui/react-label": "^9.4.4",

--- a/scripts/executors/src/tag-react-components.ts
+++ b/scripts/executors/src/tag-react-components.ts
@@ -28,6 +28,16 @@ function tagPackage(name: string, version: string, npmToken: string): boolean {
   }
 
   const prereleaseTag = prerelease[0];
+  // npm rejects dist-tags that parse as a semver range, which is what an anonymous prerelease
+  // like `9.0.1-0` yields. Nothing to tag, so warn instead of failing the release.
+  if (typeof prereleaseTag === 'number' || semver.validRange(String(prereleaseTag)) !== null) {
+    console.warn(
+      `skipping dist-tag for ${name}@${version}: prerelease identifier "${prereleaseTag}" is not a usable tag name. ` +
+        `Give this package a named prerelease version (e.g. "-beta.0") if it should be tagged.`,
+    );
+    return true;
+  }
+
   const command = `npm dist-tag add ${name}@${version} ${prereleaseTag} --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=${npmToken}`;
   console.log(command);
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,7 +3354,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/react-alert@npm:9.0.2-0, @fluentui/react-alert@workspace:packages/react-components/deprecated/react-alert":
+"@fluentui/react-alert@npm:9.0.2-beta.0, @fluentui/react-alert@workspace:packages/react-components/deprecated/react-alert":
   version: 0.0.0-use.local
   resolution: "@fluentui/react-alert@workspace:packages/react-components/deprecated/react-alert"
   dependencies:
@@ -3901,7 +3901,7 @@ __metadata:
   resolution: "@fluentui/react-components@workspace:packages/react-components/react-components"
   dependencies:
     "@fluentui/react-accordion": "npm:^9.12.3"
-    "@fluentui/react-alert": "npm:9.0.2-0"
+    "@fluentui/react-alert": "npm:9.0.2-beta.0"
     "@fluentui/react-aria": "npm:^9.17.14"
     "@fluentui/react-avatar": "npm:^9.11.6"
     "@fluentui/react-badge": "npm:^9.5.5"
@@ -3917,7 +3917,7 @@ __metadata:
     "@fluentui/react-drawer": "npm:^9.13.3"
     "@fluentui/react-field": "npm:^9.5.4"
     "@fluentui/react-image": "npm:^9.4.4"
-    "@fluentui/react-infobutton": "npm:9.0.1-0"
+    "@fluentui/react-infobutton": "npm:9.0.1-beta.0"
     "@fluentui/react-infolabel": "npm:^9.4.25"
     "@fluentui/react-input": "npm:^9.8.6"
     "@fluentui/react-label": "npm:^9.4.4"
@@ -4511,7 +4511,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fluentui/react-infobutton@npm:9.0.1-0, @fluentui/react-infobutton@workspace:packages/react-components/deprecated/react-infobutton":
+"@fluentui/react-infobutton@npm:9.0.1-beta.0, @fluentui/react-infobutton@workspace:packages/react-components/deprecated/react-infobutton":
   version: 0.0.0-use.local
   resolution: "@fluentui/react-infobutton@workspace:packages/react-components/deprecated/react-infobutton"
   dependencies:


### PR DESCRIPTION
## Problem

Deprecated v9 packages are supposed to live on a named prerelease line (`-beta.x` / `-alpha.x`) forever. Two of them silently fell off it:

| Package | Was | Published |
| --- | --- | --- |
| @fluentui/react-alert | 9.0.0-beta.143 | **9.0.1-0** (2026-08-11), **9.0.2-0** (2026-08-24) |
| @fluentui/react-infobutton | 9.0.0-beta.119 | **9.0.1-0** (2026-08-24) |

### Root cause

These packages carry `"disallowedChangeTypes": ["major", "minor", "patch"]` and have no change files of their own — they are bumped as **dependents** of `react-popover` etc., where the default `dependentChangeType` is `patch`.

Beachball resolves a disallowed change type by stepping exactly **one notch** down its ordered list:

```js
SortedChangeTypes = ['none','prerelease','prepatch','patch','preminor','minor','premajor','major']
```

So `patch` → `prepatch`, and:

```
semver.inc('9.0.0-beta.119', 'prepatch')   -> 9.0.1-0          <- what happened
semver.inc('9.0.0-beta.119', 'prerelease') -> 9.0.0-beta.120   <- what we wanted
```

`prepatch` starts a *new* prerelease line and drops the `beta` identifier. Beachball's downgrade is prerelease-unaware, but our config is what exposed it — `prepatch` was left allowed.

It's intermittent: it only fires when some upstream change file carries `dependentChangeType: patch`. When everything upstream was `prerelease`, the packages stayed on `beta.x`. That's why it went unnoticed for two releases.

### Knock-on: the release pipeline goes red

`tag-react-components.ts` derives the dist-tag from `prerelease[0]`. For `9.0.1-0` that is `0`:

```
npm dist-tag add @fluentui/react-alert@9.0.2-0 0
npm error Tag name must not be a valid SemVer range: 0
failed to tag @fluentui/react-alert@9.0.2-0
```

That is the `succeededWithIssues` on "Tag prelease packages with prerelease tag" in build 383600. Net effect — the `beta` tags are stale:

| Package | `beta` | `latest` |
| --- | --- | --- |
| @fluentui/react-infobutton | 9.0.0-beta.119 (stale) | 9.0.1-0 |
| @fluentui/react-alert | 9.0.0-beta.143 (stale) | 9.0.2-0 |

## Fix (three parts)

**1. Stop the bug recurring** — disallow `premajor`/`preminor`/`prepatch` on all three deprecated packages, so a dependent `patch` degrades all the way to `prerelease`:

```
current  config | patch -> prepatch   | 9.0.1-0
this PR         | patch -> prerelease | 9.0.0-beta.120
```

`@fluentui/react-virtualizer` (`9.0.0-alpha.115`) was the next domino — same config, still intact. Without this it would have gone to `9.0.1-0` on the next dependent bump.

**2. Repair the two damaged packages.** The old line is unreachable (`9.0.0-beta.120 > 9.0.1-0` is `false`), so they move forward onto a named line that outranks what's published:

| Package | npm | this PR | next publish |
| --- | --- | --- | --- |
| @fluentui/react-infobutton | 9.0.1-0 | 9.0.1-beta.0 | 9.0.1-beta.1 |
| @fluentui/react-alert | 9.0.2-0 | 9.0.2-beta.0 | 9.0.2-beta.1 |

Both are `> ` the published version, so this is forward progress, and the derived dist-tag becomes `beta` again. `react-components` pins these exactly, so its pins are updated to match.

**3. Stop a version-shape problem from failing the release.** `tag-react-components.ts` now skips prerelease identifiers that npm would reject, with a warning naming the package, instead of erroring out.

## Verification

Simulated a real release against this branch:

```
react-infobutton   npm:9.0.1-0          -> 9.0.1-beta.1    | tag: beta  OK | >npm: true
react-alert        npm:9.0.2-0          -> 9.0.2-beta.1    | tag: beta  OK | >npm: true
react-virtualizer  npm:9.0.0-alpha.115  -> 9.0.0-alpha.115 | tag: alpha OK
suite: 9.74.8      pins: 9.0.2-beta.1 / 9.0.1-beta.1
```

The new tagging guard checked against every version shape we publish:

```
9.0.1-0                        -> tag: 0        SKIP (warn)
9.0.1-1                        -> tag: 1        SKIP (warn)
9.0.1-beta.0                   -> tag: beta     tag it
9.0.0-alpha.115                -> tag: alpha    tag it
0.0.0-nightly-20260825-0407.1  -> tag: nightly… tag it
9.74.5-experimental.…          -> tag: experimental  tag it
9.74.7                         -> stable, skip
```

No behaviour change for `beta`, `alpha`, `nightly` or `experimental` tagging.

## Not addressed

The already-published `9.0.1-0` / `9.0.2-0` can't be withdrawn. Consumers of `@fluentui/react-components` are unaffected (exact pins); only someone installing these deprecated packages directly via `@beta` was seeing a stale version, and the next release fixes that.
