### PR TITLE
fix(react-tag-picker): tie aside-width frame cancellation to observer detach

### DIFF
--- a/change/@fluentui-react-tag-picker-36405b70-c741-4f6f-8aea-08d335f732a5.json
+++ b/change/@fluentui-react-tag-picker-36405b70-c741-4f6f-8aea-08d335f732a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cancel the aside-width animation frame from the observer ref's detach path instead of a passive-effect cleanup, so the frame's lifecycle is tied to the observation it belongs to",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-3be02325-3ba0-4940-ae75-1087abd1f291.json
+++ b/change/@fluentui-react-tag-picker-3be02325-3ba0-4940-ae75-1087abd1f291.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: cancel the aside-width animation frame in the effect cleanup instead of the effect body, so the width token is written deterministically",
+  "packageName": "@fluentui/react-tag-picker",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@fluentui-react-tag-picker-3be02325-3ba0-4940-ae75-1087abd1f291.json
+++ b/change/@fluentui-react-tag-picker-3be02325-3ba0-4940-ae75-1087abd1f291.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: cancel the aside-width animation frame in the effect cleanup instead of the effect body, so the width token is written deterministically",
-  "packageName": "@fluentui/react-tag-picker",
-  "email": "array.knight@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-components/react-tag-picker/library/rit.config.cjs
+++ b/packages/react-components/react-tag-picker/library/rit.config.cjs
@@ -1,0 +1,17 @@
+// @ts-check
+
+/** @type {import('@fluentui/react-integration-tester').Config} */
+const config = {
+  react: {
+    18: {
+      runConfig: {
+        test: {
+          // Include the StrictMode regression in the React 18 integration suite.
+          configPath: 'jest.config.cjs',
+        },
+      },
+    },
+  },
+};
+
+module.exports = config;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
@@ -19,13 +19,14 @@ describe('TagPickerControl', () => {
 
   describe('the aside width custom property', () => {
     // useTagPickerControl schedules the write of --fui-TagPickerControl-aside-width from the
-    // ResizeObserver callback, and cancels that frame from an effect. The observer is attached by
-    // a ref callback, so `observe()` runs in the COMMIT phase -- before React flushes the passive
-    // effect. A ResizeObserver whose `observe()` invokes its callback synchronously therefore
-    // reproduces, deterministically, the ordering that the production race lands on 8-11 times out
-    // of 12: a frame is already pending by the time the effect runs. If the cancel sits in the
-    // effect BODY it kills that frame and the property is never written; in the effect's CLEANUP
-    // it only runs on unmount, which is what these two tests pin.
+    // ResizeObserver callback, and cancels that frame when the observer's callback ref
+    // receives null (element unmount), alongside ResizeObserver.disconnect() -- not from a
+    // passive effect's cleanup. That keeps the frame's lifecycle tied to the same event that
+    // owns it (the ref attach/detach that starts and stops the observation) instead of an
+    // effect whose cleanup timing is independent of it. A ResizeObserver whose `observe()`
+    // invokes its callback synchronously reproduces, deterministically, a frame already being
+    // in flight by the time the ref detaches -- without depending on real async timing, which
+    // jsdom cannot reproduce.
     const realRaf = window.requestAnimationFrame;
     const realCaf = window.cancelAnimationFrame;
     const realResizeObserver = window.ResizeObserver;
@@ -92,6 +93,31 @@ describe('TagPickerControl', () => {
 
       expect(cancelledBeforeUnmount).not.toContain(frames[0].id);
       expect(cancelledIds).toContain(frames[0].id);
+    });
+
+    it('writes the property after mount inside React.StrictMode', () => {
+      // Regression test for https://github.com/microsoft/fluentui/pull/36667#discussion_r3925809333:
+      // StrictMode mounts, simulates an unmount/remount of the render output (detaching and
+      // reattaching refs, and replaying effects), then settles. Cancelling the pending frame
+      // from a passive effect's cleanup -- rather than from the observer ref's own detach path
+      // -- risked cancelling the frame during that replay with nothing left to reschedule it,
+      // since callback refs are not necessarily re-invoked the same way effects are replayed.
+      // Asserting the property IS set after the dust settles pins the fix: the frame's
+      // cancellation now lives on the same ref-detach path as ResizeObserver.disconnect(), so
+      // it only ever cancels a frame that its own detach actually orphaned, and any reattach
+      // schedules its own fresh frame that survives.
+      const result = render(
+        <React.StrictMode>
+          <TagPickerControl>Default PickerControl</TagPickerControl>
+        </React.StrictMode>,
+      );
+
+      act(() => {
+        frames.forEach(frame => frame.callback(0));
+      });
+
+      const control = result.container.querySelector('.fui-TagPickerControl') as HTMLElement;
+      expect(control.style.getPropertyValue('--fui-TagPickerControl-aside-width')).toBe(`${ASIDE_WIDTH}px`);
     });
   });
 });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { isConformant } from '../../testing/isConformant';
 import { TagPickerControl } from './TagPickerControl';
 
