### PR TITLE
fix(react-storybook-addon-export-to-sandbox): find the addon registration on Windows

### DIFF
--- a/change/@fluentui-react-storybook-addon-export-to-sandbox-4a111ae2-83ac-4fad-8039-eeed61b69743.json
+++ b/change/@fluentui-react-storybook-addon-export-to-sandbox-4a111ae2-83ac-4fad-8039-eeed61b69743.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: match backslash-separated preset paths so the addon finds its registration on Windows",
+  "packageName": "@fluentui/react-storybook-addon-export-to-sandbox",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-storybook-addon-export-to-sandbox/src/webpack.ts
+++ b/packages/react-components/react-storybook-addon-export-to-sandbox/src/webpack.ts
@@ -16,7 +16,11 @@ export function webpack(config: WebpackFinalConfig, options: WebpackFinalOptions
 }
 
 const identity = <T extends unknown>(value: T) => value;
-const addonFilePattern = /react-storybook-addon-export-to-sandbox\/[a-z/]+.[jt]s$/;
+// Both path separators on purpose: on Windows the registered preset name is an absolute
+// path with backslashes (e.g. `...\react-storybook-addon-export-to-sandbox\temp\preset.ts`);
+// a forward-slash-only pattern fails to find the registration, silently drops the addon
+// options, and the full-source babel plugin then crashes on undefined `importMappings`.
+const addonFilePattern = /react-storybook-addon-export-to-sandbox[\\/][a-z\\/]+.[jt]s$/;
 const defaultOptions = {
   webpackRule: {},
   babelLoaderOptionsUpdater: identity,


### PR DESCRIPTION
`react-storybook-addon-export-to-sandbox` locates its own registration by matching the registered preset name against a pattern that accepts forward slashes only. On Windows the registered preset name is an absolute path with backslashes (e.g. `...\react-storybook-addon-export-to-sandbox\temp\preset.ts`), so the pattern matches nothing: the addon options are silently dropped and the full-source babel plugin crashes downstream on undefined `importMappings`. The failure is platform-specific and silent right up to the crash — Linux CI has never seen it — and it hits any contributor the first time they run a Storybook that registers this addon on Windows.

The fix widens `addonFilePattern` to accept either separator, with a comment explaining why both are there so it is not tidied back.

Fixes #36653.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.
