### PR TITLE
fix(react-headless-components-preview): apply state.arrowClassName in renderTooltip

### DIFF
--- a/change/@fluentui-react-headless-components-preview-bebba5c3-9ce1-42db-b357-0a5b55eec41e.json
+++ b/change/@fluentui-react-headless-components-preview-bebba5c3-9ce1-42db-b357-0a5b55eec41e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: renderTooltip applies state.arrowClassName to the arrow element instead of silently discarding it",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/Tooltip.test.tsx
@@ -4,6 +4,9 @@ import { resetIdsForTests } from '@fluentui/react-utilities';
 import { isConformant } from '../../testing/isConformant';
 import type { IsConformantOptions } from '@fluentui/react-conformance';
 import { Tooltip } from './Tooltip';
+import { useTooltip } from './useTooltip';
+import { renderTooltip } from './renderTooltip';
+import type { TooltipProps } from './Tooltip.types';
 
 export const getTooltipElement: IsConformantOptions['getTargetElement'] = () => {
   return screen.queryByRole('tooltip') as HTMLElement;
@@ -109,6 +112,26 @@ describe('Tooltip', () => {
     );
 
     expect(screen.getByRole('tooltip').querySelector('[data-arrow]')).not.toBeNull();
+  });
+
+  // Regression test for https://github.com/microsoft/fluentui/issues/36650 — renderTooltip dropped
+  // state.arrowClassName, so a styled layer setting it between useTooltip and renderTooltip never
+  // reached the arrow element.
+  it('applies state.arrowClassName to the arrow element', () => {
+    const StyledTooltip = (props: TooltipProps) => {
+      const state = useTooltip(props);
+      state.arrowClassName = 'custom-arrow-class';
+      return renderTooltip(state);
+    };
+
+    render(
+      <StyledTooltip content="Styled arrow tooltip" relationship="label" visible withArrow>
+        <button>Trigger</button>
+      </StyledTooltip>,
+    );
+
+    const arrow = screen.getByRole('tooltip').querySelector('[data-arrow]');
+    expect(arrow).toHaveClass('custom-arrow-class');
   });
 
   it('does not render arrow element when withArrow is false', () => {

--- a/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/renderTooltip.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Tooltip/renderTooltip.tsx
@@ -16,7 +16,7 @@ export const renderTooltip = (state: TooltipState): JSXElement => {
       {state.children}
       {state.shouldRenderTooltip && (
         <state.content>
-          {state.withArrow && <div ref={state.arrowRef} data-arrow="" />}
+          {state.withArrow && <div ref={state.arrowRef} className={state.arrowClassName} data-arrow="" />}
           {state.content.children}
         </state.content>
       )}


### PR DESCRIPTION
The headless `renderTooltip` renders the arrow element as `<div ref={state.arrowRef} data-arrow="" />` with no `className`, silently discarding `state.arrowClassName` — a field the published Tooltip type contract declares (`Tooltip.types.ts` / `react-tooltip.api.md`), the Griffel renderer applies, and `useTooltipStyles.styles.ts` sets. A consumer or styling layer that sets it gets no error and no warning, just an unstyled arrow.

The fix applies the field: `<div ref={state.arrowRef} className={state.arrowClassName} data-arrow="" />`, matching the Griffel renderer the headless copy mirrors. One line; the field was previously inert, so no existing render output changes unless a consumer was already setting a value that was being thrown away.

Fixes #36650.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.
