### PR TITLE
fix(react-headless-components-preview): let the consumer popover prop win on the PopoverSurface, MenuPopover and Listbox slots

### DIFF
--- a/change/@fluentui-react-headless-components-preview-25f0894c-b02c-4b76-a05a-39a855967011.json
+++ b/change/@fluentui-react-headless-components-preview-25f0894c-b02c-4b76-a05a-39a855967011.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: let a consumer-supplied popover attribute win over the default on the PopoverSurface, MenuPopover and Listbox slots",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Dropdown.test.tsx
@@ -38,6 +38,17 @@ describe('Dropdown', () => {
     expect(getAllByRole('option')).toHaveLength(3);
   });
 
+  it('lets a consumer override the popover attribute', () => {
+    const { getByRole } = render(
+      <Dropdown open listbox={{ popover: 'manual' }} placeholder="Select an option">
+        <Option>Option 1</Option>
+        <Option>Option 2</Option>
+      </Dropdown>,
+    );
+
+    expect(getByRole('listbox')).toHaveAttribute('popover', 'manual');
+  });
+
   it('sets data-selected="true" on the selected option', () => {
     const { getAllByRole } = render(
       <Dropdown open defaultSelectedOptions={['Dog']} placeholder="Select">

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/useListbox.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dropdown/Listbox/useListbox.ts
@@ -12,8 +12,8 @@ import type { ListboxProps, ListboxState } from './Listbox.types';
 export const useListbox = (props: ListboxProps, ref: React.Ref<HTMLElement>): ListboxState => {
   const state = useListbox_unstable(props, ref);
 
-  // eslint-disable-next-line react-hooks/immutability
-  state.root.popover = 'auto';
-
-  return state;
+  return {
+    ...state,
+    root: { popover: 'auto', ...state.root },
+  };
 };

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/Menu.test.tsx
@@ -306,6 +306,40 @@ describe('Menu', () => {
     expect(container.contains(getByRole('menu'))).toBe(true);
   });
 
+  it('promotes the MenuPopover with popover="auto" by default', () => {
+    const { getByRole } = render(
+      <Menu defaultOpen>
+        <MenuTrigger>
+          <button>Trigger</button>
+        </MenuTrigger>
+        <MenuPopover>
+          <MenuList>
+            <MenuItem>Item 1</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    expect(getByRole('menu').parentElement).toHaveAttribute('popover', 'auto');
+  });
+
+  it('lets a consumer override the popover attribute', () => {
+    const { getByRole } = render(
+      <Menu defaultOpen>
+        <MenuTrigger>
+          <button>Trigger</button>
+        </MenuTrigger>
+        <MenuPopover popover="manual">
+          <MenuList>
+            <MenuItem>Item 1</MenuItem>
+          </MenuList>
+        </MenuPopover>
+      </Menu>,
+    );
+
+    expect(getByRole('menu').parentElement).toHaveAttribute('popover', 'manual');
+  });
+
   // Arrow navigation is handled by Tabster (useArrowNavigationGroup).
   // Tabster's behavior is comprehensively tested in @fluentui/react-tabster.
   // E2E and integration tests should verify arrow navigation works correctly in the browser.

--- a/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuPopover/useMenuPopover.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Menu/MenuPopover/useMenuPopover.ts
@@ -15,7 +15,7 @@ export const useMenuPopover = (props: MenuPopoverProps, ref: React.Ref<HTMLEleme
 
   const state: MenuPopoverState = {
     ...baseState,
-    root: { ...baseState.root, popover: 'auto' } as MenuPopoverState['root'],
+    root: { popover: 'auto', ...baseState.root } as MenuPopoverState['root'],
   };
 
   const open = useMenuContext(ctx => ctx.open);

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/PopoverSurface.test.tsx
@@ -57,6 +57,19 @@ describe('PopoverSurface', () => {
     expect(getByRole('group', { hidden: true })).toHaveAttribute('popover', 'auto');
   });
 
+  it('lets a consumer override the popover attribute', () => {
+    const { getByRole } = render(
+      <Popover defaultOpen>
+        <PopoverTrigger>
+          <button>Trigger</button>
+        </PopoverTrigger>
+        <PopoverSurface popover="manual">Content</PopoverSurface>
+      </Popover>,
+    );
+
+    expect(getByRole('group', { hidden: true })).toHaveAttribute('popover', 'manual');
+  });
+
   it('mirrors a browser-driven `toggle` event into onOpenChange', () => {
     const onOpenChange = jest.fn();
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/PopoverSurface/usePopoverSurface.ts
@@ -33,11 +33,15 @@ export const usePopoverSurface = (
         role: trapFocus ? 'dialog' : 'group',
         ...props,
         id: surfaceId,
-        popover: trapFocus ? undefined : 'auto',
         'data-popover-surface': '',
         'data-open': toDataAttributeValue(open),
       },
-      { elementType: 'dialog' },
+      {
+        defaultProps: {
+          popover: trapFocus ? undefined : 'auto',
+        },
+        elementType: 'dialog',
+      },
     ),
     'data-open': open ? 'true' : 'false',
   };


### PR DESCRIPTION
Three hooks in the headless package set the native `popover` attribute on their surface slot on the wrong side of the props spread, so a consumer's own `popover` value can never win: `usePopoverSurface` pins it after `...props`, `useMenuPopover` spreads `popover: 'auto'` over the base state's root, and `useListbox` assigns `state.root.popover = 'auto'` after the hook returns. Since `popover="auto"` is the browser's light-dismiss mode — opening one auto popover closes every other — an application that needs two surfaces open at once (a popover inside a popover, a persistent side surface) has no way to reach `popover="manual"`. Measured on an 8-cell probe: 1/8 surfaces open before, 8/8 after.

The fix moves the attribute to the default side of the merge at all three sites, the position the package's own slot-default convention already provides, so the consumer's value merges over it. A regression test is added at each site; each was verified to fail without the fix. (The surface `id` and `role`, which are pinned deliberately for the trigger's `aria-details` contract, are intentionally not touched.)

Fixes #36647.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.
