### PR TITLE
fix(workspace-plugin): normalize path separators for Windows in generate-api

### DIFF
--- a/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/executor.spec.ts
@@ -9,6 +9,7 @@ import {
   type ExtractorMessage,
   type ExtractorResult,
 } from '@microsoft/api-extractor';
+import * as path from 'node:path';
 import { basename, join } from 'node:path';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
@@ -18,6 +19,7 @@ import { type TsConfig } from '../../types';
 import { type GenerateApiExecutorSchema } from './schema';
 import executor from './executor';
 import { isCI } from './lib/shared';
+import { getExportSubpathConfigs } from './lib/utils';
 
 const fixturesRootDir = join(__dirname, '__fixtures__');
 
@@ -346,6 +348,31 @@ describe('GenerateApi Executor – export subpath resolution', () => {
       expect(cfg.reportFilePath).toBe(join(paths.projRoot, 'etc', `${name}.api.md`));
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       expect(cfg.reportTempFilePath).toBe(join(paths.projRoot, 'temp', `${name}.api.md`));
+    }
+  });
+
+  it('resolves declaration base correctly when path.resolve returns Windows-style backslashes', async () => {
+    const subDirs = ['alpha'];
+    const { context } = prepareExportFixture({ wildcardSubDirs: subDirs });
+
+    const resolveSpy = jest.spyOn(path, 'resolve').mockImplementation((...args) => {
+      const posixPath = path.posix.resolve(...args);
+      return posixPath.replace(/\//g, '\\');
+    });
+
+    const capturedConfigs: ExtractorConfig[] = [];
+    jest.spyOn(Extractor, 'invoke').mockImplementation(cfg => {
+      capturedConfigs.push(cfg);
+      return { succeeded: true } as ExtractorResult;
+    });
+
+    try {
+      const output = await executor({ ...options, exportSubpaths: true }, context);
+
+      expect(capturedConfigs).toHaveLength(1 + subDirs.length);
+      expect(output.success).toBe(true);
+    } finally {
+      resolveSpy.mockRestore();
     }
   });
 

--- a/tools/workspace-plugin/src/executors/generate-api/lib/utils.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/lib/utils.ts
@@ -146,10 +146,11 @@ export function getExportSubpathConfigs(options: NormalizedOptions): IConfigFile
     // they act as literal path segments that the subsequent "../" chain traverses through.
     // path.resolve(configDir, "<projectRoot>/../../../../../../...") naturally normalizes to the correct path.
     const configDir = dirname(opts.config);
+    // Normalize to POSIX separators so the suffix check and slice work consistently across platforms (e.g. Windows).
     const resolvedPrimaryEntry = resolve(
       configDir,
       primaryMainEntryTemplate.replace(/<unscopedPackageName>/g, unscopedPackageName),
-    );
+    ).replace(/\\/g, '/');
 
     const indexDtsSuffix = '/index.d.ts';
     if (!resolvedPrimaryEntry.endsWith(indexDtsSuffix)) {


### PR DESCRIPTION
## Previous Behavior

In `tools/workspace-plugin/src/executors/generate-api/lib/utils.ts`, `resolveDeclarationBase` resolves the primary main entry template using `path.resolve(...)`. On Windows systems, `path.resolve` returns backslash-separated paths (`\`), which causes `resolvedPrimaryEntry.endsWith('/index.d.ts')` to evaluate to `false`. As a result, export subpath API rollup generation is silently skipped on Windows environments.

## New Behavior

Normalize `resolvedPrimaryEntry` with `.replace(/\\/g, '/')` so that the POSIX `/index.d.ts` suffix check and slice work consistently across all platforms (including Windows). Added a unit test in `executor.spec.ts` covering path resolution with Windows-style backslashes.

## Related Issue(s)

- Fixes #36654