### PR TITLE
chore: use github app token for beachball release

### DIFF
--- a/.devops/templates/run-with-token.yml
+++ b/.devops/templates/run-with-token.yml
@@ -18,7 +18,7 @@ steps:
           --app-client-id Iv23ligBoU5jc9SIFnGR \
           --key-id https://fluentui-oss-release-kv.vault.azure.net/keys/office-ogx-auth-helper-key \
           --repository '$(Build.Repository.Name)' \
-          --permissions contents:write \
+          --permissions contents:write,pull_requests:read \
           --ci-output-name GITHUB_APP_TOKEN
 
   - ${{ each step in parameters.steps }}:

--- a/.devops/templates/run-with-token.yml
+++ b/.devops/templates/run-with-token.yml
@@ -1,0 +1,31 @@
+# Run the given steps after a GitHub App token is created and before it's revoked.
+# The token is available as $(createToken.GITHUB_APP_TOKEN)
+parameters:
+  - name: steps
+    type: stepList
+
+steps:
+  - task: AzureCLI@2
+    name: createToken
+    displayName: Create GitHub App token
+    inputs:
+      azureSubscription: 'Azure - fabricweb storage - NEW'
+      scriptType: bash
+      scriptLocation: inlineScript
+      # office-ogx-auth-helper GitHub App
+      inlineScript: |
+        yarn beachball-auth-helper create-github-app-token \
+          --app-client-id Iv23ligBoU5jc9SIFnGR \
+          --key-id https://fluentui-oss-release-kv.vault.azure.net/keys/office-ogx-auth-helper-key \
+          --repository '$(Build.Repository.Name)' \
+          --permissions contents:write \
+          --ci-output-name GITHUB_APP_TOKEN
+
+  - ${{ each step in parameters.steps }}:
+      - ${{ step }}
+
+  - script: yarn beachball-auth-helper revoke-github-app-token
+    displayName: Revoke GitHub App token
+    condition: and(always(), ne(variables['createToken.GITHUB_APP_TOKEN'], ''))
+    env:
+      TOKEN: $(createToken.GITHUB_APP_TOKEN)

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -4,10 +4,6 @@ parameters:
     displayName: Dry Run Mode
     type: boolean
     default: false
-  - name: githubPAT
-    displayName: GitHub Personal Access Token
-    type: string
-    default: ''
 
 steps:
   # Logs a message when dry run mode is enabled.
@@ -54,14 +50,9 @@ steps:
     condition: eq(variables['Agent.OS'], 'Linux')
 
   - script: |
-      git config user.name "Fluent UI Build"
-      git config user.email "fluentui-internal@service.microsoft.com"
+      git config user.name "OGX bot"
+      git config user.email "257645319+office-ogx-auth-helper[bot]@users.noreply.github.com"
     displayName: Configure git user (used by beachball)
-
-  - script: |
-      git remote set-url origin https://fabricteam:$(githubPAT)@github.com/microsoft/fluentui.git
-    displayName: Authenticate git for pushes
-    condition: and(succeeded(), ne('${{ parameters.githubPAT }}', ''))
 
   - script: |
       corepack enable

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -107,21 +107,14 @@
       "name": "Debug update release notes",
       "type": "node",
       "request": "launch",
-      "protocol": "inspector",
       "cwd": "${workspaceRoot}",
-      "args": [
-        "${workspaceRoot}/scripts/update-release-notes/src/index.ts",
-        "--token",
-        // For local testing, generate a personal access token (https://github.com/settings/tokens)
-        // and replace "your token here" with the token. DO NOT COMMIT YOUR TOKEN!
-        "your token here",
-        "--patch",
-        "--age",
-        "10"
-      ],
+      "args": ["${workspaceRoot}/scripts/update-release-notes/src/index.ts", "--patch", "--age", "10"],
       "runtimeArgs": ["--nolazy", "--inspect", "-r", "${workspaceRoot}/scripts/ts-node/src/register"],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        // For local testing, generate a personal access token (https://github.com/settings/tokens)
+        // and replace "your token here" with the token. DO NOT COMMIT YOUR TOKEN!
+        "TOKEN": "your token here"
       },
       "sourceMaps": true,
       "console": "integratedTerminal"

--- a/azure-pipelines.release-headless-experimental.yml
+++ b/azure-pipelines.release-headless-experimental.yml
@@ -118,4 +118,4 @@ extends:
                 displayName: Publish changes and bump versions
                 condition: and(succeeded(), not(${{ parameters.dryRun }}))
                 env:
