### PR TITLE
fix: avoid duplicate primary story in docs

### DIFF
--- a/change/@fluentui-react-storybook-addon-0f3d5f6b-82c4-4d52-9271-831e6ade49c8.json
+++ b/change/@fluentui-react-storybook-addon-0f3d5f6b-82c4-4d52-9271-831e6ade49c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: render the primary story only once on docs pages",
+  "packageName": "@fluentui/react-storybook-addon",
+  "email": "dmytrokirpa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
+++ b/packages/react-components/react-storybook-addon/src/docs/FluentDocsPage.tsx
@@ -327,8 +327,8 @@ const RenderPrimaryStory = ({
   );
 };
 
-const RenderStories = ({ skipPrimaryStory }: { stories: PrimaryStory[]; skipPrimaryStory?: boolean }) => (
-  <Stories includePrimary={!skipPrimaryStory} />
+const RenderStories = (_props: { stories: PrimaryStory[]; skipPrimaryStory?: boolean }) => (
+  <Stories includePrimary={false} />
 );
 
 export type FluentDocsPageProps = {


### PR DESCRIPTION
## Summary

- render the primary story only in its dedicated section
- exclude the primary story from the secondary stories block
- add a patch change file for `@fluentui/react-storybook-addon`

## Validation

- `yarn nx run-many -t type-check lint test -p react-storybook-addon --nxBail`