### PR TITLE
fix(react-utilities): add loading to img element property whitelist

### DIFF
--- a/change/@fluentui-react-utilities-2487f27f-0f06-4edf-8046-4f2016681dfd.json
+++ b/change/@fluentui-react-utilities-2487f27f-0f06-4edf-8046-4f2016681dfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Add loading to img element property whitelist",
+  "packageName": "@fluentui/react-utilities",
+  "email": "84954628+lukiod@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.test.ts
@@ -1,5 +1,12 @@
 import type * as React from 'react';
-import { getNativeProps, divProperties, inputProperties, anchorProperties, buttonProperties, imgProperties } from './properties';
+import {
+  getNativeProps,
+  divProperties,
+  inputProperties,
+  anchorProperties,
+  buttonProperties,
+  imgProperties,
+} from './properties';
 
 describe('getNativeProps', () => {
   it('can pass through data tags', () => {

--- a/packages/react-components/react-utilities/src/utils/properties.test.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.test.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react';
-import { getNativeProps, divProperties, inputProperties, anchorProperties, buttonProperties } from './properties';
+import { getNativeProps, divProperties, inputProperties, anchorProperties, buttonProperties, imgProperties } from './properties';
 
 describe('getNativeProps', () => {
   it('can pass through data tags', () => {
@@ -108,6 +108,27 @@ describe('getNativeProps', () => {
       target: '_blank',
       referrerPolicy: 'no-referrer',
       download: 'file.txt',
+    });
+
+    expect(result).not.toHaveProperty('foobar');
+  });
+
+  it('can pass through img props including loading', () => {
+    const result = getNativeProps<React.ImgHTMLAttributes<HTMLImageElement>>(
+      {
+        src: 'https://example.com/image.png',
+        alt: 'An image',
+        loading: 'lazy',
+        // Non-img property
+        foobar: 1,
+      },
+      imgProperties,
+    );
+
+    expect(result).toMatchObject({
+      src: 'https://example.com/image.png',
+      alt: 'An image',
+      loading: 'lazy',
     });
 
     expect(result).not.toHaveProperty('foobar');

--- a/packages/react-components/react-utilities/src/utils/properties.ts
+++ b/packages/react-components/react-utilities/src/utils/properties.ts
@@ -416,6 +416,7 @@ export const imgProperties = toObjectMap(htmlElementProperties, [
   'alt', // area, img, input
   'crossOrigin', // img
   'height', // canvas, embed, iframe, img, input, object, video
+  'loading', // img, iframe
   'src', // audio, embed, iframe, img, input, script, source, track, video
   'srcSet', // img, source
   'useMap', // img, object,


### PR DESCRIPTION
Closes #36635.

`imgProperties` in `getNativeElementProps`'s allowlist didn't include `loading`, so passing `loading="lazy"` to the v9 `Image` component (or any other component whose root slot renders an `img`) got silently stripped before it ever reached the native element, even though `loading` is a valid prop on `ImageProps` per its `Slot<'img'>` type — matches the reporter's own diagnosis exactly.

Added `loading` next to the other native img properties, alphabetically between `height` and `src` matching the file's existing convention. Added a test mirroring the existing `referrerPolicy`/`anchorProperties` test in the same file (added in #35447, same shape of bug in a different allowlist).

**Verification.** Couldn't get a working clone of this repo in my environment (real, repeated timeouts on both shallow and blobless partial clones, not skipped without trying), so I extracted `toObjectMap`/`getNativeProps` verbatim from `properties.ts` and ran them standalone under Node: a negative control against the original allowlist reproduces the bug (`loading` silently dropped, `src`/`alt` pass through fine), and the same call against the fixed allowlist shows `loading` passing through while an unrelated prop still gets stripped. I wasn't able to run the actual Jest suite for this package given the clone issue — flagging that plainly rather than claiming a full test run that didn't happen.