-                  NPM_TOKEN: $(npmToken)
+                  BEACHBALL_NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.release-vnext-experimental.yml
+++ b/azure-pipelines.release-vnext-experimental.yml
@@ -111,4 +111,4 @@ extends:
                 displayName: Publish changes and bump versions
                 condition: and(succeeded(), not(${{ parameters.dryRun }}))
                 env:
-                  NPM_TOKEN: $(npmToken)
+                  BEACHBALL_NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.release-vnext-nightly.yml
+++ b/azure-pipelines.release-vnext-nightly.yml
@@ -96,4 +96,4 @@ extends:
                 displayName: Publish changes and bump versions
                 condition: not(${{ parameters.dryRun }})
                 env:
-                  NPM_TOKEN: $(npmToken)
+                  BEACHBALL_NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.release-vnext.yml
+++ b/azure-pipelines.release-vnext.yml
@@ -52,7 +52,6 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - script: |
                   FLUENT_PROD_BUILD=true yarn nx run-many -t build -p tag:vNext --exclude 'tag:tools,tag:type:stories,apps/**' --nxBail
@@ -66,14 +65,17 @@ extends:
                   FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p tag:vNext --exclude 'tag:tools,tag:type:stories,apps/**' --nxBail
                 displayName: lint
 
-              - script: |
-                  yarn beachball publish --config scripts/beachball/src/release-vNext.config.js --message 'release: applying package updates - react-components'
-                  git reset --hard origin/master
-                env:
-                  GITHUB_PAT: $(githubPAT)
-                  NPM_TOKEN: $(npmToken)
-                displayName: Publish changes and bump versions
-                condition: not(${{ parameters.dryRun }})
+              - template: .devops/templates/run-with-token.yml@self
+                parameters:
+                  steps:
+                    - script: |
+                        yarn beachball publish --config scripts/beachball/src/release-vNext.config.js --message 'release: applying package updates - react-components'
+                        git reset --hard origin/master
+                      env:
+                        BEACHBALL_GIT_TOKEN: $(createToken.GITHUB_APP_TOKEN)
+                        BEACHBALL_NPM_TOKEN: $(npmToken)
+                      displayName: Publish changes and bump versions
+                      condition: not(${{ parameters.dryRun }})
 
               - script: |
                   node -r ./scripts/ts-node/src/register scripts/executors/src/tag-react-components.ts --token $(npmToken)

--- a/azure-pipelines.release.headless.yml
+++ b/azure-pipelines.release.headless.yml
@@ -52,7 +52,6 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - script: |
                   echo "Following packages will be published (if they contain changes):"
@@ -71,11 +70,14 @@ extends:
                   FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p 'tag:react-headless,!tag:npm:private,!tag:type:stories' --exclude 'apps/**' --nxBail
                 displayName: lint
 
-              - script: |
-                  yarn beachball publish --config scripts/beachball/src/release-headless.config.js --message 'release: applying package updates - react-headless'
-                  git reset --hard origin/master
-                env:
-                  GITHUB_PAT: $(githubPAT)
-                  NPM_TOKEN: $(npmToken)
-                displayName: Publish changes and bump versions
-                condition: not(${{ parameters.dryRun }})
+              - template: .devops/templates/run-with-token.yml@self
+                parameters:
+                  steps:
+                    - script: |
+                        yarn beachball publish --config scripts/beachball/src/release-headless.config.js --message 'release: applying package updates - react-headless'
+                        git reset --hard origin/master
+                      env:
+                        BEACHBALL_GIT_TOKEN: $(createToken.GITHUB_APP_TOKEN)
+                        BEACHBALL_NPM_TOKEN: $(npmToken)
+                      displayName: Publish changes and bump versions
+                      condition: not(${{ parameters.dryRun }})

--- a/azure-pipelines.release.tools-experimental.yml
+++ b/azure-pipelines.release.tools-experimental.yml
@@ -52,7 +52,6 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - task: Bash@3
                 name: validation
@@ -111,4 +110,4 @@ extends:
                 displayName: Publish changes and bump versions
                 condition: and(succeeded(), not(${{ parameters.dryRun }}))
                 env:
-                  NPM_TOKEN: $(npmToken)
+                  BEACHBALL_NPM_TOKEN: $(npmToken)

