### PR TITLE
fix(react-color-picker): use nullish fallback in adjustChannel so zero channel values resolve

### DIFF
--- a/change/@fluentui-react-color-picker-23cd9249-19ec-4f83-b918-1fbfa29c5119.json
+++ b/change/@fluentui-react-color-picker-23cd9249-19ec-4f83-b918-1fbfa29c5119.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use nullish fallback in adjustChannel so a channel whose value is 0 resolves to its own action instead of hue's",
+  "packageName": "@fluentui/react-color-picker",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-color-picker/library/src/utils/adjustChannel.test.ts
+++ b/packages/react-components/react-color-picker/library/src/utils/adjustChannel.test.ts
@@ -38,4 +38,18 @@ describe('adjustChannel', () => {
     expect(adjustChannel('saturation', actions)).toBe('saturationAction');
     expect(adjustChannel('value', actions)).toBe('valueAction');
   });
+
+  // Regression test for https://github.com/microsoft/fluentui/issues/36646 — the previous `||`
+  // fallback treated falsy channel values (e.g. 0) as missing and returned the hue action instead.
+  it('should return falsy channel values instead of falling back to the hue action', () => {
+    const numericActions: ChannelActions<number> = {
+      hue: 120,
+      saturation: 0,
+      value: 0,
+    };
+
+    expect(adjustChannel('saturation', numericActions)).toBe(0);
+    expect(adjustChannel('value', numericActions)).toBe(0);
+    expect(adjustChannel('hue', numericActions)).toBe(120);
+  });
 });

--- a/packages/react-components/react-color-picker/library/src/utils/adjustChannel.ts
+++ b/packages/react-components/react-color-picker/library/src/utils/adjustChannel.ts
@@ -29,5 +29,5 @@ export type ChannelActions<T> = {
  * @returns {T} - The result of the action corresponding to the specified channel, or the hue action if the channel is not found.
  */
 export function adjustChannel<T>(channel: ColorChannel, actions: ChannelActions<T>): T {
-  return actions[channel] || actions.hue;
+  return actions[channel] ?? actions.hue;
 }


### PR DESCRIPTION
`adjustChannel.ts` selects the per-channel action with `actions[channel] || actions.hue`. The `||` arm was presumably meant as a default for an unknown channel, but in the code path that reaches it the expression evaluates on the channel's *value* — so a channel whose value is `0` (zero saturation, zero alpha, …) takes the falsy branch and is handled by the **hue** action instead of its own. The visible symptom is the slider for that channel rendering with hue's domain: `<input value="210" max="100">`, with the thumb painted off the end of the track.

The fix is `actions[channel] ?? actions.hue`, so the fallback fires only when the channel key is genuinely absent. No API or type change.

Fixes #36646.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.
