### PR TITLE
feat(react-headless-components-preview): expose AvatarGroup context

### DIFF
--- a/change/@fluentui-react-headless-components-preview-30cabdfc-56c7-47ed-9b2a-a9b5824ad6d4.json
+++ b/change/@fluentui-react-headless-components-preview-30cabdfc-56c7-47ed-9b2a-a9b5824ad6d4.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "feat: expose the AvatarGroup context reader from the headless entry point",
+  "comment": "feat: expose the Avatar and AvatarGroup context readers from the headless entry points",
   "packageName": "@fluentui/react-headless-components-preview",
   "email": "vgenaev@gmail.com"
 }

--- a/change/@fluentui-react-headless-components-preview-30cabdfc-56c7-47ed-9b2a-a9b5824ad6d4.json
+++ b/change/@fluentui-react-headless-components-preview-30cabdfc-56c7-47ed-9b2a-a9b5824ad6d4.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "feat: expose the AvatarGroup context reader from the headless entry point",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com"
+}

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar-group.api.md
@@ -29,6 +29,7 @@ import { renderAvatarGroup_unstable as renderAvatarGroup } from '@fluentui/react
 import { renderAvatarGroupItem_unstable as renderAvatarGroupItem } from '@fluentui/react-avatar';
 import type { Slot } from '@fluentui/react-utilities';
 import type { TooltipBaseProps } from '@fluentui/react-tooltip';
+import { useAvatarGroupContext_unstable as useAvatarGroupContext } from '@fluentui/react-avatar';
 
 // @public
 export const AvatarGroup: ForwardRefComponent<AvatarGroupProps>;
@@ -104,6 +105,8 @@ export const renderAvatarGroupPopover: (state: AvatarGroupPopoverState, contextV
 
 // @public
 export const useAvatarGroup: (props: AvatarGroupProps, ref: React_2.Ref<HTMLDivElement>) => AvatarGroupState;
+
+export { useAvatarGroupContext }
 
 // @public
 export const useAvatarGroupContextValues: (state: AvatarGroupState) => AvatarGroupContextValues;

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
@@ -10,6 +10,7 @@ import { AvatarBaseState as AvatarState } from '@fluentui/react-avatar';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
 import { renderAvatar_unstable as renderAvatar } from '@fluentui/react-avatar';
+import { useAvatarContext } from '@fluentui/react-avatar';
 
 // @public
 export const Avatar: ForwardRefComponent<AvatarProps>;
@@ -24,6 +25,8 @@ export { renderAvatar }
 
 // @public
 export const useAvatar: (props: AvatarProps, ref: React_2.Ref<HTMLElement>) => AvatarState;
+
+export { useAvatarContext }
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/src/avatar-group.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/avatar-group.ts
@@ -2,6 +2,7 @@ export {
   AvatarGroup,
   renderAvatarGroup,
   useAvatarGroup,
+  useAvatarGroupContext,
   useAvatarGroupContextValues,
   AvatarGroupItem,
   renderAvatarGroupItem,

--- a/packages/react-components/react-headless-components-preview/library/src/avatar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/avatar.ts
@@ -1,2 +1,2 @@
-export { Avatar, renderAvatar, useAvatar } from './components/Avatar/index';
+export { Avatar, renderAvatar, useAvatar, useAvatarContext } from './components/Avatar/index';
 export type { AvatarSlots, AvatarProps, AvatarState } from './components/Avatar/index';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/index.ts
@@ -1,4 +1,4 @@
 export { Avatar } from './Avatar';
 export { renderAvatar } from './renderAvatar';
-export { useAvatar } from './useAvatar';
+export { useAvatar, useAvatarContext } from './useAvatar';
 export type { AvatarSlots, AvatarProps, AvatarState } from './Avatar.types';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/useAvatar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/useAvatar.ts
@@ -14,3 +14,8 @@ export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): Avat
 
   return state;
 };
+
+/**
+ * Returns the value from the nearest Avatar context.
+ */
+export { useAvatarContext } from '@fluentui/react-avatar';

--- a/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/index.ts
@@ -1,6 +1,6 @@
 export { AvatarGroup } from './AvatarGroup';
 export { renderAvatarGroup } from './renderAvatarGroup';
-export { useAvatarGroup } from './useAvatarGroup';
+export { useAvatarGroup, useAvatarGroupContext } from './useAvatarGroup';
 export { useAvatarGroupContextValues } from './useAvatarGroupContextValues';
 export type {
   AvatarGroupSlots,

--- a/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/useAvatarGroup.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/AvatarGroup/useAvatarGroup.ts
@@ -17,3 +17,8 @@ export const useAvatarGroup = (props: AvatarGroupProps, ref: React.Ref<HTMLDivEl
 
   return state;
 };
+
+/**
+ * Returns a selected value from the nearest AvatarGroup context.
+ */
+export { useAvatarGroupContext_unstable as useAvatarGroupContext } from '@fluentui/react-avatar';


### PR DESCRIPTION
## Previous Behavior

The headless AvatarGroup entry point exports its context-value builder, but not
the context reader. Headless consumers that need group state must either depend
directly on `@fluentui/react-avatar` or introduce a duplicate context.

## New Behavior

Export `useAvatarGroupContext` from the headless AvatarGroup entry point as a
stable alias for `useAvatarGroupContext_unstable