--- a/azure-pipelines.release.tools.yml
+++ b/azure-pipelines.release.tools.yml
@@ -52,7 +52,6 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - script: |
                   echo "Following packages will be published(if they contain changes):"
@@ -70,11 +69,14 @@ extends:
                   FLUENT_PROD_BUILD=true yarn nx run-many -t lint -p 'tag:tools,!tag:npm:private,!tag:v8' --exclude 'apps/**' --nxBail
                 displayName: lint
 
-              - script: |
-                  yarn beachball publish --config scripts/beachball/src/release-tools.config.js --message 'release: applying package updates - tools'
-                  git reset --hard origin/master
-                env:
-                  GITHUB_PAT: $(githubPAT)
-                  NPM_TOKEN: $(npmToken)
-                displayName: Publish changes and bump versions
-                condition: not(${{ parameters.dryRun }})
+              - template: .devops/templates/run-with-token.yml@self
+                parameters:
+                  steps:
+                    - script: |
+                        yarn beachball publish --config scripts/beachball/src/release-tools.config.js --message 'release: applying package updates - tools'
+                        git reset --hard origin/master
+                      env:
+                        BEACHBALL_GIT_TOKEN: $(createToken.GITHUB_APP_TOKEN)
+                        BEACHBALL_NPM_TOKEN: $(npmToken)
+                      displayName: Publish changes and bump versions
+                      condition: not(${{ parameters.dryRun }})

--- a/azure-pipelines.release.web-components.yml
+++ b/azure-pipelines.release.web-components.yml
@@ -62,17 +62,19 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - script: |
                   yarn nx run-many -t format:check lint test build -p tag:web-components --exclude vr-tests-web-components --nxBail
                 displayName: Build, Test, Lint
 
-              - script: |
-                  yarn beachball publish --config scripts/beachball/src/release-web-components.config.js --message 'release: applying package updates - web-components'
-                  git reset --hard origin/master
-                env:
-                  GITHUB_PAT: $(githubPAT)
-                  NPM_TOKEN: $(npmToken)
-                displayName: Publish changes and bump versions
-                condition: not(${{ parameters.dryRun }})
+              - template: .devops/templates/run-with-token.yml@self
+                parameters:
+                  steps:
+                    - script: |
+                        yarn beachball publish --config scripts/beachball/src/release-web-components.config.js --message 'release: applying package updates - web-components'
+                        git reset --hard origin/master
+                      env:
+                        BEACHBALL_GIT_TOKEN: $(createToken.GITHUB_APP_TOKEN)
+                        BEACHBALL_NPM_TOKEN: $(npmToken)
+                      displayName: Publish changes and bump versions
+                      condition: not(${{ parameters.dryRun }})

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -62,7 +62,6 @@ extends:
               - template: .devops/templates/tools.yml@self
                 parameters:
                   dryRun: ${{ parameters.dryRun }}
-                  githubPAT: $(githubPAT)
 
               - script: |
                   yarn generate-version-files
@@ -88,36 +87,41 @@ extends:
                   FLUENT_PROD_BUILD=true yarn nx run-many -t verify-packaging -p tag:v8 --exclude tag:vNext,tag:tools,ssr-tests,vr-tests,perf-test --nxBail
                 displayName: verify packaged assets
 
-              - script: |
-                  yarn beachball publish --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
-                  git reset --hard origin/master
-                condition: and(succeeded(), not(${{ parameters.dryRun }}))
-                env:
-                  GITHUB_PAT: $(githubPAT)
-                  NPM_TOKEN: $(npmToken)
-                displayName: Publish changes and bump versions
+              - template: .devops/templates/run-with-token.yml@self
+                parameters:
+                  steps:
+                    - script: |
+                        yarn beachball publish --config scripts/beachball/src/release-v8.config.js --message 'release: applying package updates - react v8'
+                        git reset --hard origin/master
+                      condition: and(succeeded(), not(${{ parameters.dryRun }}))
+                      env:
+                        BEACHBALL_GIT_TOKEN: $(createToken.GITHUB_APP_TOKEN)
+                        BEACHBALL_NPM_TOKEN: $(npmToken)
+                      displayName: Publish changes and bump versions
 
