### PR TITLE
fix(react-teaching-popover): move focus to page title on carousel step change

### DIFF
--- a/change/@fluentui-react-teaching-popover-d7c78e6e-6bf1-499a-9c7c-7e5e3534747b.json
+++ b/change/@fluentui-react-teaching-popover-d7c78e6e-6bf1-499a-9c7c-7e5e3534747b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: move focus to the active page's TeachingPopoverTitle when a TeachingPopoverCarousel step changes, so assistive technology announces the new heading and step count in a single pass (fixes screen reader not announcing step changes on Next/Previous)",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "paulmardling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-teaching-popover-d7c78e6e-6bf1-499a-9c7c-7e5e3534747b.json
+++ b/change/@fluentui-react-teaching-popover-d7c78e6e-6bf1-499a-9c7c-7e5e3534747b.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: move focus to the active page's TeachingPopoverTitle when a TeachingPopoverCarousel step changes, so assistive technology announces the new heading and step count in a single pass (fixes screen reader not announcing step changes on Next/Previous)",
+  "comment": "fix: move focus to the active page's TeachingPopoverTitle after Next/Previous navigation while preserving navigation-tab focus and newer focus choices",
   "packageName": "@fluentui/react-teaching-popover",
   "email": "paulmardling@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/react-teaching-popover/library/config/tests.cjs
+++ b/packages/react-components/react-teaching-popover/library/config/tests.cjs
@@ -1,1 +1,3 @@
 /** Jest test setup file. */
+
+require('@testing-library/jest-dom');

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -40,6 +40,21 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
 
   const { announce } = useAnnounce();
 
+  // Tracks the value of a carousel page that is in the process of becoming active, so that focus is only moved
+  // to a page's title when its DOM node mounts *because of* a navigation - not whenever any
+  // `[data-carousel-title]` node happens to be added anywhere under the carousel (e.g. unrelated async content).
+  const pendingFocusValueRef = React.useRef<string | null>(null);
+  const isInitialRenderRef = React.useRef(true);
+
+  React.useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+      return;
+    }
+
+    pendingFocusValueRef.current = value;
+  }, [value]);
+
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
@@ -95,15 +110,25 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
             store.insertValue(newValue, previousNode?.value ?? null);
           }
 
