### PR TITLE
fix(workspace-plugin): generate-api emits export-subpath rollups on Windows

### DIFF
--- a/tools/workspace-plugin/src/executors/generate-api/lib/utils.ts
+++ b/tools/workspace-plugin/src/executors/generate-api/lib/utils.ts
@@ -146,10 +146,13 @@ export function getExportSubpathConfigs(options: NormalizedOptions): IConfigFile
     // they act as literal path segments that the subsequent "../" chain traverses through.
     // path.resolve(configDir, "<projectRoot>/../../../../../../...") naturally normalizes to the correct path.
     const configDir = dirname(opts.config);
+    // Normalized to posix separators: path.resolve emits backslashes on Windows, which
+    // would fail the '/index.d.ts' suffix check below and silently skip every subpath
+    // rollup on Windows machines (CI on Linux was unaffected).
     const resolvedPrimaryEntry = resolve(
       configDir,
       primaryMainEntryTemplate.replace(/<unscopedPackageName>/g, unscopedPackageName),
-    );
+    ).replace(/\\/g, '/');
 
     const indexDtsSuffix = '/index.d.ts';
     if (!resolvedPrimaryEntry.endsWith(indexDtsSuffix)) {


### PR DESCRIPTION
In `getExportSubpathConfigs`, the resolved primary entry is checked against the hard-coded posix suffix `'/index.d.ts'` — but `path.resolve` emits backslash-separated paths on Windows, so the guard fires for every project and every export-subpath API rollup is silently skipped on Windows machines. Linux CI is unaffected, which is why it has survived. Concretely: on a Windows checkout, `generate-api` for `@fluentui/react-headless-components-preview` emits 0 subpath rollups where it should emit 56, and a run that produces nothing looks identical to a run that had nothing to produce.

The fix normalizes the resolved path to posix separators before the suffix check, with a comment recording why. Verification on a Windows checkout: the package's `generate-api` jest suite goes from 8 failed / 5 passed on current master to 4 failed / 9 passed with this change — the four subpath-resolution tests this code path owns now pass; the remaining four failures are pre-existing Windows path-separator expectations elsewhere in the same spec file, unaffected by this change (everything passes on Linux).

Fixes #36654.

Extracted from #36656 per maintainer request — each in-tree fix from that PR as an isolated change.