-              # create-site-manifests is a script defined in @fluentui/public-docsite-setup.
-              # It generates manifest files used to load the current version on developer.microsoft.com/fluentui.
-              - script: |
-                  yarn create-site-manifests ./packages/react
-                displayName: 'Generate website manifests'
+                    # create-site-manifests is a script defined in @fluentui/public-docsite-setup.
+                    # It generates manifest files used to load the current version on developer.microsoft.com/fluentui.
+                    - script: |
+                        yarn create-site-manifests ./packages/react
+                      displayName: 'Generate website manifests'
 
-              # Generate the homepage.htm file used to load developer.microsoft.com/fluentui. Note that the
-              # generated file must be manually checked in to an internal repo, it's just generated as a build
-              # artifact for convenience and tracking.
-              - script: |
-                  node ./packages/public-docsite-setup/scripts/generateHomepage ./homepage
-                displayName: 'Generate homepage.htm'
+                    # Generate the homepage.htm file used to load developer.microsoft.com/fluentui. Note that the
+                    # generated file must be manually checked in to an internal repo, it's just generated as a build
+                    # artifact for convenience and tracking.
+                    - script: |
+                        node ./packages/public-docsite-setup/scripts/generateHomepage ./homepage
+                      displayName: 'Generate homepage.htm'
 
-              # Since v8 updates should be very rare, it's probably not necessary to update the website.
-              # If this is re-enabled, the Azure service connection will need to be re-created.
-              # - ${{ if eq(parameters.dryRun, false) }}:
-              #     - template: .devops/templates/publish-website.yml@self
+                    # Since v8 updates should be very rare, it's probably not necessary to update the website.
+                    # If this is re-enabled, the Azure service connection will need to be re-created.
+                    # - ${{ if eq(parameters.dryRun, false) }}:
+                    #     - template: .devops/templates/publish-website.yml@self
 
-              # Run this near the end because it's more likely to fail than the artifact upload tasks, and its
-              # failure doesn't need to block anything else
-              - script: |
-                  node -r ./scripts/ts-node/src/register ./scripts/update-release-notes/src/index.ts --token=$(githubPAT) --apply --debug
-                condition: not(${{ parameters.dryRun }})
-                displayName: 'Update github release notes'
+                    # Run this near the end because it's more likely to fail than the artifact upload tasks, and its
+                    # failure doesn't need to block anything else
+                    - script: |
+                        node -r ./scripts/ts-node/src/register ./scripts/update-release-notes/src/index.ts --apply --debug
+                      condition: not(${{ parameters.dryRun }})
+                      displayName: 'Update github release notes'
+                      env:
+                        TOKEN: $(createToken.GITHUB_APP_TOKEN)

--- a/scripts/beachball/src/customRenderers.ts
+++ b/scripts/beachball/src/customRenderers.ts
@@ -4,9 +4,9 @@ import { fluentRepoDetails, getPullRequestForCommit } from '@fluentui/scripts-gi
 import { Octokit } from '@octokit/rest';
 import { ChangelogEntry, PackageChangelogRenderInfo } from 'beachball';
 
