### PR TITLE
fix(react-breadcrumb): make BreadcrumbButtonBaseProps distribute over the ARIA button union

### DIFF
--- a/change/@fluentui-react-breadcrumb-78372ea0-823d-4939-b9f5-600d215feb68.json
+++ b/change/@fluentui-react-breadcrumb-78372ea0-823d-4939-b9f5-600d215feb68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: make BreadcrumbButtonBaseProps distribute over the ARIA button union so the anchor arm's href stays assignable",
+  "packageName": "@fluentui/react-breadcrumb",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-breadcrumb/library/etc/react-breadcrumb.api.md
+++ b/packages/react-components/react-breadcrumb/library/etc/react-breadcrumb.api.md
@@ -9,6 +9,7 @@ import type { ButtonSlots } from '@fluentui/react-button';
 import type { ButtonState } from '@fluentui/react-button';
 import type { ComponentProps } from '@fluentui/react-utilities';
 import type { ComponentState } from '@fluentui/react-utilities';
+import type { DistributiveOmit } from '@fluentui/react-utilities';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 import * as React_2 from 'react';
@@ -29,7 +30,7 @@ export type BreadcrumbBaseState = Omit<BreadcrumbState, 'size'>;
 export const BreadcrumbButton: ForwardRefComponent<BreadcrumbButtonProps>;
 
 // @public (undocumented)
-export type BreadcrumbButtonBaseProps = Omit<BreadcrumbButtonProps, 'size'>;
+export type BreadcrumbButtonBaseProps = DistributiveOmit<BreadcrumbButtonProps, 'size'>;
 
 // @public (undocumented)
 export type BreadcrumbButtonBaseState = Omit<BreadcrumbButtonState, 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { BreadcrumbButton } from './BreadcrumbButton';
-import type { BreadcrumbButtonProps } from './BreadcrumbButton.types';
+import type { BreadcrumbButtonBaseProps, BreadcrumbButtonProps } from './BreadcrumbButton.types';
 import { isConformant } from '../../testing/isConformant';
 import { breadcrumbButtonClassNames } from './useBreadcrumbButtonStyles.styles';
 import { ArrowRight16Filled } from '@fluentui/react-icons';
@@ -66,5 +66,21 @@ describe('BreadcrumbButton', () => {
         </button>
       </div>
     `);
+  });
+
+  // Type-level regression test for https://github.com/microsoft/fluentui/issues/36645.
+  // `BreadcrumbButtonBaseProps` used a plain `Omit`, which collapsed the distributive ARIA button
+  // union and dropped the anchor arm's `href`. These assignments are validated by the package's
+  // type-check target.
+  it('keeps both arms of the ARIA button union assignable to BreadcrumbButtonBaseProps', () => {
+    const anchorProps: BreadcrumbButtonBaseProps = { as: 'a', href: '/somewhere' };
+    const buttonProps: BreadcrumbButtonBaseProps = { as: 'button' };
+
+    // @ts-expect-error - `size` is omitted from BreadcrumbButtonBaseProps
+    const sizeProps: BreadcrumbButtonBaseProps = { as: 'button', size: 'small' };
+
+    expect(anchorProps).toBeDefined();
+    expect(buttonProps).toBeDefined();
+    expect(sizeProps).toBeDefined();
   });
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -69,25 +69,16 @@ describe('BreadcrumbButton', () => {
     `);
   });
 
-  // Regression test for https://github.com/microsoft/fluentui/issues/36645: a plain `Omit`
-  // collapsed the distributive ARIA button union, so the anchor arm's `href` was not assignable.
-  // Type-check runs against tests, so this covers the base hook and the types together.
   it('accepts the anchor arm of the ARIA button union in the base hook', () => {
     const { result } = renderHook(() =>
       useBreadcrumbButtonBase_unstable({ as: 'a', href: '/somewhere' }, React.createRef<HTMLAnchorElement>()),
     );
 
-    // `components.root` stays 'button' (the slot's declared default); the anchor arm resolves
-    // through the slot props, where useARIAButtonProps carries `as: 'a'` to the render layer.
     expect(result.current).toMatchObject({
       root: { as: 'a', href: '/somewhere' },
     });
   });
 