-          // Move focus to the new page's title (if present) once it has actually mounted in the DOM, so
-          // assistive technology can announce the updated heading (and any aria-describedby'd step count) in a
-          // single pass, instead of relying solely on the `announcement` live region. Because this only runs for
-          // nodes added after the observer starts, the initial page's title is left untouched on mount.
-          const titleEl = addedNode.matches(`[${CAROUSEL_TITLE}]`)
-            ? addedNode
-            : addedNode.querySelector<HTMLElement>(`[${CAROUSEL_TITLE}]`);
+          // Move focus to a page's title only when it mounts as part of an actual navigation to it (tracked via
+          // `pendingFocusValueRef`), so assistive technology announces the updated heading (and any
+          // aria-describedby'd step count) in a single pass. A page's own root element (marked with
+          // `data-carousel-item`) is never removed/re-added on navigation - only its children toggle - so the
+          // title's *owning* item is resolved via the closest `[data-carousel-item]` ancestor and compared
+          // against the pending value. This ensures unrelated title mounts elsewhere in the carousel - e.g. async
+          // content added to a page that isn't the one just navigated to - never steal focus.
+          if (pendingFocusValueRef.current !== null) {
+            const titleEl = addedNode.matches(`[${CAROUSEL_TITLE}]`)
+              ? addedNode
+              : addedNode.querySelector<HTMLElement>(`[${CAROUSEL_TITLE}]`);
 
-          titleEl?.focus({ preventScroll: true });
+            const owningItemValue = titleEl?.closest(`[${CAROUSEL_ITEM}]`)?.getAttribute(CAROUSEL_ITEM);
+
+            if (titleEl && owningItemValue === pendingFocusValueRef.current) {
+              titleEl.focus({ preventScroll: true });
+              pendingFocusValueRef.current = null;
+            }
+          }
         }
 
         for (const removedNode of Array.from(mutation.removedNodes)) {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { isHTMLElement, useMergedRefs, useControllableState, useEventCallback } from '@fluentui/react-utilities';
 import { useAnnounce, useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
-import { CAROUSEL_ITEM } from './constants';
+import { CAROUSEL_ITEM, CAROUSEL_TITLE } from './constants';
 import { useCarouselWalker_unstable } from './useCarouselWalker';
 import { createCarouselStore } from './createCarouselStore';
 import type { CarouselStore, UseCarouselOptions } from './Carousel.types';
@@ -80,7 +80,11 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
     const callback: MutationCallback = mutationList => {
       for (const mutation of mutationList) {
         for (const addedNode of Array.from(mutation.addedNodes)) {
-          if (isHTMLElement(addedNode) && addedNode.hasAttribute(CAROUSEL_ITEM)) {
+          if (!isHTMLElement(addedNode)) {
+            continue;
+          }
+
+          if (addedNode.hasAttribute(CAROUSEL_ITEM)) {
             const newValue = addedNode.getAttribute(CAROUSEL_ITEM)!;
             const newNode = carouselWalker.find(newValue);
             if (!newNode?.value) {
@@ -90,6 +94,16 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
             const previousNode = carouselWalker.prevPage(newNode?.value);
             store.insertValue(newValue, previousNode?.value ?? null);
           }
+
+          // Move focus to the new page's title (if present) once it has actually mounted in the DOM, so
+          // assistive technology can announce the updated heading (and any aria-describedby'd step count) in a
+          // single pass, instead of relying solely on the `announcement` live region. Because this only runs for
+          // nodes added after the observer starts, the initial page's title is left untouched on mount.
+          const titleEl = addedNode.matches(`[${CAROUSEL_TITLE}]`)
+            ? addedNode
+            : addedNode.querySelector<HTMLElement>(`[${CAROUSEL_TITLE}]`);
+
+          titleEl?.focus({ preventScroll: true });
         }
 
         for (const removedNode of Array.from(mutation.removedNodes)) {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { isHTMLElement, useMergedRefs, useControllableState, useEventCallback } from '@fluentui/react-utilities';
+import {
+  isHTMLElement,
+  useMergedRefs,
+  useControllableState,
+  useEventCallback,
+  useIsomorphicLayoutEffect,
+} from '@fluentui/react-utilities';
 import { useAnnounce, useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
 import { CAROUSEL_ITEM, CAROUSEL_TITLE } from './constants';
@@ -9,6 +15,12 @@ import { useCarouselWalker_unstable } from './useCarouselWalker';
 import { createCarouselStore } from './createCarouselStore';
 import type { CarouselStore, UseCarouselOptions } from './Carousel.types';
 import type { CarouselContextValue } from './CarouselContext';
+
+type CarouselFocusRequest = {
+  requestedValue: string;
+  origin: Element | null;
+  committed: boolean;
+};
 
 // TODO: Migrate this into an external @fluentui/carousel component
 // For now, we won't export this publicly, is only for internal TeachingPopover use until stabilized.
@@ -40,20 +52,25 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
 
   const { announce } = useAnnounce();
 
-  // Tracks the value of a carousel page that is in the process of becoming active, so that focus is only moved
-  // to a page's title when its DOM node mounts *because of* a navigation - not whenever any
-  // `[data-carousel-title]` node happens to be added anywhere under the carousel (e.g. unrelated async content).
-  const pendingFocusValueRef = React.useRef<string | null>(null);
-  const isInitialRenderRef = React.useRef(true);
+  const previousValueRef = React.useRef(value);
+  const focusRequestRef = React.useRef<CarouselFocusRequest | null>(null);
 
-  React.useEffect(() => {
-    if (isInitialRenderRef.current) {
-      isInitialRenderRef.current = false;
+  // A controlled value does not carry the request that caused it, so delayed acceptance is recognized by matching
+  // the latest directional request while its captured focus origin still owns focus. Any different committed value,
+  // direct tab activation, or newer directional request supersedes it.
+  useIsomorphicLayoutEffect(() => {
+    if (previousValueRef.current === value) {
       return;
     }
 
-    pendingFocusValueRef.current = value;
-  }, [value]);
+    previousValueRef.current = value;
+
+    if (focusRequestRef.current?.requestedValue === value) {
+      focusRequestRef.current.committed = true;
+    } else {
+      focusRequestRef.current = null;
+    }
+  });
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -110,23 +127,26 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
             store.insertValue(newValue, previousNode?.value ?? null);
           }
 
-          // Move focus to a page's title only when it mounts as part of an actual navigation to it (tracked via
-          // `pendingFocusValueRef`), so assistive technology announces the updated heading (and any
-          // aria-describedby'd step count) in a single pass. A page's own root element (marked with
-          // `data-carousel-item`) is never removed/re-added on navigation - only its children toggle - so the
-          // title's *owning* item is resolved via the closest `[data-carousel-item]` ancestor and compared
-          // against the pending value. This ensures unrelated title mounts elsewhere in the carousel - e.g. async
-          // content added to a page that isn't the one just navigated to - never steal focus.
-          if (pendingFocusValueRef.current !== null) {
+          const focusRequest = focusRequestRef.current;
+
+          if (focusRequest?.committed) {
             const titleEl = addedNode.matches(`[${CAROUSEL_TITLE}]`)
               ? addedNode
               : addedNode.querySelector<HTMLElement>(`[${CAROUSEL_TITLE}]`);
 
             const owningItemValue = titleEl?.closest(`[${CAROUSEL_ITEM}]`)?.getAttribute(CAROUSEL_ITEM);
 
-            if (titleEl && owningItemValue === pendingFocusValueRef.current) {
-              titleEl.focus({ preventScroll: true });
-              pendingFocusValueRef.current = null;
+            if (titleEl && owningItemValue === focusRequest.requestedValue) {
+              const activeElement: Element | null = targetDocument?.activeElement ?? null;
+              const originWasRemoved = focusRequest.origin !== null && !focusRequest.origin.isConnected;
+              const requestStillOwnsFocus =
+                activeElement === focusRequest.origin || (originWasRemoved && activeElement === targetDocument?.body);
+
+              if (requestStillOwnsFocus) {
+                titleEl.focus({ preventScroll: true });
+              }
+
+              focusRequestRef.current = null;
             }
           }
         }
@@ -151,7 +171,7 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
     return () => {
       observer.disconnect();
     };
-  }, [carouselWalker, store, win]);
+  }, [carouselWalker, store, targetDocument, win]);
 
   const updateSlide = useEventCallback(
     (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, newValue: string) => {
@@ -176,10 +196,20 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
       direction === 'prev' ? carouselWalker.prevPage(active.value) : carouselWalker.nextPage(active.value);
 
     if (newPage) {
+      focusRequestRef.current = {
+        requestedValue: newPage.value,
+        origin: targetDocument?.activeElement ?? null,
+        committed: false,
+      };
       updateSlide(event, newPage?.value);
     } else {
       onFinish?.(event, { event, type: 'click', value: active?.value });
     }
+  });
+
+  const selectPageByValue: CarouselContextValue['selectPageByValue'] = useEventCallback((event, newValue) => {
+    focusRequestRef.current = null;
+    updateSlide(event, newValue);
   });
 
   return {
@@ -188,7 +218,7 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
       store,
       value,
       selectPageByDirection,
-      selectPageByValue: updateSlide,
+      selectPageByValue,
     },
   };
 }

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/constants.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/constants.ts
@@ -1,2 +1,9 @@
 export const CAROUSEL_ITEM = 'data-carousel-item';
 export const CAROUSEL_ACTIVE_ITEM = 'data-carousel-active-item';
+
+/**
+ * Marks the heading (TeachingPopoverTitle) belonging to a carousel page, so that focus can be moved to it
+ * when the active page changes. This lets assistive technology announce the new step's accessible name/role
+ * in a single pass, instead of relying solely on a separate live region announcement.
+ */
+export const CAROUSEL_TITLE = 'data-carousel-title';

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
+import { TeachingPopoverCarouselCard } from '../TeachingPopoverCarouselCard/TeachingPopoverCarouselCard';
+import { TeachingPopoverCarouselFooter } from '../TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter';
+import { TeachingPopoverTitle } from '../TeachingPopoverTitle/TeachingPopoverTitle';
 
 describe('TeachingPopoverCarousel', () => {
   isConformant({
@@ -20,5 +23,60 @@ describe('TeachingPopoverCarousel', () => {
       <TeachingPopoverCarousel defaultValue="">Default TeachingPopoverCarousel</TeachingPopoverCarousel>,
     );
     expect(result.container).toMatchSnapshot();
+  });
+
+  it('moves focus to the new page title when navigating to the next page', async () => {
+    render(
+      <TeachingPopoverCarousel defaultValue="one">
+        <TeachingPopoverCarouselCard value="one">
+          <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselCard value="two">
+          <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+          Footer
+        </TeachingPopoverCarouselFooter>
+      </TeachingPopoverCarousel>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(screen.getByText('Step two')).toHaveFocus());
+  });
+
+  it('moves focus to the new page title when navigating to the previous page', async () => {
+    render(
+      <TeachingPopoverCarousel defaultValue="two">
+        <TeachingPopoverCarouselCard value="one">
+          <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselCard value="two">
+          <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+          Footer
+        </TeachingPopoverCarouselFooter>
+      </TeachingPopoverCarousel>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous' }));
+
+    await waitFor(() => expect(screen.getByText('Step one')).toHaveFocus());
+  });
+
+  it('does not move focus to the title on initial render', async () => {
+    render(
+      <TeachingPopoverCarousel defaultValue="one">
+        <TeachingPopoverCarouselCard value="one">
+          <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+      </TeachingPopoverCarousel>,
+    );
+
+    // Flush any pending microtasks (e.g. the carousel's mutation observer) before asserting.
+    await Promise.resolve();
+
+    expect(screen.getByText('Step one')).not.toHaveFocus();
   });
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
@@ -79,4 +79,35 @@ describe('TeachingPopoverCarousel', () => {
 
     expect(screen.getByText('Step one')).not.toHaveFocus();
   });
+
+  it('does not move focus when a title mounts on the active page outside of a navigation', async () => {
+    const AsyncTitle = () => {
+      const [loaded, setLoaded] = React.useState(false);
+
+      React.useEffect(() => {
+        setLoaded(true);
+      }, []);
+
+      return loaded ? <TeachingPopoverTitle>Async step one</TeachingPopoverTitle> : null;
+    };
+
+    render(
+      <TeachingPopoverCarousel defaultValue="one">
+        <TeachingPopoverCarouselCard value="one">
+          <button type="button">Focus me</button>
+          <AsyncTitle />
+        </TeachingPopoverCarouselCard>
+      </TeachingPopoverCarousel>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Focus me' });
+    button.focus();
+
+    // Wait for the async title to mount, plus any pending microtasks (e.g. the carousel's mutation observer).
+    await waitFor(() => expect(screen.getByText('Async step one')).toBeInTheDocument());
+    await Promise.resolve();
+
+    expect(button).toHaveFocus();
+    expect(screen.getByText('Async step one')).not.toHaveFocus();
+  });
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/TeachingPopoverCarousel.test.tsx
@@ -1,10 +1,40 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
 import { TeachingPopoverCarouselCard } from '../TeachingPopoverCarouselCard/TeachingPopoverCarouselCard';
 import { TeachingPopoverCarouselFooter } from '../TeachingPopoverCarouselFooter/TeachingPopoverCarouselFooter';
+import { TeachingPopoverCarouselNav } from '../TeachingPopoverCarouselNav/TeachingPopoverCarouselNav';
+import { TeachingPopoverCarouselNavButton } from '../TeachingPopoverCarouselNavButton/TeachingPopoverCarouselNavButton';
 import { TeachingPopoverTitle } from '../TeachingPopoverTitle/TeachingPopoverTitle';
+
+const DeferredSecondPage = (props: {
+  autoFocus?: boolean;
+  removeNavigationOrigin?: boolean;
+  revealTitleRef: React.RefObject<(() => void) | null>;
+}) => {
+  const [showTitle, setShowTitle] = React.useState(false);
+  props.revealTitleRef.current = () => setShowTitle(true);
+  const footer = (
+    <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+      Footer
+    </TeachingPopoverCarouselFooter>
+  );
+
+  return (
+    <TeachingPopoverCarousel defaultValue="one">
+      <TeachingPopoverCarouselCard value="one">
+        <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+        {props.removeNavigationOrigin && footer}
+      </TeachingPopoverCarouselCard>
+      <TeachingPopoverCarouselCard value="two">
+        {showTitle && <TeachingPopoverTitle>Step two</TeachingPopoverTitle>}
+        <input aria-label="Step two input" autoFocus={props.autoFocus} />
+      </TeachingPopoverCarouselCard>
+      {!props.removeNavigationOrigin && footer}
+    </TeachingPopoverCarousel>
+  );
+};
 
 describe('TeachingPopoverCarousel', () => {
   isConformant({
@@ -65,18 +95,296 @@ describe('TeachingPopoverCarousel', () => {
     await waitFor(() => expect(screen.getByText('Step one')).toHaveFocus());
   });
 
-  it('does not move focus to the title on initial render', async () => {
+  it('keeps focus on the navigation tab when activating it', async () => {
     render(
       <TeachingPopoverCarousel defaultValue="one">
         <TeachingPopoverCarouselCard value="one">
           <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
         </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselCard value="two">
+          <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+        </TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselNav>
+          {value => <TeachingPopoverCarouselNavButton aria-label={`Step ${value}`} />}
+        </TeachingPopoverCarouselNav>
       </TeachingPopoverCarousel>,
     );
 
-    // Flush any pending microtasks (e.g. the carousel's mutation observer) before asserting.
-    await Promise.resolve();
+    const stepTwoTab = screen.getByRole('tab', { name: 'Step two' });
+    stepTwoTab.focus();
+    fireEvent.click(stepTwoTab);
 
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(stepTwoTab).toHaveFocus();
+  });
+
+  it('does not move focus to a deferred title after the user moves focus', async () => {
+    const revealTitleRef: React.RefObject<(() => void) | null> = { current: null };
+    render(<DeferredSecondPage revealTitleRef={revealTitleRef} />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+
+    const input = await screen.findByRole('textbox', { name: 'Step two input' });
+    input.focus();
+    expect(input).toHaveFocus();
+    act(() => revealTitleRef.current?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(input).toHaveFocus();
+  });
+
+  it('does not override autofocus when a deferred title mounts', async () => {
+    const revealTitleRef: React.RefObject<(() => void) | null> = { current: null };
+    render(<DeferredSecondPage autoFocus revealTitleRef={revealTitleRef} />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+
+    const input = await screen.findByRole('textbox', { name: 'Step two input' });
+    expect(input).toHaveFocus();
+    act(() => revealTitleRef.current?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(input).toHaveFocus();
+  });
+
+  it('moves focus to a deferred title when the navigation origin still has focus', async () => {
+    const revealTitleRef: React.RefObject<(() => void) | null> = { current: null };
+    render(<DeferredSecondPage revealTitleRef={revealTitleRef} />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+    expect(nextButton).toHaveFocus();
+    act(() => revealTitleRef.current?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toHaveFocus());
+  });
+
+  it('moves focus to a deferred title when the navigation origin was removed', async () => {
+    const revealTitleRef: React.RefObject<(() => void) | null> = { current: null };
+    render(<DeferredSecondPage removeNavigationOrigin revealTitleRef={revealTitleRef} />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+
+    await waitFor(() => expect(nextButton).not.toBeInTheDocument());
+    expect(document.body).toHaveFocus();
+    act(() => revealTitleRef.current?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toHaveFocus());
+  });
+
+  it('does not move focus when the controlled value changes directly', async () => {
+    const ControlledCarousel = () => {
+      const [value, setValue] = React.useState('one');
+
+      return (
+        <>
+          <button type="button" onClick={() => setValue('two')}>
+            Show step two
+          </button>
+          <TeachingPopoverCarousel value={value}>
+            <TeachingPopoverCarouselCard value="one">
+              <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+            </TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselCard value="two">
+              <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+            </TeachingPopoverCarouselCard>
+          </TeachingPopoverCarousel>
+        </>
+      );
+    };
+
+    render(<ControlledCarousel />);
+
+    const control = screen.getByRole('button', { name: 'Show step two' });
+    control.focus();
+    fireEvent.click(control);
+
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(control).toHaveFocus();
+  });
+
+  it('does not reuse a rejected controlled navigation request for a later external change', async () => {
+    const ControlledCarousel = () => {
+      const [value, setValue] = React.useState('one');
+
+      return (
+        <>
+          <button type="button" onClick={() => setValue('two')}>
+            Show step two
+          </button>
+          <TeachingPopoverCarousel value={value}>
+            <TeachingPopoverCarouselCard value="one">
+              <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+            </TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselCard value="two">
+              <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+            </TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselFooter
+              next="Next"
+              previous="Previous"
+              initialStepText="Close"
+              finalStepText="Finish"
+            >
+              Footer
+            </TeachingPopoverCarouselFooter>
+          </TeachingPopoverCarousel>
+        </>
+      );
+    };
+
+    render(<ControlledCarousel />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+    expect(screen.getByText('Step one')).toBeVisible();
+
+    const control = screen.getByRole('button', { name: 'Show step two' });
+    control.focus();
+    fireEvent.click(control);
+
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(control).toHaveFocus();
+  });
+
+  it('clears a pending directional focus request when the active navigation tab is selected', async () => {
+    let showStepTwo: (() => void) | undefined;
+
+    const ControlledCarousel = () => {
+      const [value, setValue] = React.useState('one');
+      showStepTwo = () => setValue('two');
+
+      return (
+        <TeachingPopoverCarousel value={value}>
+          <TeachingPopoverCarouselCard value="one">
+            <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselCard value="two">
+            <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselNav>
+            {pageValue => <TeachingPopoverCarouselNavButton aria-label={`Step ${pageValue}`} />}
+          </TeachingPopoverCarouselNav>
+          <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+            Footer
+          </TeachingPopoverCarouselFooter>
+        </TeachingPopoverCarousel>
+      );
+    };
+
+    render(<ControlledCarousel />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+
+    const activeTab = screen.getByRole('tab', { name: 'Step one' });
+    activeTab.focus();
+    fireEvent.click(activeTab);
+    act(() => showStepTwo?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toBeVisible());
+    expect(activeTab).toHaveFocus();
+  });
+
+  it('moves focus to the title after directional navigation in controlled mode', async () => {
+    const ControlledCarousel = () => {
+      const [value, setValue] = React.useState('one');
+
+      return (
+        <TeachingPopoverCarousel value={value} onValueChange={(_, data) => setValue(data.value!)}>
+          <TeachingPopoverCarouselCard value="one">
+            <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselCard value="two">
+            <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+            Footer
+          </TeachingPopoverCarouselFooter>
+        </TeachingPopoverCarousel>
+      );
+    };
+
+    render(<ControlledCarousel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(screen.getByText('Step two')).toHaveFocus());
+  });
+
+  it('supports delayed controlled acceptance while the navigation origin retains focus', async () => {
+    let acceptNavigation: (() => void) | undefined;
+
+    const ControlledCarousel = () => {
+      const [value, setValue] = React.useState('one');
+
+      return (
+        <TeachingPopoverCarousel
+          value={value}
+          onValueChange={(_, data) => {
+            acceptNavigation = () => setValue(data.value!);
+          }}
+        >
+          <TeachingPopoverCarouselCard value="one">
+            <TeachingPopoverTitle>Step one</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselCard value="two">
+            <TeachingPopoverTitle>Step two</TeachingPopoverTitle>
+          </TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselFooter next="Next" previous="Previous" initialStepText="Close" finalStepText="Finish">
+            Footer
+          </TeachingPopoverCarouselFooter>
+        </TeachingPopoverCarousel>
+      );
+    };
+
+    render(<ControlledCarousel />);
+
+    const nextButton = screen.getByRole('button', { name: 'Next' });
+    nextButton.focus();
+    fireEvent.click(nextButton);
+    expect(screen.getByText('Step one')).toBeVisible();
+
+    act(() => acceptNavigation?.());
+
+    await waitFor(() => expect(screen.getByText('Step two')).toHaveFocus());
+  });
+
+  it('does not move focus to a deferred initial title in StrictMode', async () => {
+    let revealInitialTitle: (() => void) | undefined;
+
+    const StrictModeCarousel = () => {
+      const [showTitle, setShowTitle] = React.useState(false);
+      revealInitialTitle = () => setShowTitle(true);
+
+      return (
+        <TeachingPopoverCarousel defaultValue="one">
+          <TeachingPopoverCarouselCard value="one">
+            {showTitle && <TeachingPopoverTitle>Step one</TeachingPopoverTitle>}
+          </TeachingPopoverCarouselCard>
+        </TeachingPopoverCarousel>
+      );
+    };
+
+    render(
+      <React.StrictMode>
+        <StrictModeCarousel />
+      </React.StrictMode>,
+    );
+
+    expect(document.body).toHaveFocus();
+    act(() => revealInitialTitle?.());
+
+    await waitFor(() => expect(screen.getByText('Step one')).toBeVisible());
+    expect(document.body).toHaveFocus();
     expect(screen.getByText('Step one')).not.toHaveFocus();
   });
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/__snapshots__/TeachingPopoverTitle.test.tsx.snap
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/__snapshots__/TeachingPopoverTitle.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`TeachingPopoverTitle renders a default state 1`] = `
 <div>
   <h2
     class="fui-TeachingPopoverTitle"
+    data-carousel-title="true"
+    tabindex="-1"
   >
     Default TeachingPopoverTitle
   </h2>

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverTitle/useTeachingPopoverTitleBase.tsx
@@ -3,6 +3,7 @@
 import type * as React from 'react';
 import { usePopoverContext_unstable } from '@fluentui/react-popover';
 import { getIntrinsicElementProps, slot, useEventCallback } from '@fluentui/react-utilities';
+import { CAROUSEL_TITLE } from '../TeachingPopoverCarousel/Carousel/constants';
 import type { TeachingPopoverTitleBaseProps, TeachingPopoverTitleBaseState } from './TeachingPopoverTitle.types';
 
 /**
@@ -38,6 +39,10 @@ export const useTeachingPopoverTitleBase_unstable = (
     root: slot.always(
       getIntrinsicElementProps('h2', {
         ref,
+        // Not in the tab sequence, but programmatically focusable so a TeachingPopoverCarousel can move focus
+        // here when the active page changes, letting assistive technology announce the new title in one pass.
+        tabIndex: -1,
+        [CAROUSEL_TITLE]: true,
         ...props,
       }),
       { elementType: 'h2' },

--- a/packages/react-components/react-teaching-popover/library/tsconfig.spec.json
+++ b/packages/react-components/react-teaching-popover/library/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "include": [
     "**/*.spec.ts",


### PR DESCRIPTION
## Why

Screen readers (Narrator/NVDA) did not reliably announce the new step's title/content when navigating a `TeachingPopoverCarousel` with Next/Previous. The existing live-region mechanism depends on a consumer-supplied `announcement` callback, so the active heading also needs a reliable focus handoff for directional navigation.

## What changed

- `TeachingPopoverTitle` renders with `tabIndex={-1}` and a `data-carousel-title` marker by default, allowing it to receive programmatic focus without entering the tab sequence.
- Next/Previous navigation records the requested page and the element that owned focus before the value update.
- The new heading receives focus only after the requested page becomes the committed active value and the original element still owns focus.
- If the original navigation control is removed during the page transition and focus naturally falls back to `body`, the heading can still receive focus.
- Newer user focus choices, including an input with `autoFocus`, are preserved rather than being overridden by a delayed heading mount.
- Activating a carousel navigation tab keeps focus on that tab and clears any pending directional handoff.
- Direct controlled `value` changes do not initiate heading focus. Delayed controlled acceptance of a Next/Previous request remains supported while that request still owns focus and has not been superseded.
- Committed-value tracking prevents React StrictMode effect replay from treating the initial page as navigation.
- No new public props, context, or API surface were added.
- Updated the beachball change file.

## Testing

- Focused `TeachingPopoverCarousel` Jest suite: 31 tests pass, including Next/Previous, navigation-tab retention, deferred headings, user-focused input, `autoFocus`, removed-origin fallback, controlled acceptance/rejection, and StrictMode initial-mount coverage.
- `yarn nx run react-teaching-popover:lint` — passes.
- `yarn nx run react-teaching-popover:type-check` — passes.
- `yarn nx run react-teaching-popover:build` — passes.

https://github.com/user-attachments/assets/8977d895-e0ab-40d5-95d0-11f99d2677eb

## Fixes

ADO [#39651](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/39651/)
Related PR for fluentui-modern [#5636212](https://dev.azure.com/office/Office/_git/1JS/pullrequest/5636212)