-const githubPAT = process.env.GITHUB_PAT;
+const githubPAT = process.env.BEACHBALL_GIT_TOKEN;
 if (!githubPAT && (process.argv.includes('bump') || process.argv.includes('publish'))) {
-  console.warn('\nGITHUB_PAT environment variable not found. GitHub requests may be rate-limited.\n');
+  console.warn('\nBEACHBALL_GIT_TOKEN environment variable not found. GitHub requests may be rate-limited.\n');
 }
 
 const github = new Octokit({
@@ -41,7 +41,12 @@ export async function renderEntry(entry: ChangelogEntry): Promise<string> {
   return `- ${entry.comment} (${commitLink} by ${entry.author})`;
 }
 
+const prNumberCache = new Map<ChangelogEntry, number | undefined>();
+
 async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> {
+  if (prNumberCache.has(entry)) {
+    return prNumberCache.get(entry);
+  }
   if (!entry.commit || entry.commit === 'not available') {
     return undefined;
   }
@@ -51,9 +56,11 @@ async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> 
     const logResult = spawnSync('git', ['log', '--pretty=format:%s', '-n', '1', entry.commit]);
     if (logResult.status === 0) {
       const message = logResult.stdout.toString().trim();
-      const prMatch = message.split(/\r?\n/)[0].match(/\(#(\d+)\)$/m);
+      const prMatch = message.match(/\(#(\d+)\)$/m);
       if (prMatch) {
-        return Number(prMatch[1]);
+        const prNumber = Number(prMatch[1]);
+        prNumberCache.set(entry, prNumber);
+        return prNumber;
       }
     }
   } catch (ex) {
@@ -63,6 +70,7 @@ async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> 
   // Or fetch from GitHub API
   console.log(`Attempting to fetch pull request corresponding to ${entry.commit}...`);
   const pr = await getPullRequestForCommit({ commit: entry.commit, github, repoDetails: fluentRepoDetails });
+  prNumberCache.set(entry, pr?.number);
   if (pr) {
     console.log('...success!'); // failure message is logged by getPullRequestForCommit
     return pr.number;

--- a/scripts/beachball/src/customRenderers.ts
+++ b/scripts/beachball/src/customRenderers.ts
@@ -4,16 +4,6 @@ import { fluentRepoDetails, getPullRequestForCommit } from '@fluentui/scripts-gi
 import { Octokit } from '@octokit/rest';
 import { ChangelogEntry, PackageChangelogRenderInfo } from 'beachball';
 
-const githubPAT = process.env.BEACHBALL_GIT_TOKEN;
-if (!githubPAT && (process.argv.includes('bump') || process.argv.includes('publish'))) {
-  console.warn('\nBEACHBALL_GIT_TOKEN environment variable not found. GitHub requests may be rate-limited.\n');
-}
-
-const github = new Octokit({
-  ...fluentRepoDetails,
-  ...(githubPAT && { auth: 'token ' + githubPAT }),
-});
-
 const repoUrl = `https://github.com/${fluentRepoDetails.owner}/${fluentRepoDetails.repo}`;
 
 export async function renderHeader(renderInfo: PackageChangelogRenderInfo): Promise<string> {
@@ -41,14 +31,14 @@ export async function renderEntry(entry: ChangelogEntry): Promise<string> {
   return `- ${entry.comment} (${commitLink} by ${entry.author})`;
 }
 
-const prNumberCache = new Map<ChangelogEntry, number | undefined>();
+const prNumberCache = new Map<string, number | undefined>();
 
 async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> {
-  if (prNumberCache.has(entry)) {
-    return prNumberCache.get(entry);
-  }
   if (!entry.commit || entry.commit === 'not available') {
     return undefined;
+  }
+  if (prNumberCache.has(entry.commit)) {
+    return prNumberCache.get(entry.commit);
   }
   // Look for (presumably) the PR number at the end of the first line of the commit
   try {
@@ -59,7 +49,7 @@ async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> 
       const prMatch = message.match(/\(#(\d+)\)$/m);
       if (prMatch) {
         const prNumber = Number(prMatch[1]);
-        prNumberCache.set(entry, prNumber);
+        prNumberCache.set(entry.commit, prNumber);
         return prNumber;
       }
     }
@@ -69,10 +59,30 @@ async function _getPrNumber(entry: ChangelogEntry): Promise<number | undefined> 
 
   // Or fetch from GitHub API
   console.log(`Attempting to fetch pull request corresponding to ${entry.commit}...`);
+  const github = getGithubClient();
   const pr = await getPullRequestForCommit({ commit: entry.commit, github, repoDetails: fluentRepoDetails });
-  prNumberCache.set(entry, pr?.number);
+  prNumberCache.set(entry.commit, pr?.number);
   if (pr) {
     console.log('...success!'); // failure message is logged by getPullRequestForCommit
     return pr.number;
   }
+}
+
+let _github: Octokit | undefined;
+
+function getGithubClient(): Octokit {
+  if (_github) {
+    return _github;
+  }
+
+  const githubToken = process.env.BEACHBALL_GIT_TOKEN;
+  if (!githubToken) {
+    console.warn('\nBEACHBALL_GIT_TOKEN environment variable not found. GitHub requests may be rate-limited.\n');
+  }
+  _github = new Octokit({
+    ...fluentRepoDetails,
+    ...(githubToken && { auth: 'token ' + githubToken }),
+  });
+
+  return _github;
 }

--- a/scripts/beachball/src/shared.config.ts
+++ b/scripts/beachball/src/shared.config.ts
@@ -17,7 +17,7 @@ export const config: SharedConfig = {
   // This can't be in the base config because people might use different names for remotes,
   // but it should be safe in release pipelines.
   branch: 'origin/master',
-  // In beachball v3 alpha, this is required if NPM_TOKEN is used.
+  // In beachball v3 alpha, this is required if BEACHBALL_NPM_TOKEN is used.
   registry: 'https://registry.npmjs.org',
   changelog: {
     customRenderers: {

--- a/scripts/update-release-notes/src/init.ts
+++ b/scripts/update-release-notes/src/init.ts
@@ -3,11 +3,10 @@ import * as yargs from 'yargs';
 import { fluentRepoDetails } from '@fluentui/scripts-github';
 
 const tokenMsg =
-  '\nA GitHub personal access token is required even for dry runs due to the potential high rate of requests.\n' +
+  '\nA GitHub token is required as TOKEN even for dry runs due to the potential high rate of requests.\n' +
   'Generate one here: https://github.com/settings/tokens\n';
 
 export const argv = yargs
-  .option('token', { describe: 'GitHub personal access token', type: 'string', required: tokenMsg })
   .option('apply', {
     describe: 'Actually apply changes (without this option, do a dry run)',
     type: 'boolean',
@@ -31,12 +30,18 @@ export const argv = yargs
   .version(false)
   .help().argv;
 
-if (!argv.token) {
+const token = process.env.TOKEN;
+
+if (!token) {
   console.error(tokenMsg);
   process.exit(1);
 }
+if (token.startsWith('$')) {
+  console.error('The token appears to be an invalid pipeline variable reference');
+  process.exit(1);
+}
 // check for placeholder token from launch.json
-if (argv.token === 'your token here') {
+if (token === 'your token here') {
   console.error(tokenMsg);
   console.error('To test this script, temporarily update launch.json with your token. DO NOT COMMIT YOUR TOKEN!\n');
   process.exit(1);
@@ -50,5 +55,5 @@ export const repoDetails = {
 // Authenticate with github and set up logging if debug arg is provided
 export const github = new Octokit({
   ...(argv.debug && { log: console }),
-  auth: 'token ' + argv.token,
+  auth: 'token ' + token,
 });

--- a/scripts/update-release-notes/src/pullRequests.ts
+++ b/scripts/update-release-notes/src/pullRequests.ts
@@ -4,30 +4,34 @@ import { IPullRequest, processPullRequestApiResponse, getPullRequestForCommit } 
 import { repoDetails, github } from './init';
 import { IExtendedPullRequest } from './types';
 
+const pullRequestCache = new Map<string, IPullRequest | undefined>();
+
 /**
- * Get the single pull request associated with the given changelog entry.
+ * Get the single pull request associated with the given changelog entry, with caching.
  */
 export async function getPullRequest(entry: ChangelogEntry): Promise<IPullRequest | undefined> {
   const { commit, author: authorEmail } = entry;
   if (!commit || commit === 'not available') {
     return undefined;
   }
-  const pr = await getPullRequestForCommit({
-    commit,
-    github,
-    repoDetails,
-    authorEmail,
-    verbose: true,
-  });
-  if (pr) {
-    return pr;
+  if (!pullRequestCache.has(commit)) {
+    let pr = await getPullRequestForCommit({
+      commit,
+      github,
+      repoDetails,
+      authorEmail,
+      verbose: true,
+    });
+    if (!pr) {
+      // Backup approach: check recent PRs for a commit with a matching message and author
+      // (the commit referenced in the change file might not directly exist in a PR if the PR was rebased)
+      console.log(`Could not find a PR matching ${commit}.`);
+      console.log(`Checking for a commit with a matching message recent PRs by ${authorEmail} instead...`);
+      pr = await getMatchingRecentPullRequest(entry);
+    }
+    pullRequestCache.set(commit, pr);
   }
-
-  // Backup approach: check recent PRs for a commit with a matching message and author
-  // (the commit referenced in the change file might not directly exist in a PR if the PR was rebased)
-  console.log(`Could not find a PR matching ${commit}.`);
-  console.log(`Checking for a commit with a matching message recent PRs by ${authorEmail} instead...`);
-  return getMatchingRecentPullRequest(entry);
+  return pullRequestCache.get(commit);
 }
 
 /**


### PR DESCRIPTION
As a temporary measure until #36626 is ready, apply *only* the changes to release with the `office-ogx-auth-helper` GitHub app's token. There's a temporary template `.devops/templates/run-with-token.yml` which handles getting and revoking the token, and takes steps to run inside as a parameter. 

To validate that creating the token works, I ran the pipeline against this branch. All branch rules have been updated to allow the app to bypass.

Also update `scripts/beachball/src/customRenderers.ts` and `update-release-notes` to use new token variables, and to cache the fetched PRs by commit, which should make the release process faster.