### PR TITLE
fix(react-headless-components-preview): reserve the scrollbar gutter while a dialog locks scroll

### DIFF
--- a/change/@fluentui-react-headless-components-preview-4e33a94a-d467-47f7-87d9-2714995d6202.json
+++ b/change/@fluentui-react-headless-components-preview-4e33a94a-d467-47f7-87d9-2714995d6202.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: reserve the scrollbar gutter while a modal dialog locks document scroll, so opening a dialog no longer shifts the page",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
@@ -106,6 +106,92 @@ describe('Dialog', () => {
     expect(dialog).not.toHaveAttribute('aria-labelledby');
   });
 
+  describe('scroll lock', () => {
+    // jsdom reports clientWidth 0, which would read as a scrollbar on every page.
+    const setScrollbarWidth = (width: number) =>
+      Object.defineProperty(document.documentElement, 'clientWidth', {
+        configurable: true,
+        value: window.innerWidth - width,
+      });
+
+    afterEach(() => {
+      delete (document.documentElement as Partial<HTMLElement>).clientWidth;
+      document.documentElement.style.removeProperty('scrollbar-gutter');
+      document.body.style.removeProperty('overflow');
+    });
+
+    const renderModal = () =>
+      render(
+        <Dialog unmountOnClose={false}>
+          <DialogTrigger>
+            <button>Open dialog</button>
+          </DialogTrigger>
+          <DialogSurface>
+            <DialogTitle>Dialog title</DialogTitle>
+            <DialogActions>
+              <DialogTrigger>
+                <button>Close dialog</button>
+              </DialogTrigger>
+            </DialogActions>
+          </DialogSurface>
+        </Dialog>,
+      );
+
+    it('reserves the scrollbar gutter while a modal holds the lock', () => {
+      setScrollbarWidth(15);
+      const result = renderModal();
+
+      fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
+
+      expect(document.body.style.overflow).toBe('visible clip');
+      // On <html>, not <body>: scrollbar-gutter does not propagate to the viewport.
+      expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+      fireEvent.click(result.getByRole('button', { name: 'Close dialog' }));
+
+      expect(document.documentElement.style.scrollbarGutter).toBe('');
+    });
+
+    it('reserves nothing when the scrollbar takes no layout width', () => {
+      setScrollbarWidth(0);
+      const result = renderModal();
+
+      fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
+
+      expect(document.body.style.overflow).toBe('visible clip');
+      expect(document.documentElement.style.scrollbarGutter).toBe('');
+    });
+
+    it('restores a gutter the host application had already set', () => {
+      setScrollbarWidth(15);
+      document.documentElement.style.scrollbarGutter = 'both-edges';
+      const result = renderModal();
+
+      fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
+
+      expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+      fireEvent.click(result.getByRole('button', { name: 'Close dialog' }));
+
+      expect(document.documentElement.style.scrollbarGutter).toBe('both-edges');
+    });
+
+    it('leaves a non-modal dialog out of the lock entirely', () => {
+      setScrollbarWidth(15);
+      const result = render(
+        <Dialog defaultOpen modalType="non-modal">
+          <DialogSurface>
+            <DialogTitle>Non-modal title</DialogTitle>
+          </DialogSurface>
+        </Dialog>,
+      );
+
+      expect(result.container.querySelector('dialog')).toHaveAttribute('data-open');
+      expect(document.body.style.overflow).toBe('');
+      expect(document.documentElement.style.scrollbarGutter).toBe('');
+    });
+  });
+
   it('keeps dialog mounted after close when unmountOnClose is false', () => {
     const result = render(
       <Dialog unmountOnClose={false}>

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
@@ -115,7 +115,7 @@ describe('Dialog', () => {
       });
 
     afterEach(() => {
-      delete (document.documentElement as Partial<HTMLElement>).clientWidth;
+      Reflect.deleteProperty(document.documentElement, 'clientWidth');
       document.documentElement.style.removeProperty('scrollbar-gutter');
       document.body.style.removeProperty('overflow');
     });
@@ -162,18 +162,41 @@ describe('Dialog', () => {
       expect(document.documentElement.style.scrollbarGutter).toBe('');
     });
 
-    it('restores a gutter the host application had already set', () => {
+    it.each(['stable', 'stable both-edges'])('preserves an inline %s gutter during and after the lock', gutter => {
       setScrollbarWidth(15);
-      document.documentElement.style.scrollbarGutter = 'both-edges';
+      document.documentElement.style.scrollbarGutter = gutter;
       const result = renderModal();
 
       fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
 
-      expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+      expect(document.documentElement.style.scrollbarGutter).toBe(gutter);
 
       fireEvent.click(result.getByRole('button', { name: 'Close dialog' }));
 
-      expect(document.documentElement.style.scrollbarGutter).toBe('both-edges');
+      expect(document.documentElement.style.scrollbarGutter).toBe(gutter);
+    });
+
+    it('preserves a stable both-edges gutter supplied by a stylesheet', () => {
+      setScrollbarWidth(15);
+      const stylesheet = document.createElement('style');
+      stylesheet.textContent = 'html { scrollbar-gutter: stable both-edges; }';
+      document.head.appendChild(stylesheet);
+      try {
+        const result = renderModal();
+        expect(window.getComputedStyle(document.documentElement).scrollbarGutter).toBe('stable both-edges');
+
+        fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
+
+        expect(document.documentElement.style.scrollbarGutter).toBe('');
+        expect(window.getComputedStyle(document.documentElement).scrollbarGutter).toBe('stable both-edges');
+
+        fireEvent.click(result.getByRole('button', { name: 'Close dialog' }));
+
+        expect(document.documentElement.style.scrollbarGutter).toBe('');
+        expect(window.getComputedStyle(document.documentElement).scrollbarGutter).toBe('stable both-edges');
+      } finally {
+        stylesheet.remove();
+      }
     });
 
     it('leaves a non-modal dialog out of the lock entirely', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/Dialog.test.tsx
@@ -162,6 +162,20 @@ describe('Dialog', () => {
       expect(document.documentElement.style.scrollbarGutter).toBe('');
     });
 
+    it('restores an inline auto gutter after the lock replaces it', () => {
+      setScrollbarWidth(15);
+      document.documentElement.style.scrollbarGutter = 'auto';
+      const result = renderModal();
+
+      fireEvent.click(result.getByRole('button', { name: 'Open dialog' }));
+
+      expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+      fireEvent.click(result.getByRole('button', { name: 'Close dialog' }));
+
+      expect(document.documentElement.style.scrollbarGutter).toBe('auto');
+    });
+
     it.each(['stable', 'stable both-edges'])('preserves an inline %s gutter during and after the lock', gutter => {
       setScrollbarWidth(15);
       document.documentElement.style.scrollbarGutter = gutter;

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
@@ -1,14 +1,20 @@
 type ScrollLockState = {
   lockCount: number;
   previousBodyOverflow: string;
+  previousScrollbarGutter: string;
 };
 
 const scrollLockStateByDocument = new WeakMap<Document, ScrollLockState>();
 
 /**
  * Prevents background scrolling while a modal/alert dialog is open by applying
- * `overflow: hidden` to `<body>`. The `<html>` element is intentionally left
- * untouched so host-application styles on the document element are preserved.
+ * `overflow: hidden` to `<body>`, and reserves the space the page scrollbar was
+ * occupying so nothing on the page moves sideways as it disappears.
+ *
+ * The gutter has to be reserved on `<html>`: `scrollbar-gutter` does not propagate
+ * from `<body>` to the viewport the way `overflow` does, so spelling it on `<body>`
+ * reserves nothing. It is written only when the scrollbar actually takes layout
+ * width, because `stable` otherwise reserves a gutter the page never had.
  *
  * Nested modal dialogs share a single lock via a reference count.
  */
@@ -19,18 +25,27 @@ export function lockDocumentScroll(targetDocument: Document): void {
     return;
   }
 
+  const { body, documentElement } = targetDocument;
+  // Read the scrollbar's layout width before the lock takes it away. Overlay
+  // scrollbars and unscrollable pages both measure 0, and both want no gutter.
+  const scrollbarWidth = (targetDocument.defaultView?.innerWidth ?? 0) - documentElement.clientWidth;
+
   scrollLockStateByDocument.set(targetDocument, {
     lockCount: 1,
-    previousBodyOverflow: targetDocument.body.style.overflow,
+    previousBodyOverflow: body.style.overflow,
+    previousScrollbarGutter: documentElement.style.scrollbarGutter,
   });
 
-  targetDocument.body.style.overflow = 'visible clip';
+  body.style.overflow = 'visible clip';
+  if (scrollbarWidth > 0) {
+    documentElement.style.scrollbarGutter = 'stable';
+  }
 }
 
 /**
- * Restores the document's scroll behavior by reverting the `overflow` style
- * on the `<body>` element to its previous value. This function is typically
- * called when a modal/alert dialog is closed.
+ * Restores the document's scroll behavior by reverting the `overflow` style on the
+ * `<body>` element and the reserved scrollbar gutter on `<html>` to their previous
+ * values. This function is typically called when a modal/alert dialog is closed.
  */
 export function unlockDocumentScroll(targetDocument: Document): void {
   const state = scrollLockStateByDocument.get(targetDocument);
@@ -44,5 +59,6 @@ export function unlockDocumentScroll(targetDocument: Document): void {
   }
 
   targetDocument.body.style.overflow = state.previousBodyOverflow;
+  targetDocument.documentElement.style.scrollbarGutter = state.previousScrollbarGutter;
   scrollLockStateByDocument.delete(targetDocument);
 }

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
@@ -8,7 +8,7 @@ const scrollLockStateByDocument = new WeakMap<Document, ScrollLockState>();
 
 /**
  * Prevents background scrolling while a modal/alert dialog is open by applying
- * `overflow: hidden` to `<body>`, and reserves the space the page scrollbar was
+ * `overflow: visible clip` to `<body>`, and reserves the space the page scrollbar was
  * occupying so nothing on the page moves sideways as it disappears.
  *
  * The gutter has to be reserved on `<html>`: `scrollbar-gutter` does not propagate

--- a/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Dialog/utils/scroll.ts
@@ -29,6 +29,8 @@ export function lockDocumentScroll(targetDocument: Document): void {
   // Read the scrollbar's layout width before the lock takes it away. Overlay
   // scrollbars and unscrollable pages both measure 0, and both want no gutter.
   const scrollbarWidth = (targetDocument.defaultView?.innerWidth ?? 0) - documentElement.clientWidth;
+  const scrollbarGutter = targetDocument.defaultView?.getComputedStyle(documentElement).scrollbarGutter;
+  const hasStableGutter = scrollbarGutter?.split(/\s+/).includes('stable');
 
   scrollLockStateByDocument.set(targetDocument, {
     lockCount: 1,
@@ -37,7 +39,7 @@ export function lockDocumentScroll(targetDocument: Document): void {
   });
 
   body.style.overflow = 'visible clip';
-  if (scrollbarWidth > 0) {
+  if (scrollbarWidth > 0 && !hasStableGutter) {
     documentElement.style.scrollbarGutter = 'stable';
   }
 }


### PR DESCRIPTION
The headless Dialog's `lockDocumentScroll` clips `body` overflow and reserves nothing in the scrollbar's place, so on a page that scrolls, opening a modal dialog removes the scrollbar's layout width and every fixed and centred element shifts sideways for as long as the dialog is open (measured at a 7.5px jump with classic scrollbars; the Griffel Dialog on the same page does not move).

The fix reserves the gutter while the lock is held, with three details that were measured rather than assumed: the `scrollbar-gutter` write must go on `documentElement` (overflow propagates from body to the viewport, `scrollbar-gutter` does not); it must be guarded on the scrollbar actually taking layout width, read before the lock removes it, so pages that never scroll — and overlay-scrollbar environments — do not get the mirror-image shift; and unlock restores the previous inline gutter alongside the previous overflow. Non-modal dialogs never take the lock and are unaffected. Regression tests cover classic and no-layout-width scrollbars, existing inline and stylesheet-provided gutters, restoration of an inline auto value, and non-modal dialogs. All 19 Dialog tests pass. The auto -> stable -> auto regression is verified to fail if the gutter-restoration assignment is removed.

Note for verification: Puppeteer passes `--hide-scrollbars` by default, under which this defect cannot reproduce at all — measurements were taken with `ignoreDefaultArgs: ['--hide-scrollbars']`.

Fixes #36648.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.