-  // Regression test for the controlType operator-precedence bug: `as ?? href ? 'a' : 'button'`
-  // parses as `(as ?? href) ? 'a' : 'button'`, so an explicit `as: 'button'` (truthy) computed
-  // controlType 'a' and the ARIA button pipeline emitted the anchor arm (`as: 'a'`, role="button")
-  // for a caller who asked for a real <button>.
   it('keeps an explicit as="button" on the button arm of the base hook', () => {
     const { result } = renderHook(() =>
       useBreadcrumbButtonBase_unstable({ as: 'button' }, React.createRef<HTMLButtonElement>()),

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -83,4 +83,17 @@ describe('BreadcrumbButton', () => {
       root: { as: 'a', href: '/somewhere' },
     });
   });
+
+  // Regression test for the controlType operator-precedence bug: `as ?? href ? 'a' : 'button'`
+  // parses as `(as ?? href) ? 'a' : 'button'`, so an explicit `as: 'button'` (truthy) computed
+  // controlType 'a' and the ARIA button pipeline emitted the anchor arm (`as: 'a'`, role="button")
+  // for a caller who asked for a real <button>.
+  it('keeps an explicit as="button" on the button arm of the base hook', () => {
+    const { result } = renderHook(() =>
+      useBreadcrumbButtonBase_unstable({ as: 'button' }, React.createRef<HTMLButtonElement>()),
+    );
+
+    expect(result.current.root.as).toBe('button');
+    expect(result.current.root.role).toBeUndefined();
+  });
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import { BreadcrumbButton } from './BreadcrumbButton';
-import type { BreadcrumbButtonBaseProps, BreadcrumbButtonProps } from './BreadcrumbButton.types';
+import { useBreadcrumbButtonBase_unstable } from './useBreadcrumbButton';
+import type { BreadcrumbButtonProps } from './BreadcrumbButton.types';
 import { isConformant } from '../../testing/isConformant';
 import { breadcrumbButtonClassNames } from './useBreadcrumbButtonStyles.styles';
 import { ArrowRight16Filled } from '@fluentui/react-icons';
@@ -68,19 +69,18 @@ describe('BreadcrumbButton', () => {
     `);
   });
 
-  // Type-level regression test for https://github.com/microsoft/fluentui/issues/36645.
-  // `BreadcrumbButtonBaseProps` used a plain `Omit`, which collapsed the distributive ARIA button
-  // union and dropped the anchor arm's `href`. These assignments are validated by the package's
-  // type-check target.
-  it('keeps both arms of the ARIA button union assignable to BreadcrumbButtonBaseProps', () => {
-    const anchorProps: BreadcrumbButtonBaseProps = { as: 'a', href: '/somewhere' };
-    const buttonProps: BreadcrumbButtonBaseProps = { as: 'button' };
+  // Regression test for https://github.com/microsoft/fluentui/issues/36645: a plain `Omit`
+  // collapsed the distributive ARIA button union, so the anchor arm's `href` was not assignable.
+  // Type-check runs against tests, so this covers the base hook and the types together.
+  it('accepts the anchor arm of the ARIA button union in the base hook', () => {
+    const { result } = renderHook(() =>
+      useBreadcrumbButtonBase_unstable({ as: 'a', href: '/somewhere' }, React.createRef<HTMLAnchorElement>()),
+    );
 
-    // @ts-expect-error - `size` is omitted from BreadcrumbButtonBaseProps
-    const sizeProps: BreadcrumbButtonBaseProps = { as: 'button', size: 'small' };
-
-    expect(anchorProps).toBeDefined();
-    expect(buttonProps).toBeDefined();
-    expect(sizeProps).toBeDefined();
+    // `components.root` stays 'button' (the slot's declared default); the anchor arm resolves
+    // through the slot props, where useARIAButtonProps carries `as: 'a'` to the render layer.
+    expect(result.current).toMatchObject({
+      root: { as: 'a', href: '/somewhere' },
+    });
   });
 });

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.types.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/BreadcrumbButton.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentState } from '@fluentui/react-utilities';
+import type { ComponentProps, ComponentState, DistributiveOmit } from '@fluentui/react-utilities';
 import type { ButtonProps, ButtonSlots, ButtonState } from '@fluentui/react-button';
 import type { BreadcrumbProps } from '../Breadcrumb/Breadcrumb.types';
 
@@ -25,6 +25,6 @@ export type BreadcrumbButtonState = ComponentState<BreadcrumbButtonSlots> &
   Omit<ButtonState, keyof ButtonSlots | 'components'> &
   Required<Pick<BreadcrumbButtonProps, 'current' | 'size'>>;
 
-export type BreadcrumbButtonBaseProps = Omit<BreadcrumbButtonProps, 'size'>;
+export type BreadcrumbButtonBaseProps = DistributiveOmit<BreadcrumbButtonProps, 'size'>;
 
 export type BreadcrumbButtonBaseState = Omit<BreadcrumbButtonState, 'appearance' | 'size' | 'shape'>;

--- a/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButton.ts
+++ b/packages/react-components/react-breadcrumb/library/src/components/BreadcrumbButton/useBreadcrumbButton.ts
@@ -49,7 +49,7 @@ export const useBreadcrumbButtonBase_unstable = (
 ): BreadcrumbButtonBaseState => {
   const { current = false, as, ...rest } = props;
 
-  const controlType = as ?? (props as ARIAButtonProps<'a'>).href ? 'a' : 'button';
+  const controlType = as ?? ((props as ARIAButtonProps<'a'>).href ? 'a' : 'button');
 
   const buttonState = useButtonBase_unstable(
     {


### PR DESCRIPTION
`BreadcrumbButtonBaseProps` is declared as a plain `Omit<BreadcrumbButtonProps, 'size'>`. `BreadcrumbButtonProps` includes `ComponentProps<ButtonSlots>`, whose root is `ARIAButtonSlotProps` — a distributive union over `as: 'button' | 'a'`. A plain `Omit` collapses that union into a single object type keyed on the intersection of its members, so the anchor arm's `href` disappears and the anchor spelling of `BreadcrumbButton` (the one the component's own Default story uses) no longer type-checks against the base props type.

The fix switches to `DistributiveOmit`, matching what `@fluentui/react-button` already does for the same reason. Type-level only — no runtime change — and the widened type is strictly a superset of the current one, so no existing consumer code stops compiling. The `etc/react-breadcrumb.api.md` report is regenerated to match.

Fixes #36645.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.


---

Also fixes #36681: while adding the requested base-hook test, we found that `controlType`'s `as ?? href ? 'a' : 'button'` parses as `(as ?? href) ? 'a' : 'button'`, so an explicit `as: 'button'` (truthy) computed `'a'` and the ARIA button pipeline emitted the anchor arm (`<a role="button">`). Parenthesized so an explicit `as` short-circuits the `href` inference, with a red/green renderHook regression test alongside the existing anchor-arm test.
