### PR TITLE
Fix Dropdown filled boundary in high contrast themes

### DIFF
--- a/change/@fluentui-react-combobox-dropdown-high-contrast-border.json
+++ b/change/@fluentui-react-combobox-dropdown-high-contrast-border.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: render filled Dropdown boundaries in high contrast themes",
+  "packageName": "@fluentui/react-combobox",
+  "email": "bernardo.sunderhus@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
+++ b/packages/react-components/react-combobox/library/src/components/Dropdown/useDropdownStyles.styles.ts
@@ -171,11 +171,11 @@ const useStyles = makeStyles({
   },
   'filled-lighter': {
     backgroundColor: tokens.colorNeutralBackground1,
-    border: `${tokens.strokeWidthThin} solid transparent`,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorTransparentStroke}`,
   },
   'filled-darker': {
     backgroundColor: tokens.colorNeutralBackground3,
-    border: `${tokens.strokeWidthThin} solid transparent`,
+    border: `${tokens.strokeWidthThin} solid ${tokens.colorTransparentStroke}`,
   },
   invalid: {
     ':not(:focus-within),:hover:not(:focus-within)': {


### PR DESCRIPTION
## Previous Behavior

`Dropdown` controls using `appearance="filled-darker"` or `appearance="filled-lighter"` used a literal transparent border. In Teams high contrast, this made the resting boundary invisible for filled appearances.

## New Behavior

Filled `Dropdown` appearances now use `tokens.colorTransparentStroke`, matching `Combobox`, `Input`, and `Textarea`, so high contrast themes can render a visible resting boundary.

## Related Issue

Fixes #36636

## Validation

- Verified locally in Storybook with `components-dropdown--appearance` and `storybook_fluentui-react-addon_theme:teams-high-contrast`; `filled-darker` now computes to a visible white solid border.
- Ran `yarn nx run react-combobox:test`.