@@ -15,5 +15,83 @@ describe('TagPickerControl', () => {
   it('renders a default state', () => {
     const result = render(<TagPickerControl>Default PickerControl</TagPickerControl>);
     expect(result.container).toMatchSnapshot();
+  });
+
+  describe('the aside width custom property', () => {
+    // useTagPickerControl schedules the write of --fui-TagPickerControl-aside-width from the
+    // ResizeObserver callback, and cancels that frame from an effect. The observer is attached by
+    // a ref callback, so `observe()` runs in the COMMIT phase -- before React flushes the passive
+    // effect. A ResizeObserver whose `observe()` invokes its callback synchronously therefore
+    // reproduces, deterministically, the ordering that the production race lands on 8-11 times out
+    // of 12: a frame is already pending by the time the effect runs. If the cancel sits in the
+    // effect BODY it kills that frame and the property is never written; in the effect's CLEANUP
+    // it only runs on unmount, which is what these two tests pin.
+    const realRaf = window.requestAnimationFrame;
+    const realCaf = window.cancelAnimationFrame;
+    const realResizeObserver = window.ResizeObserver;
+
+    const ASIDE_WIDTH = 18;
+    let frames: { id: number; callback: FrameRequestCallback }[] = [];
+    let cancelledIds: number[] = [];
+
+    beforeEach(() => {
+      frames = [];
+      cancelledIds = [];
+      let nextId = 1;
+      window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+        const id = nextId++;
+        frames.push({ id, callback });
+        return id;
+      };
+      window.cancelAnimationFrame = (id: number) => {
+        cancelledIds.push(id);
+      };
+      window.ResizeObserver = class implements ResizeObserver {
+        constructor(private callback: ResizeObserverCallback) {}
+        public observe(element: Element) {
+          this.callback([{ target: element, contentRect: { width: ASIDE_WIDTH } }] as never, this);
+        }
+        public unobserve() {
+          /* no-op */
+        }
+        public disconnect() {
+          /* no-op */
+        }
+      };
+    });
+
+    afterEach(() => {
+      window.requestAnimationFrame = realRaf;
+      window.cancelAnimationFrame = realCaf;
+      window.ResizeObserver = realResizeObserver;
+    });
+
+    it('does not cancel the pending frame on mount, so the property is written', () => {
+      const result = render(<TagPickerControl>Default PickerControl</TagPickerControl>);
+
+      expect(frames).toHaveLength(1);
+      expect(cancelledIds).not.toContain(frames[0].id);
+
+      act(() => {
+        frames[0].callback(0);
+      });
+
+      const control = result.container.querySelector('.fui-TagPickerControl') as HTMLElement;
+      expect(control.style.getPropertyValue('--fui-TagPickerControl-aside-width')).toBe(`${ASIDE_WIDTH}px`);
+    });
+
+    it('cancels a still-pending frame on unmount', () => {
+      const result = render(<TagPickerControl>Default PickerControl</TagPickerControl>);
+
+      expect(frames).toHaveLength(1);
+
+      // Snapshot before unmounting: a cancel that already happened on mount would make the
+      // assertion below pass vacuously, which is exactly what the defective form did.
+      const cancelledBeforeUnmount = [...cancelledIds];
+      result.unmount();
+
+      expect(cancelledBeforeUnmount).not.toContain(frames[0].id);
+      expect(cancelledIds).toContain(frames[0].id);
+    });
   });
 });

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/TagPickerControl.test.tsx
@@ -35,10 +35,21 @@ describe('TagPickerControl', () => {
     let frames: { id: number; callback: FrameRequestCallback }[] = [];
     let cancelledIds: number[] = [];
 
+    function flushFrames() {
+      const queuedFrames = frames;
+      frames = [];
+      for (const { id, callback } of queuedFrames) {
+        if (!cancelledIds.includes(id)) {
+          callback(0);
+        }
+      }
+    }
+
     beforeEach(() => {
       frames = [];
       cancelledIds = [];
-      let nextId = 1;
+      // Zero is a valid animation-frame handle, not the absence of a pending frame.
+      let nextId = 0;
       window.requestAnimationFrame = (callback: FrameRequestCallback) => {
         const id = nextId++;
         frames.push({ id, callback });
@@ -73,9 +84,7 @@ describe('TagPickerControl', () => {
       expect(frames).toHaveLength(1);
       expect(cancelledIds).not.toContain(frames[0].id);
 
-      act(() => {
-        frames[0].callback(0);
-      });
+      act(flushFrames);
 
       const control = result.container.querySelector('.fui-TagPickerControl') as HTMLElement;
       expect(control.style.getPropertyValue('--fui-TagPickerControl-aside-width')).toBe(`${ASIDE_WIDTH}px`);
@@ -97,24 +106,17 @@ describe('TagPickerControl', () => {
 
     it('writes the property after mount inside React.StrictMode', () => {
       // Regression test for https://github.com/microsoft/fluentui/pull/36667#discussion_r3925809333:
-      // StrictMode mounts, simulates an unmount/remount of the render output (detaching and
-      // reattaching refs, and replaying effects), then settles. Cancelling the pending frame
-      // from a passive effect's cleanup -- rather than from the observer ref's own detach path
-      // -- risked cancelling the frame during that replay with nothing left to reschedule it,
-      // since callback refs are not necessarily re-invoked the same way effects are replayed.
-      // Asserting the property IS set after the dust settles pins the fix: the frame's
-      // cancellation now lives on the same ref-detach path as ResizeObserver.disconnect(), so
-      // it only ever cancels a frame that its own detach actually orphaned, and any reattach
-      // schedules its own fresh frame that survives.
+      // React 18 replays effects without replaying callback refs. Effect cleanup would cancel
+      // the initial frame with no ref reattachment to schedule a replacement. React 19 also
+      // replays refs, so run this with the React 18 integration target as well as the default
+      // tests. Only uncancelled frames may run: executing cancelled callbacks hides the bug.
       const result = render(
         <React.StrictMode>
           <TagPickerControl>Default PickerControl</TagPickerControl>
         </React.StrictMode>,
       );
 
-      act(() => {
-        frames.forEach(frame => frame.callback(0));
-      });
+      act(flushFrames);
 
       const control = result.container.querySelector('.fui-TagPickerControl') as HTMLElement;
       expect(control.style.getPropertyValue('--fui-TagPickerControl-aside-width')).toBe(`${ASIDE_WIDTH}px`);

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -142,9 +142,11 @@ export const useTagPickerControlBase_unstable = (
   }
 
   React.useEffect(() => {
-    if (rafIdRef.current && targetDocument?.defaultView) {
-      targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
-    }
+    return () => {
+      if (rafIdRef.current && targetDocument?.defaultView) {
+        targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
+      }
+    };
   }, [targetDocument]);
 
   return state;

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -71,15 +71,23 @@ export const useTagPickerControlBase_unstable = (
     expandIcon.ref = expandIconMergeRef;
   }
 
+  const handleAsideDetach = useEventCallback(() => {
+    if (rafIdRef.current && targetDocument?.defaultView) {
+      targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
+    }
+    rafIdRef.current = null;
+  });
+
   const observerRef = useResizeObserverRef<HTMLSpanElement>(([entry]) => {
     const targetWindow = targetDocument?.defaultView;
 
     if (targetWindow) {
       rafIdRef.current = targetWindow.requestAnimationFrame(() => {
         innerRef.current?.style.setProperty(tagPickerControlAsideWidthToken, `${entry.contentRect.width}px`);
+        rafIdRef.current = null;
       });
     }
-  });
+  }, handleAsideDetach);
   const aside = slot.optional<ExtractSlotProps<Slot<'span'>>>(undefined, {
     elementType: 'span',
     renderByDefault: Boolean(secondaryAction || expandIcon),
@@ -140,14 +148,6 @@ export const useTagPickerControlBase_unstable = (
   if (state.expandIcon) {
     state.expandIcon.ref = expandIconLabelMergeRef;
   }
-
-  React.useEffect(() => {
-    return () => {
-      if (rafIdRef.current && targetDocument?.defaultView) {
-        targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
-      }
-    };
-  }, [targetDocument]);
 
   return state;
 };

--- a/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
+++ b/packages/react-components/react-tag-picker/library/src/components/TagPickerControl/useTagPickerControl.tsx
@@ -72,7 +72,7 @@ export const useTagPickerControlBase_unstable = (
   }
 
   const handleAsideDetach = useEventCallback(() => {
-    if (rafIdRef.current && targetDocument?.defaultView) {
+    if (rafIdRef.current !== null && targetDocument?.defaultView) {
       targetDocument.defaultView.cancelAnimationFrame(rafIdRef.current);
     }
     rafIdRef.current = null;

--- a/packages/react-components/react-tag-picker/library/src/utils/useResizeObserverRef.ts
+++ b/packages/react-components/react-tag-picker/library/src/utils/useResizeObserverRef.ts
@@ -3,7 +3,19 @@
 import * as React from 'react';
 import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 
-export const useResizeObserverRef = <E extends HTMLElement>(callback: ResizeObserverCallback): React.Ref<E> => {
+/**
+ * @param callback - invoked by the ResizeObserver with the observed entries.
+ * @param onDetach - invoked when the ref is detached (element unmounts or is swapped for
+ * null), immediately before `disconnect()`. Use it to tear down anything the observer
+ * callback scheduled (e.g. a pending `requestAnimationFrame`) so it shares the observer's
+ * own attach/detach lifecycle instead of an unrelated effect's. Must be a stable reference
+ * (e.g. via `useEventCallback`) -- it participates in the ref callback's memoization, so an
+ * identity that changes every render would detach and reattach the observer every render.
+ */
+export const useResizeObserverRef = <E extends HTMLElement>(
+  callback: ResizeObserverCallback,
+  onDetach?: () => void,
+): React.Ref<E> => {
   const { targetDocument } = useFluent();
   const [observer] = React.useState(() => {
     const ResizeObserverConstructor = targetDocument?.defaultView?.ResizeObserver;
@@ -16,10 +28,11 @@ export const useResizeObserverRef = <E extends HTMLElement>(callback: ResizeObse
       if (element) {
         observer?.observe(element);
       } else {
+        onDetach?.();
         observer?.disconnect();
       }
     },
-    [observer],
+    [observer, onDetach],
   );
   return ref;
 };


### PR DESCRIPTION
In `useTagPickerControl`, the ResizeObserver schedules the aside-width CSS property in an animation frame, but the original effect body cancels that frame before it can write. Moving cancellation into passive-effect cleanup also fails under React 18 StrictMode: effects replay without replaying the callback ref that schedules the frame.

This ties cancellation to the observer ref's detach lifecycle, clears completed frame handles, and treats handle `0` as a valid pending frame. The tests flush only uncancelled callbacks and cover mount, unmount, and StrictMode. The React 18 integration configuration explicitly selects this package's `jest.config.cjs` so the suite is included.

Validation: all three frame regressions pass with React/ReactDOM 18.3.1 and the default React 19.2.0; package lint and type-check pass. On React 18, temporarily restoring passive-effect cleanup makes the StrictMode test fail with an unset width. Restoring the truthy handle check makes the zero-handle unmount test fail.

Fixes #36649.

Extracted from #36656 per maintainer request.
