### PR TITLE
explore: engine option to support floating-ui based positioning in headless

### DIFF
--- a/apps/public-docsite-v9-headless/src/PolyfillsAndFallbacks.mdx
+++ b/apps/public-docsite-v9-headless/src/PolyfillsAndFallbacks.mdx
@@ -19,9 +19,11 @@ experience to provide. Fluent UI Headless leaves that tradeoff to the consuming 
    anchor-positioning polyfill. This keeps the common path lean and requires little application code,
    although a polyfill may implement only part of the positioning behavior listed in the
    [browser support matrix](?path=/docs/overview-browser-support--docs#detailed-feature-support).
-2. **Use product-owned positioning logic.** When `CSS.supports('anchor-name', '--x')` returns `false`,
-   hand the layer to a measurement-based positioner. This adds implementation work, but lets the
-   product control placement, flipping, and collision handling.
+2. **Supply a JavaScript positioning engine.** Components that accept a `positioning` prop also accept
+   `positioning.engine`, which delegates placement to a measurement-based positioner such as
+   `usePositioning` from `@fluentui/react-positioning`. This also unlocks options CSS anchor
+   positioning cannot express, such as `flipBoundary` and `shift`. Nothing is added to your bundle
+   unless you supply one, so it can be applied to every surface or only the ones that need it.
 3. **Allow static placement.** Keep the native fallback behavior: the surface opens, but it may appear
    at its document position rather than beside the trigger. Products aimed primarily at browsers with
    native support may find this sufficient.
@@ -57,8 +59,9 @@ if (!hasPopover) {
 
 Overlays are positioned relative to their trigger with
 [CSS anchor positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning).
-The headless library does **not** include a JavaScript positioning fallback, so without support these
-overlays render at their static position. Use the feature detection and fallback options above, and
-load any polyfill before Fluent UI Headless renders. Consult the
+The headless library does not bundle a JavaScript positioner, so by default these overlays render at
+their static position where anchor positioning is unavailable. Supply one through
+`positioning.engine` if you need measurement-based placement — see the fallback options above — or
+load a polyfill before Fluent UI Headless renders. Consult the
 [browser support matrix](?path=/docs/overview-browser-support--docs#detailed-feature-support) for the
 individual CSS properties Fluent UI Headless uses.

--- a/change/@fluentui-react-headless-components-preview-3d562117-93c3-4441-92c8-022ee796f5bf.json
+++ b/change/@fluentui-react-headless-components-preview-3d562117-93c3-4441-92c8-022ee796f5bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: add positioning.engine to delegate placement to a JavaScript positioner",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "vgenaev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
+++ b/packages/react-components/react-headless-components-preview/library/bundle-isolation.config.json
@@ -2,7 +2,7 @@
   "$schema": "../../../../tools/verify-bundle-isolation/schema.json",
   "fixturesRoot": "./bundle-size",
   "externals": ["react", "react-dom", "react/jsx-runtime", "react/compiler-runtime"],
-  "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons"],
+  "forbiddenPackages": ["tabster", "@griffel/*", "@fluentui/react-icons", "@floating-ui/*"],
   "fixtures": {
     "AllComponents.fixture.js": {}
   }

--- a/packages/react-components/react-headless-components-preview/library/docs/popover-spec.md
+++ b/packages/react-components/react-headless-components-preview/library/docs/popover-spec.md
@@ -178,23 +178,59 @@ Placement is handled entirely by the `usePositioning` hook, which writes native 
 
 ### Options (all optional)
 
-| Option              | Type                                                  | Default      | Effect                                                                                                                                                                               |
-| ------------------- | ----------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `position`          | `'above' \| 'below' \| 'before' \| 'after'`           | `'above'`    | Which side of the anchor the surface sits on. Physical `top` / `bottom` / `left` / `right` are normalized.                                                                           |
-| `align`             | `'start' \| 'center' \| 'end' \| 'top' \| 'bottom'`   | `'center'`   | Cross-axis alignment. `top` → `start`, `bottom` → `end` (v9 aliases).                                                                                                                |
-| `offset`            | `number \| { mainAxis?: number; crossAxis?: number }` | `0`          | Logical-margin offset from the anchor.                                                                                                                                               |
-| `fallbackPositions` | `PositioningShorthandValue[]`                         | `[]`         | Custom fallback chain. Each entry is converted to a `<position-area>` value inline in `position-try-fallbacks`.                                                                      |
-| `coverTarget`       | `boolean`                                             | `false`      | Overlap the anchor instead of sitting beside it.                                                                                                                                     |
-| `pinned`            | `boolean`                                             | `false`      | Disable fallback flipping; surface stays at the requested placement even if it overflows.                                                                                            |
-| `matchTargetSize`   | `'width'`                                             | —            | Sets the surface's `width` to `anchor-size(width)`.                                                                                                                                  |
-| `strategy`          | `'fixed' \| 'absolute'`                               | `'absolute'` | CSS `position` property value on the surface. Matches v9's default. Use `'fixed'` when the surface needs to escape transformed / `contain: layout` ancestors for anchoring purposes. |
-| `target`            | `HTMLElement \| RefObject`                            | —            | Custom anchor element. When set, `anchor-name` is written on this element instead of the trigger.                                                                                    |
-| `positioningRef`    | `Ref<PositioningImperativeRef>`                       | —            | `{ setTarget(el): void; updatePosition(): void }`. `updatePosition` is a no-op — native positioning self-updates.                                                                    |
+| Option              | Type                                                  | Default     | Effect                                                                                                                                                                                                                                               |
+| ------------------- | ----------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `position`          | `'above' \| 'below' \| 'before' \| 'after'`           | `'above'`   | Which side of the anchor the surface sits on. Physical `top` / `bottom` / `left` / `right` are normalized.                                                                                                                                           |
+| `align`             | `'start' \| 'center' \| 'end' \| 'top' \| 'bottom'`   | `'center'`  | Cross-axis alignment. `top` → `start`, `bottom` → `end` (v9 aliases).                                                                                                                                                                                |
+| `offset`            | `number \| { mainAxis?: number; crossAxis?: number }` | `0`         | Logical-margin offset from the anchor.                                                                                                                                                                                                               |
+| `fallbackPositions` | `PositioningShorthandValue[]`                         | `[]`        | Custom fallback chain. Each entry is converted to a `<position-area>` value inline in `position-try-fallbacks`.                                                                                                                                      |
+| `coverTarget`       | `boolean`                                             | `false`     | Overlap the anchor instead of sitting beside it.                                                                                                                                                                                                     |
+| `pinned`            | `boolean`                                             | `false`     | Disable fallback flipping; surface stays at the requested placement even if it overflows.                                                                                                                                                            |
+| `matchTargetSize`   | `'width'`                                             | —           | Sets the surface's `width` to `anchor-size(width)`.                                                                                                                                                                                                  |
+| `strategy`          | `'fixed' \| 'absolute'`                               | `'fixed'`   | CSS `position` property value on the surface. Defaults to `'fixed'` because the surface is promoted to the top layer, where it must escape transformed / `contain: layout` ancestors. Use `'absolute'` only for a surface that stays in normal flow. |
+| `target`            | `HTMLElement \| RefObject`                            | —           | Custom anchor element. When set, `anchor-name` is written on this element instead of the trigger.                                                                                                                                                    |
+| `positioningRef`    | `Ref<PositioningImperativeRef>`                       | —           | `{ setTarget(el): void; updatePosition(): void }`. `updatePosition` is a no-op — native positioning self-updates.                                                                                                                                    |
+| `engine`            | `'default' \| PositioningEngine`                      | `'default'` | Which positioning implementation places the surface. See _Positioning engines_ below.                                                                                                                                                                |
+
+### Positioning engines
+
+Placement is performed by an _engine_. The default engine uses native CSS anchor positioning and is
+what every surface gets unless `positioning.engine` says otherwise.
+
+CSS anchor positioning cannot express everything the canonical positioning contract offers — it
+flips between discrete fallbacks rather than sliding, and it needs a real DOM node to anchor to. A
+consumer who needs those behaviours supplies a JavaScript engine:
+
+```tsx
+import { usePositioning } from '@fluentui/react-positioning';
+
+<Menu positioning={{ autoSize: 'height', engine: usePositioning }} />;
+```
+
+`usePositioning` satisfies the engine contract directly — this library ships no adapter, and nothing
+in its default entry points references a JavaScript positioner, so bundles that do not supply one
+contain no positioning library. That guarantee is enforced by the package's bundle isolation check.
+
+Options unsupported by the default engine are rejected at compile time unless an engine is
+supplied, so `positioning={{ autoSize: 'height' }}` does not silently do nothing.
+
+Notes:
+
+- **The engine is passed uncalled and invoked by the component**, with options the component has
+  already merged. Configuration a component derives internally — a submenu's placement, a
+  pointer-derived context target — therefore reaches the engine without the consumer restating it.
+- **The engine's identity must be stable** for the lifetime of the component instance, because it is
+  invoked as a hook. Pass a module-scope import, not an inline function — changing it mid-life fails
+  as a React hook-order error.
+- **Two concerns stay with the component regardless of engine**, because they belong to the surface
+  rather than the positioner: the top-layer `inset`/`margin` reset, and reporting resolved placement
+  through `data-placement`. Consumer styling keyed on placement keeps working across engines.
+- Consumers supplying `@fluentui/react-positioning` need it in their own dependencies.
 
 ### Rendering
 
 - The hook writes `anchor-name: --popover-anchor-<id>` on the anchor (trigger or custom target) via `useIsomorphicLayoutEffect`.
-- On the surface it writes `position: absolute` (or `fixed` if `strategy: 'fixed'`); `inset: auto; margin: 0; position-anchor: --popover-anchor-<id>; position-area: <value>; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline`. The `inset: auto; margin: 0` reset is required because the UA popover stylesheet sets `inset: 0; margin: auto`, which fights `position-area`.
+- On the surface it writes `position: fixed` (or `absolute` if `strategy: 'absolute'`); `inset: auto; margin: 0; position-anchor: --popover-anchor-<id>; position-area: <value>; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline`. The `inset: auto; margin: 0` reset is required because the UA popover stylesheet sets `inset: 0; margin: auto`, which fights `position-area`.
 - For center alignment, the hook also writes `place-self: anchor-center` as a workaround for https://crbug.com/438334710 (Chromium <=130 doesn't reliably apply the implicit anchor-center self-alignment to single-keyword `position-area` values).
 - `data-placement` is set to the requested placement and then live-updated by `usePlacementObserver` (ResizeObserver + scroll listener) to reflect the browser's post-flip decision.
 

--- a/packages/react-components/react-headless-components-preview/library/etc/positioning.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/positioning.api.md
@@ -25,6 +25,16 @@ export function getPlacementString(position: Position, align: Alignment): Positi
 
 export { Position }
 
+// @public
+export type PositioningEngine = (options: PositioningProps_2) => PositioningEngineReturn;
+
+// @public
+export type PositioningEngineReturn = {
+    targetRef: React_2.Ref<HTMLElement>;
+    containerRef: React_2.Ref<HTMLElement>;
+    arrowRef?: React_2.Ref<HTMLElement>;
+};
+
 export { PositioningImperativeRef }
 
 // @public (undocumented)
@@ -36,8 +46,12 @@ export type PositioningReturn = {
     containerRef: React_2.RefCallback<HTMLElement>;
 };
 
-// @public (undocumented)
-export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
+// @public
+export type PositioningShorthand = PositioningShorthandValue | (PositioningProps & {
+    engine?: 'default';
+}) | (PositioningProps_2 & {
+    engine: PositioningEngine;
+});
 
 export { PositioningShorthandValue }
 
@@ -52,8 +66,10 @@ export const POSITIONS: {
 // @public (undocumented)
 export const resolvePositioningShorthand: ResolvePositioningShorthand;
 
-// @public (undocumented)
-export function usePositioning(options: PositioningProps): PositioningReturn;
+// @public
+export function usePositioning(options: PositioningProps & {
+    engine?: 'default' | PositioningEngine;
+}): PositioningReturn;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/tooltip.api.md
@@ -8,6 +8,7 @@ import type { JSXElement } from '@fluentui/react-utilities';
 import { OnVisibleChangeData } from '@fluentui/react-tooltip';
 import type { PositioningProps as PositioningProps_2 } from '@fluentui/react-positioning';
 import type { PositioningShorthandValue } from '@fluentui/react-positioning';
+import type * as React_2 from 'react';
 import type { TooltipBaseProps } from '@fluentui/react-tooltip';
 import type { TooltipBaseState } from '@fluentui/react-tooltip';
 import { TooltipSlots } from '@fluentui/react-tooltip';

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/FlipBoundary.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/FlipBoundary.cy.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { mount } from '@fluentui/scripts-cypress';
+import { usePositioning } from '@fluentui/react-positioning';
+
+import { Popover } from './Popover';
+import { PopoverTrigger } from './PopoverTrigger';
+import { PopoverSurface } from './PopoverSurface';
+
+/**
+ * Guards the documented `flipBoundary` example in the Engine positioning story.
+ *
+ * The trigger sits near the bottom of a short scrolling box that is itself near the top of the
+ * viewport. There is viewport room below the trigger but not box room, so the requested `below`
+ * placement is only overridden when the engine treats the box as its boundary.
+ */
+const boundaryStyle: React.CSSProperties = {
+  position: 'relative',
+  height: 220,
+  overflow: 'auto',
+  border: '1px dashed #888',
+  padding: 16,
+};
+
+const surfaceStyle: React.CSSProperties = { display: 'block', width: 220, height: 90, background: '#fff' };
+
+const DefaultEngine: React.FC = () => (
+  <div style={{ padding: 16 }}>
+    <div style={boundaryStyle}>
+      <div style={{ height: 150 }} />
+      <Popover defaultOpen positioning={{ position: 'below', align: 'start' }}>
+        <PopoverTrigger>
+          <button>Trigger</button>
+        </PopoverTrigger>
+        <PopoverSurface data-testid="surface" style={surfaceStyle}>
+          Boundary is the viewport
+        </PopoverSurface>
+      </Popover>
+    </div>
+  </div>
+);
+
+const InjectedEngine: React.FC = () => {
+  const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={boundaryStyle} ref={setBoundary}>
+        <div style={{ height: 150 }} />
+        <Popover
+          defaultOpen
+          positioning={{ position: 'below', align: 'start', flipBoundary: boundary, engine: usePositioning }}
+        >
+          <PopoverTrigger>
+            <button data-testid="trigger">Trigger</button>
+          </PopoverTrigger>
+          <PopoverSurface data-testid="surface" style={surfaceStyle}>
+            Boundary is the scrolling box
+          </PopoverSurface>
+        </Popover>
+      </div>
+    </div>
+  );
+};
+
+describe('flipBoundary — flip detection scoped to an element', () => {
+  beforeEach(() => cy.viewport(800, 800));
+
+  it('keeps the surface below the trigger under the default engine', () => {
+    // CSS anchor positioning resolves against the viewport, where there is ample room below.
+    mount(<DefaultEngine />);
+
+    cy.get('[data-testid="surface"]')
+      .should('have.attr', 'data-placement')
+      .and('match', /^below/);
+  });
+
+  it('flips the surface above the trigger when the box is the flip boundary', () => {
+    mount(<InjectedEngine />);
+
+    cy.get('[data-testid="surface"]')
+      .should('have.attr', 'data-placement')
+      .and('match', /^above/);
+  });
+
+  it('keeps the flipped surface inside the boundary box', () => {
+    mount(<InjectedEngine />);
+
+    cy.get('[data-testid="trigger"]').then($trigger => {
+      const triggerTop = $trigger[0].getBoundingClientRect().top;
+
+      cy.get('[data-testid="surface"]').should($surface => {
+        expect($surface[0].getBoundingClientRect().bottom, 'sits above the trigger').to.be.at.most(triggerTop + 1);
+      });
+    });
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/index.ts
@@ -1,8 +1,17 @@
 export { resolvePositioningShorthand } from './resolvePositioningShorthand';
 export { usePositioning } from './usePositioning';
+export { useCssAnchorPositioning } from './useCssAnchorPositioning';
 export { getPlacementString } from './utils';
 export { POSITIONS, ALIGNMENTS } from './constants';
-export type { PositioningProps, PositioningShorthand, PositioningReturn } from './types';
+export { hasPositioningEngine } from './types';
+export type {
+  PositioningProps,
+  PositioningShorthand,
+  PositioningReturn,
+  PositioningEngine,
+  PositioningEngineReturn,
+} from './types';
+export type { ResolvedPositioning } from './resolvePositioningShorthand';
 
 export type {
   Alignment,

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/positioningEngine.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/positioningEngine.test.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { usePositioning as useFloatingUIPositioning } from '@fluentui/react-positioning';
+
+import { usePositioning } from './usePositioning';
+import type { PositioningEngine, PositioningShorthand } from './types';
+
+/**
+ * The premise of this design: `@fluentui/react-positioning` satisfies the engine contract as-is.
+ *
+ * If this stops compiling, an adapter has become necessary and the "no wrapper" decision in
+ * design.md needs revisiting.
+ */
+const floatingUIEngine: PositioningEngine = useFloatingUIPositioning;
+
+describe('PositioningEngine contract', () => {
+  it('is satisfied by usePositioning from @fluentui/react-positioning with no adapter', () => {
+    expect(typeof floatingUIEngine).toBe('function');
+  });
+});
+
+/**
+ * Type-level assertions, checked by the `type-check` target. A `@ts-expect-error` that stops being
+ * an error is itself reported, so these fail in both directions.
+ */
+describe('positioning option typing', () => {
+  it('rejects a JS-only option without an engine, as a fresh literal', () => {
+    // @ts-expect-error - `autoSize` cannot be expressed by CSS anchor positioning
+    const invalid: PositioningShorthand = { autoSize: 'height' };
+    expect(invalid).toBeDefined();
+  });
+
+  it('rejects a JS-only option without an engine, through a variable', () => {
+    // Excess property checking does not apply to a non-fresh object. This case is rejected by
+    // TypeScript's weak-type rule instead: `PositioningProps` has only optional properties, so an
+    // object sharing none of them is not assignable.
+    const options = { autoSize: 'height' as const };
+
+    // @ts-expect-error - still rejected when passed through a variable
+    const invalid: PositioningShorthand = options;
+    expect(invalid).toBeDefined();
+  });
+
+  it('rejects a JS-only option alongside engine: "default"', () => {
+    // @ts-expect-error - the default engine cannot honour `autoSize`
+    const invalid: PositioningShorthand = { autoSize: 'height', engine: 'default' };
+    expect(invalid).toBeDefined();
+  });
+
+  it('accepts a JS-only option alongside an injected engine', () => {
+    const valid: PositioningShorthand = { autoSize: 'height', engine: floatingUIEngine };
+    expect(valid).toBeDefined();
+  });
+
+  it('accepts supported options with no engine, and with the default sentinel', () => {
+    const bare: PositioningShorthand = { position: 'below', align: 'start', offset: 4 };
+    const explicit: PositioningShorthand = { position: 'below', engine: 'default' };
+    const shorthand: PositioningShorthand = 'below-start';
+
+    expect([bare, explicit, shorthand]).toHaveLength(3);
+  });
+});
+
+const NoopEngine: PositioningEngine = () => ({ targetRef: () => undefined, containerRef: () => undefined });
+
+describe('usePositioning engine dispatch', () => {
+  it('returns callable refs under the default engine', () => {
+    let captured: { targetRef: unknown; containerRef: unknown } | undefined;
+    const Capture = () => {
+      captured = usePositioning({});
+      return null;
+    };
+
+    render(<Capture />);
+
+    expect(typeof captured?.targetRef).toBe('function');
+    expect(typeof captured?.containerRef).toBe('function');
+  });
+
+  it('delegates to an injected engine instead of writing anchor declarations', () => {
+    const node = document.createElement('div');
+    let captured: ReturnType<typeof usePositioning> | undefined;
+    const Capture = () => {
+      captured = usePositioning({ engine: NoopEngine, position: 'below', align: 'start' });
+      return null;
+    };
+
+    render(<Capture />);
+    captured?.containerRef(node);
+
+    // The engine owns placement, so none of the CSS anchor declarations are written.
+    expect(node.style.getPropertyValue('position-anchor')).toBe('');
+    expect(node.style.getPropertyValue('position-area')).toBe('');
+    expect(node.style.getPropertyValue('position-try-fallbacks')).toBe('');
+  });
+
+  it('still applies the top-layer reset when delegating, because it belongs to the surface', () => {
+    const node = document.createElement('div');
+    let captured: ReturnType<typeof usePositioning> | undefined;
+    const Capture = () => {
+      captured = usePositioning({ engine: NoopEngine });
+      return null;
+    };
+
+    render(<Capture />);
+    captured?.containerRef(node);
+
+    expect(node.style.getPropertyValue('inset')).toBe('auto');
+    expect(node.style.getPropertyValue('margin')).toBe('0px');
+  });
+
+  it('treats engine: "default" as the built-in engine', () => {
+    const node = document.createElement('div');
+    let captured: ReturnType<typeof usePositioning> | undefined;
+    const Capture = () => {
+      captured = usePositioning({ engine: 'default', position: 'below', align: 'start' });
+      return null;
+    };
+
+    render(<Capture />);
+    captured?.containerRef(node);
+
+    expect(node.style.getPropertyValue('position-area')).toBe('block-end span-inline-end');
+  });
+});

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/resolvePositioningShorthand.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/resolvePositioningShorthand.ts
@@ -1,6 +1,18 @@
 import { resolvePositioningShorthand as resolveCanonicalPositioningShorthand } from '@fluentui/react-positioning';
-import type { PositioningProps, PositioningShorthand } from './types';
+import type { PositioningProps as CanonicalPositioningProps } from '@fluentui/react-positioning';
+import type { PositioningEngine, PositioningShorthand } from './types';
 
-type ResolvePositioningShorthand = (shorthand: PositioningShorthand | undefined | null) => Readonly<PositioningProps>;
+/**
+ * A positioning configuration after shorthand resolution.
+ *
+ * Widened to the canonical option shape because an engine legitimately receives the full option
+ * set; the narrowing that keeps unsupported options out lives on `PositioningShorthand`, which is
+ * what components accept.
+ */
+export type ResolvedPositioning = CanonicalPositioningProps & { engine?: 'default' | PositioningEngine };
+
+type ResolvePositioningShorthand = (
+  shorthand: PositioningShorthand | undefined | null,
+) => Readonly<ResolvedPositioning>;
 
 export const resolvePositioningShorthand = resolveCanonicalPositioningShorthand as ResolvePositioningShorthand;

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/types.ts
@@ -25,4 +25,52 @@ export type PositioningProps = Pick<
   | 'target'
 >;
 
-export type PositioningShorthand = PositioningProps | PositioningShorthandValue;
+/**
+ * Refs an engine hands back so the component can attach them to the elements it owns.
+ *
+ * Typed as `React.Ref` rather than `React.RefCallback` because `@fluentui/react-positioning`
+ * returns ref *objects* — `useCallbackRef` facades whose `current` setter drives its position
+ * manager. `useMergedRefs` accepts either form, so no conversion is needed.
+ */
+export type PositioningEngineReturn = {
+  targetRef: React.Ref<HTMLElement>;
+  containerRef: React.Ref<HTMLElement>;
+  arrowRef?: React.Ref<HTMLElement>;
+};
+
+/**
+ * A positioning implementation, supplied uncalled and invoked by the component.
+ *
+ * The component invokes it with options it has already merged, so configuration it derives
+ * internally — a submenu's placement, a pointer-derived target — reaches the engine by
+ * construction. Consumers never restate component semantics.
+ *
+ * `usePositioning` from `@fluentui/react-positioning` satisfies this signature directly; no
+ * adapter is required.
+ *
+ * Rules of hooks apply: the component invokes this as a hook, so its identity must be stable for
+ * the lifetime of the component instance. Pass a module-scope import rather than an inline
+ * function — changing it mid-life fails as a React hook-order error.
+ */
+export type PositioningEngine = (options: CanonicalPositioningProps) => PositioningEngineReturn;
+
+/**
+ * Positioning configuration for a component.
+ *
+ * A JS-only option such as `autoSize` is rejected without an engine and accepted with one. No
+ * explicit `never` mapping is needed: the engine branch requires `engine`, so an object carrying a
+ * JS-only option but no engine fails that branch, and `PositioningProps` is a weak type — every
+ * property optional — which TypeScript refuses for an object sharing none of its properties. Both
+ * the fresh-literal and the through-a-variable cases are covered.
+ */
+export type PositioningShorthand =
+  | PositioningShorthandValue
+  | (PositioningProps & { engine?: 'default' })
+  | (CanonicalPositioningProps & { engine: PositioningEngine });
+
+/** Narrows a resolved positioning value to one carrying an engine to delegate to. */
+export function hasPositioningEngine(
+  value: Readonly<CanonicalPositioningProps> & { engine?: 'default' | PositioningEngine },
+): value is Readonly<CanonicalPositioningProps> & { engine: PositioningEngine } {
+  return typeof value.engine === 'function';
+}

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/useCssAnchorPositioning.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/useCssAnchorPositioning.ts
@@ -1,0 +1,191 @@
+'use client';
+
+import * as React from 'react';
+import { useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
+import type {
+  PositioningImperativeRef,
+  PositioningShorthandValue,
+  PositioningVirtualElement,
+} from '@fluentui/react-positioning';
+import type { PositioningProps, PositioningReturn } from './types';
+import { POSITIONS, ALIGNMENTS, POSITION_AREA_MAP } from './constants';
+import { getPlacementString, normalizeAlign } from './utils/placement';
+import { applyOffset, getCoverSelfAlignment, resolveElementRef, resolveOffset, shorthandToPositionArea } from './utils';
+import { usePlacementObserver } from './usePlacementObserver';
+
+export type TargetElement = HTMLElement | PositioningVirtualElement;
+
+const DEFAULT_FLIP = ['flip-block', 'flip-inline', 'flip-block flip-inline'];
+
+const EMPTY_FALLBACK_POSITIONS: PositioningShorthandValue[] = [];
+
+/**
+ * Reads the current anchor-name property from an element and parses it into an array of names.
+ * Handles comma-separated values and trimming.
+ */
+const readAnchorNames = (element: HTMLElement): string[] => {
+  return element.style
+    .getPropertyValue('anchor-name')
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+};
+
+export function useCssAnchorPositioning(options: PositioningProps): PositioningReturn {
+  const {
+    pinned,
+    target: customTarget = null,
+    align: alignInput = ALIGNMENTS.center,
+    position = POSITIONS.above,
+    fallbackPositions = EMPTY_FALLBACK_POSITIONS,
+    offset,
+    coverTarget = false,
+    strategy = 'fixed',
+    matchTargetSize,
+    positioningRef,
+  } = options;
+
+  const align = normalizeAlign(alignInput);
+
+  const { mainAxis, crossAxis } = resolveOffset(offset);
+  const coverAlignment = React.useMemo(
+    () => (coverTarget ? getCoverSelfAlignment(position, align) : null),
+    [coverTarget, position, align],
+  );
+
+  const [triggerEl, setTriggerEl] = React.useState<HTMLElement | null>(null);
+  const [containerEl, setContainerEl] = React.useState<HTMLElement | null>(null);
+  const [imperativeTarget, setImperativeTarget] = React.useState<HTMLElement | null>(null);
+  const effectiveTarget = imperativeTarget ?? resolveElementRef(customTarget) ?? triggerEl;
+
+  const anchorName = `--${useId('popover-anchor-')}`;
+  const positionArea = POSITION_AREA_MAP[position][align];
+  const placement = getPlacementString(position, align);
+
+  const { targetDocument } = useFluent();
+
+  const fallbackAreas = React.useMemo(() => fallbackPositions.map(shorthandToPositionArea), [fallbackPositions]);
+
+  const requestPlacementUpdate = usePlacementObserver(containerEl, effectiveTarget, targetDocument, coverTarget);
+
+  React.useImperativeHandle<PositioningImperativeRef, PositioningImperativeRef>(
+    positioningRef,
+    () => ({
+      setTarget: (el: TargetElement | null) => {
+        setImperativeTarget(resolveElementRef(el));
+      },
+      updatePosition: requestPlacementUpdate,
+    }),
+    [requestPlacementUpdate],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (!effectiveTarget) {
+      return;
+    }
+
+    // `anchor-name` is a comma-separated list. Append this instance's name
+    // instead of overwriting so that multiple positioned popovers can share a
+    // single trigger (e.g. a Tooltip on hover and a Menu on click attached to
+    // the same button) without clobbering each other's anchor. On cleanup we
+    // remove only our own name, preserving any others still in use.
+    if (anchorName) {
+      const names = readAnchorNames(effectiveTarget);
+      if (!names.includes(anchorName)) {
+        effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
+      }
+    }
+
+    return () => {
+      if (anchorName) {
+        const remaining = readAnchorNames(effectiveTarget).filter(name => name !== anchorName);
+        if (remaining.length > 0) {
+          effectiveTarget.style.setProperty('anchor-name', remaining.join(', '));
+        } else {
+          effectiveTarget.style.removeProperty('anchor-name');
+        }
+      }
+    };
+  }, [effectiveTarget, anchorName]);
+
+  const targetRef: React.RefCallback<HTMLElement> = React.useCallback(node => {
+    setTriggerEl(node);
+  }, []);
+
+  const containerRef: React.RefCallback<HTMLElement> = React.useCallback(
+    node => {
+      setContainerEl(node);
+
+      if (!node) {
+        return;
+      }
+
+      node.style.setProperty('position', strategy);
+      node.style.setProperty('inset', 'auto');
+      node.style.setProperty('margin', '0');
+
+      applyOffset(node, position, mainAxis, crossAxis);
+
+      if (matchTargetSize === 'width') {
+        node.style.setProperty('width', 'anchor-size(width)');
+      } else {
+        node.style.removeProperty('width');
+      }
+
+      node.style.setProperty('position-anchor', anchorName);
+      node.setAttribute('data-placement', placement);
+
+      if (coverAlignment) {
+        node.style.setProperty('position-area', 'center');
+        node.style.setProperty('align-self', coverAlignment.alignSelf);
+        node.style.setProperty('justify-self', coverAlignment.justifySelf);
+        node.style.removeProperty('position-try-fallbacks');
+        return;
+      }
+
+      node.style.setProperty('position-area', positionArea);
+
+      /*
+       * Workaround for https://crbug.com/438334710: Chromium (<=130-ish) doesn't
+         apply the implicit `anchor-center` self-alignment that the spec defines
+         for single-keyword `position-area` values (`block-start`, `block-end`,
+    `    inline-start`, `inline-end`) or `span-all`.
+      */
+      if (align === ALIGNMENTS.center) {
+        node.style.setProperty('place-self', 'anchor-center');
+      } else {
+        node.style.removeProperty('place-self');
+        node.style.removeProperty('align-self');
+        node.style.removeProperty('justify-self');
+      }
+
+      if (pinned) {
+        node.style.removeProperty('position-try-fallbacks');
+        return;
+      }
+
+      if (fallbackAreas.length > 0) {
+        node.style.setProperty('position-try-fallbacks', fallbackAreas.join(', '));
+      } else {
+        node.style.setProperty('position-try-fallbacks', DEFAULT_FLIP.join(', '));
+      }
+    },
+    [
+      anchorName,
+      positionArea,
+      placement,
+      fallbackAreas,
+      pinned,
+      position,
+      align,
+      mainAxis,
+      crossAxis,
+      coverAlignment,
+      strategy,
+      matchTargetSize,
+    ],
+  );
+
+  return { targetRef, containerRef };
+}

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.test.tsx
@@ -87,7 +87,7 @@ describe('usePositioning', () => {
     expect(node).toHaveStyle({ positionArea: 'block-end span-inline-end' });
   });
 
-  it('containerRef writes position: absolute by default and clears the UA inset/margin defaults', () => {
+  it('containerRef writes position: fixed by default and clears the UA inset/margin defaults', () => {
     const result = mountHook();
     const node = document.createElement('div');
 

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/usePositioning.ts
@@ -1,191 +1,113 @@
 'use client';
 
+/*
+ * React Compiler cannot analyse this module.
+ *
+ * The engine is selected at runtime and invoked as a hook — `(delegate ?? useCssAnchorEngine)(...)`
+ * — which the compiler cannot trace, so it bails on the whole function and reports the bail at each
+ * manual memoization site. Verified by substituting a static call, after which the rule passes.
+ *
+ * The consequence is that this hook is not auto-optimised; its memoization is explicit and correct,
+ * so behaviour is unaffected. Dynamic dispatch is the mechanism that lets a component delegate
+ * placement without threading a rendered element through every state and render function, so this
+ * is a deliberate trade rather than an oversight.
+ */
+/* eslint-disable react-hooks/preserve-manual-memoization */
+
 import * as React from 'react';
-import { useId, useIsomorphicLayoutEffect } from '@fluentui/react-utilities';
-import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
-import type {
-  PositioningImperativeRef,
-  PositioningShorthandValue,
-  PositioningVirtualElement,
-} from '@fluentui/react-positioning';
-import type { PositioningProps, PositioningReturn } from './types';
-import { POSITIONS, ALIGNMENTS, POSITION_AREA_MAP } from './constants';
-import { getPlacementString, normalizeAlign } from './utils/placement';
-import { applyOffset, getCoverSelfAlignment, resolveElementRef, resolveOffset, shorthandToPositionArea } from './utils';
-import { usePlacementObserver } from './usePlacementObserver';
+import { useMergedRefs } from '@fluentui/react-utilities';
+import type { PositioningProps as CanonicalPositioningProps } from '@fluentui/react-positioning';
 
-export type TargetElement = HTMLElement | PositioningVirtualElement;
-
-const DEFAULT_FLIP = ['flip-block', 'flip-inline', 'flip-block flip-inline'];
-
-const EMPTY_FALLBACK_POSITIONS: PositioningShorthandValue[] = [];
+import type { PositioningEngine, PositioningProps, PositioningReturn } from './types';
+import { useCssAnchorPositioning } from './useCssAnchorPositioning';
+import { toHeadlessPlacement } from './utils/toHeadlessPlacement';
 
 /**
- * Reads the current anchor-name property from an element and parses it into an array of names.
- * Handles comma-separated values and trimming.
+ * The built-in engine, adapted to the `PositioningEngine` signature so the dispatcher has a single
+ * call site regardless of which engine is active.
+ *
+ * Module scope, so its identity is stable.
  */
-const readAnchorNames = (element: HTMLElement): string[] => {
-  return element.style
-    .getPropertyValue('anchor-name')
-    .split(',')
-    .map(name => name.trim())
-    .filter(Boolean);
-};
+const useCssAnchorEngine: PositioningEngine = options => useCssAnchorPositioning(options as PositioningProps);
 
-export function usePositioning(options: PositioningProps): PositioningReturn {
-  const {
-    pinned,
-    target: customTarget = null,
-    align: alignInput = ALIGNMENTS.center,
-    position = POSITIONS.above,
-    fallbackPositions = EMPTY_FALLBACK_POSITIONS,
-    offset,
-    coverTarget = false,
-    strategy = 'fixed',
-    matchTargetSize,
-    positioningRef,
-  } = options;
+/**
+ * Positions a surface, delegating to an injected engine when one is supplied.
+ *
+ * Exactly one engine owns placement. The engine is invoked with options the component has already
+ * merged, so configuration derived internally — a submenu's placement, a pointer-derived target —
+ * reaches it without the consumer restating it.
+ *
+ * Two concerns stay with this hook regardless of engine, because they are properties of the
+ * surface rather than of the positioner: the top-layer reset, and reporting resolved placement
+ * through `data-placement`.
+ */
+export function usePositioning(
+  options: PositioningProps & { engine?: 'default' | PositioningEngine },
+): PositioningReturn {
+  const { engine, ...positioningOptions } = options;
+  const delegate = typeof engine === 'function' ? engine : undefined;
 
-  const align = normalizeAlign(alignInput);
+  const consumerOnPositioningEnd = (positioningOptions as CanonicalPositioningProps).onPositioningEnd;
 
-  const { mainAxis, crossAxis } = resolveOffset(offset);
-  const coverAlignment = React.useMemo(
-    () => (coverTarget ? getCoverSelfAlignment(position, align) : null),
-    [coverTarget, position, align],
+  /**
+   * Mirrors the engine's resolved placement into the headless vocabulary.
+   *
+   * Uses the public `onPositioningEnd` option rather than observing the engine's own attribute, so
+   * nothing here depends on a particular engine's internals. The event is dispatched on the
+   * surface, so `currentTarget` is the element to annotate — no ref needed.
+   */
+  const handlePositioningEnd = React.useCallback<NonNullable<CanonicalPositioningProps['onPositioningEnd']>>(
+    event => {
+      const container = event.currentTarget as HTMLElement | null;
+      const placement = toHeadlessPlacement(event.detail.placement);
+
+      if (container && placement) {
+        container.setAttribute('data-placement', placement);
+      }
+
+      consumerOnPositioningEnd?.(event);
+    },
+    [consumerOnPositioningEnd],
   );
 
-  const [triggerEl, setTriggerEl] = React.useState<HTMLElement | null>(null);
-  const [containerEl, setContainerEl] = React.useState<HTMLElement | null>(null);
-  const [imperativeTarget, setImperativeTarget] = React.useState<HTMLElement | null>(null);
-  const effectiveTarget = imperativeTarget ?? resolveElementRef(customTarget) ?? triggerEl;
-
-  const anchorName = `--${useId('popover-anchor-')}`;
-  const positionArea = POSITION_AREA_MAP[position][align];
-  const placement = getPlacementString(position, align);
-
-  const { targetDocument } = useFluent();
-
-  const fallbackAreas = React.useMemo(() => fallbackPositions.map(shorthandToPositionArea), [fallbackPositions]);
-
-  const requestPlacementUpdate = usePlacementObserver(containerEl, effectiveTarget, targetDocument, coverTarget);
-
-  React.useImperativeHandle<PositioningImperativeRef, PositioningImperativeRef>(
-    positioningRef,
-    () => ({
-      setTarget: (el: TargetElement | null) => {
-        setImperativeTarget(resolveElementRef(el));
-      },
-      updatePosition: requestPlacementUpdate,
-    }),
-    [requestPlacementUpdate],
-  );
-
-  useIsomorphicLayoutEffect(() => {
-    if (!effectiveTarget) {
+  /**
+   * Defeats the UA popover stylesheet before the engine positions the surface.
+   *
+   * `[popover]:popover-open` applies `inset: 0; margin: auto`. A JavaScript positioner writes
+   * `left` and `top` and then translates, which overrides only the longhands it sets — leaving
+   * `right: 0` and `bottom: 0` in force and stretching the surface across the viewport. Clearing
+   * `inset` is what keeps it sized to its content; the shorthand then reads back as
+   * `0px auto auto 0px`, which is correct.
+   *
+   * This belongs to the surface, not the engine: headless is what made the element a popover.
+   */
+  const applyTopLayerReset = React.useCallback<React.RefCallback<HTMLElement>>(node => {
+    if (!node) {
       return;
     }
 
-    // `anchor-name` is a comma-separated list. Append this instance's name
-    // instead of overwriting so that multiple positioned popovers can share a
-    // single trigger (e.g. a Tooltip on hover and a Menu on click attached to
-    // the same button) without clobbering each other's anchor. On cleanup we
-    // remove only our own name, preserving any others still in use.
-    if (anchorName) {
-      const names = readAnchorNames(effectiveTarget);
-      if (!names.includes(anchorName)) {
-        effectiveTarget.style.setProperty('anchor-name', [...names, anchorName].join(', '));
-      }
-    }
-
-    return () => {
-      if (anchorName) {
-        const remaining = readAnchorNames(effectiveTarget).filter(name => name !== anchorName);
-        if (remaining.length > 0) {
-          effectiveTarget.style.setProperty('anchor-name', remaining.join(', '));
-        } else {
-          effectiveTarget.style.removeProperty('anchor-name');
-        }
-      }
-    };
-  }, [effectiveTarget, anchorName]);
-
-  const targetRef: React.RefCallback<HTMLElement> = React.useCallback(node => {
-    setTriggerEl(node);
+    node.style.setProperty('inset', 'auto');
+    node.style.setProperty('margin', '0');
   }, []);
 
-  const containerRef: React.RefCallback<HTMLElement> = React.useCallback(
-    node => {
-      setContainerEl(node);
+  const engineOptions: CanonicalPositioningProps = {
+    ...(positioningOptions as CanonicalPositioningProps),
+    // Headless surfaces are promoted to the top layer, where `fixed` is correct — and
+    // `@fluentui/react-positioning` defaults to `absolute`. Supplied as a default so an explicit
+    // `strategy` from the consumer still wins.
+    strategy: positioningOptions.strategy ?? 'fixed',
+    onPositioningEnd: delegate ? handlePositioningEnd : consumerOnPositioningEnd,
+  };
 
-      if (!node) {
-        return;
-      }
+  // Exactly one engine runs, and the two do not run the same number of hooks — which is why the
+  // engine's identity has to be stable for the lifetime of the component. Changing it mid-life
+  // fails as a React hook-order error.
+  const { targetRef, containerRef } = (delegate ?? useCssAnchorEngine)(engineOptions);
 
-      node.style.setProperty('position', strategy);
-      node.style.setProperty('inset', 'auto');
-      node.style.setProperty('margin', '0');
+  const mergedContainerRef = useMergedRefs(applyTopLayerReset, containerRef);
 
-      applyOffset(node, position, mainAxis, crossAxis);
-
-      if (matchTargetSize === 'width') {
-        node.style.setProperty('width', 'anchor-size(width)');
-      } else {
-        node.style.removeProperty('width');
-      }
-
-      node.style.setProperty('position-anchor', anchorName);
-      node.setAttribute('data-placement', placement);
-
-      if (coverAlignment) {
-        node.style.setProperty('position-area', 'center');
-        node.style.setProperty('align-self', coverAlignment.alignSelf);
-        node.style.setProperty('justify-self', coverAlignment.justifySelf);
-        node.style.removeProperty('position-try-fallbacks');
-        return;
-      }
-
-      node.style.setProperty('position-area', positionArea);
-
-      /*
-       * Workaround for https://crbug.com/438334710: Chromium (<=130-ish) doesn't
-         apply the implicit `anchor-center` self-alignment that the spec defines
-         for single-keyword `position-area` values (`block-start`, `block-end`,
-    `    inline-start`, `inline-end`) or `span-all`.
-      */
-      if (align === ALIGNMENTS.center) {
-        node.style.setProperty('place-self', 'anchor-center');
-      } else {
-        node.style.removeProperty('place-self');
-        node.style.removeProperty('align-self');
-        node.style.removeProperty('justify-self');
-      }
-
-      if (pinned) {
-        node.style.removeProperty('position-try-fallbacks');
-        return;
-      }
-
-      if (fallbackAreas.length > 0) {
-        node.style.setProperty('position-try-fallbacks', fallbackAreas.join(', '));
-      } else {
-        node.style.setProperty('position-try-fallbacks', DEFAULT_FLIP.join(', '));
-      }
-    },
-    [
-      anchorName,
-      positionArea,
-      placement,
-      fallbackAreas,
-      pinned,
-      position,
-      align,
-      mainAxis,
-      crossAxis,
-      coverAlignment,
-      strategy,
-      matchTargetSize,
-    ],
-  );
-
-  return { targetRef, containerRef };
+  return {
+    targetRef: targetRef as React.RefCallback<HTMLElement>,
+    containerRef: mergedContainerRef,
+  };
 }

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/index.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/index.ts
@@ -4,3 +4,4 @@ export { debounce } from './debounce';
 export { applyOffset, resolveOffset } from './offset';
 export { getCoverSelfAlignment, getPlacementString, shorthandToPositionArea } from './placement';
 export { resolveElementRef } from './resolveElementRef';
+export { toHeadlessPlacement } from './toHeadlessPlacement';

--- a/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/toHeadlessPlacement.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/hooks/usePositioning/utils/toHeadlessPlacement.ts
@@ -1,0 +1,37 @@
+import type { PositioningShorthandValue } from '@fluentui/react-positioning';
+
+/**
+ * Floating UI reports placement in physical terms (`top-start`, `right-end`), while headless
+ * components and every consumer stylesheet keyed on `data-placement` use the logical vocabulary
+ * (`above-start`, `after-bottom`).
+ *
+ * Without this mapping an injected engine silently breaks placement-keyed styling — most visibly
+ * arrows, which are positioned entirely by consumer CSS selecting on `data-placement`.
+ *
+ * Note the alignment suffix is not a straight copy: for the block positions the physical
+ * `start`/`end` match the logical ones, but for the inline positions headless uses `top`/`bottom`.
+ */
+const PLACEMENT_MAP: Record<string, PositioningShorthandValue> = {
+  top: 'above',
+  'top-start': 'above-start',
+  'top-end': 'above-end',
+  bottom: 'below',
+  'bottom-start': 'below-start',
+  'bottom-end': 'below-end',
+  left: 'before',
+  'left-start': 'before-top',
+  'left-end': 'before-bottom',
+  right: 'after',
+  'right-start': 'after-top',
+  'right-end': 'after-bottom',
+};
+
+/**
+ * Converts a physical placement into the headless `data-placement` vocabulary.
+ *
+ * Returns `undefined` for an unrecognised placement so the caller can leave the attribute alone
+ * rather than writing a value consumers cannot style against.
+ */
+export function toHeadlessPlacement(placement: string): PositioningShorthandValue | undefined {
+  return PLACEMENT_MAP[placement];
+}

--- a/packages/react-components/react-headless-components-preview/library/src/positioning.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/positioning.ts
@@ -6,6 +6,8 @@ export type {
   PositioningImperativeRef,
   PositioningShorthand,
   PositioningShorthandValue,
+  PositioningEngine,
+  PositioningEngineReturn,
 } from './hooks/usePositioning';
 export {
   usePositioning,

--- a/packages/react-components/react-headless-components-preview/stories/eslint.config.js
+++ b/packages/react-components/react-headless-components-preview/stories/eslint.config.js
@@ -7,4 +7,17 @@ module.exports = [
   {
     rules: {},
   },
+  {
+    files: ['**/Concepts/Positioning/PositioningEngine.stories.tsx'],
+    rules: {
+      /**
+       * The shared story config steers imports to the `@fluentui/react-components` barrel, which is
+       * right for v9 stories. This story documents supplying a positioning engine to the headless
+       * library, whose premise is not depending on the v9 suite — pointing consumers at the barrel
+       * would pull in every component to obtain one hook. It imports `@fluentui/react-positioning`
+       * directly so the code shown in the docs is the code a consumer should actually write.
+       */
+      '@fluentui/no-restricted-imports': 'off',
+    },
+  },
 ];

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningDescription.md
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningDescription.md
@@ -1,6 +1,10 @@
-Headless Fluent components that make use of positioning can all be configured in the same way. In this preview package, positioning currently applies to:
+Headless Fluent components that make use of positioning can all be configured in the same way. In this preview package, positioning applies to:
 
-- Popover
+- Popover (and the components built on it, such as InfoLabel, TeachingPopover and AvatarGroupPopover)
+- Menu
+- Tooltip
+- Dropdown and Combobox
+- TagPicker
 
 Components that have slots which are positioned will always expose a `positioning` prop where the positioning of the slot can be configured.
 

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningEngine.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningEngine.stories.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Popover, PopoverTrigger, PopoverSurface } from '@fluentui/react-headless-components-preview/popover';
+import { usePositioning } from '@fluentui/react-positioning';
+
+import descriptionMd from './PositioningEngineDescription.md';
+import styles from './positioning.module.css';
+
+/**
+ * A scrolling region containing a trigger near its bottom edge.
+ *
+ * There is room below the trigger in the viewport, but not inside the box — so whether the surface
+ * flips depends entirely on what the engine treats as the boundary.
+ */
+const BoundaryDemo = ({
+  label,
+  flipBoundary,
+  onBoundaryRef,
+}: {
+  label: string;
+  flipBoundary?: HTMLElement | null;
+  onBoundaryRef?: (el: HTMLElement | null) => void;
+}) => (
+  <div className={styles.section}>
+    <div className={styles.sectionTitle}>{label}</div>
+    <div className={styles.boundary} ref={onBoundaryRef}>
+      <div className={styles.boundaryFiller} />
+      <Popover
+        defaultOpen
+        positioning={
+          flipBoundary === undefined
+            ? { position: 'below', align: 'start' }
+            : { position: 'below', align: 'start', flipBoundary, engine: usePositioning }
+        }
+      >
+        <PopoverTrigger>
+          <button className={styles.trigger}>Trigger</button>
+        </PopoverTrigger>
+        <PopoverSurface className={styles.surfaceEngine}>
+          Flipping is decided against {flipBoundary === undefined ? 'the viewport' : 'the scrolling box'}.
+        </PopoverSurface>
+      </Popover>
+    </div>
+  </div>
+);
+
+export const Engine = (): React.ReactNode => {
+  const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+
+  return (
+    <div className={styles.pageRoomy}>
+      <div className={styles.grid}>
+        <BoundaryDemo label="Default engine — flips against the viewport" />
+        <BoundaryDemo
+          label="Injected engine — flips against the box"
+          flipBoundary={boundary}
+          onBoundaryRef={setBoundary}
+        />
+      </div>
+    </div>
+  );
+};
+
+Engine.parameters = {
+  docs: {
+    description: {
+      story: descriptionMd,
+    },
+  },
+};

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningEngineDescription.md
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/PositioningEngineDescription.md
@@ -1,0 +1,27 @@
+Placement is performed by an **engine**. By default that is native CSS anchor positioning, which needs no configuration and adds nothing to your bundle.
+
+CSS anchor positioning cannot express everything the positioning contract offers. It flips between discrete fallback positions rather than sliding, it resolves collisions against the viewport or containing block rather than an element you choose, and it needs a real DOM node to anchor to. When you need one of those behaviours, supply a JavaScript engine:
+
+```tsx
+import { usePositioning } from '@fluentui/react-positioning';
+
+<Popover positioning={{ position: 'below', flipBoundary: scrollBox, engine: usePositioning }}>
+```
+
+The example above shows `flipBoundary`, which has no CSS anchor equivalent. Both popovers request `below`. The one on the left has viewport space beneath its trigger, so it stays below and overflows the scrolling box. The one on the right treats the box as its flip boundary and flips above to stay inside it.
+
+`flipBoundary` scopes the decision to flip; `overflowBoundary` scopes sliding along an edge, which CSS anchor positioning cannot do at all.
+
+Options that only a JavaScript engine can honour are rejected at compile time unless you supply one, so `positioning={{ flipBoundary: el }}` does not silently do nothing.
+
+### Things to know
+
+- **Pass the engine uncalled.** The component invokes it, with options it has already merged. Configuration a component derives internally — a submenu's placement, a context menu's pointer target — therefore reaches the engine without you restating it.
+- **Its identity must be stable**, because it is invoked as a hook. Pass a module-scope import, not an inline function such as `engine={o => usePositioning(o)}`; changing it while the component is mounted fails as a React hook-order error.
+- **Nothing is bundled unless you supply it.** No default entry point of this library references a JavaScript positioner, and that is enforced by an automated bundle check rather than convention.
+- **Styling keyed on placement keeps working.** `data-placement` is reported the same way under either engine, so arrow and animation styles do not need to change.
+- Supplying `@fluentui/react-positioning` means adding it to your own dependencies.
+
+### When you do not need this
+
+Most surfaces do not. `position`, `align`, `offset`, `coverTarget`, `matchTargetSize`, `pinned` and `fallbackPositions` are all handled by the default engine. Reach for an engine when you need collision behaviour the browser cannot express, or a positioning target that is not an element.

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/index.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/index.stories.tsx
@@ -12,6 +12,7 @@ export { FallbackPositions } from './PositioningFallbackPositions.stories';
 export { FlippingBlock } from './PositioningFlippingBlock.stories';
 export { FlippingInline } from './PositioningFlippingInline.stories';
 export { FlippingCorner } from './PositioningFlippingCorner.stories';
+export { Engine } from './PositioningEngine.stories';
 
 export default {
   title: 'Concepts/Positioning',

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/positioning.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/positioning.module.css
@@ -338,3 +338,35 @@
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* ===== Engine ===== */
+
+/*
+ * A scrolling region used as a `flipBoundary`. Sized so a surface opening below the trigger
+ * still fits in the viewport but not inside this box, which is what makes the difference between
+ * viewport-relative and boundary-relative collision detection visible.
+ */
+.boundary {
+  position: relative;
+  height: 220px;
+  overflow: auto;
+  border: var(--stroke-thin) dashed var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-soft);
+  padding: var(--space-4);
+}
+
+.boundaryFiller {
+  height: 150px;
+}
+
+.surfaceEngine {
+  display: block;
+  width: 220px;
+  background: var(--bg-elev);
+  border-radius: var(--radius-md);
+  border: var(--stroke-thin) solid var(--border);
+  box-shadow: var(--shadow-2);
+  padding: var(--space-3);
+  font-size: 13px;
+}

--- a/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/utils.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Concepts/Positioning/utils.stories.tsx
@@ -2,9 +2,12 @@ import * as React from 'react';
 import type { PositioningProps } from '@fluentui/react-headless-components-preview/positioning';
 
 /**
- * Subset of `PositioningProps` that the headless preview's `usePositioning` actually consumes.
- * Props not destructured by the hook (e.g. `autoSize`, `flipBoundary`, `useTransform`) are excluded
- * so Storybook's auto-generated args table only advertises what is supported.
+ * Options the default CSS anchor engine honours.
+ *
+ * The remaining canonical options (`autoSize`, `flipBoundary`, `overflowBoundary`, `useTransform`
+ * and friends) require a JavaScript engine — see the Engine example — and are excluded here so the
+ * auto-generated args table describes the default configuration rather than every option that could
+ * ever be legal.
  */
 type SupportedPositioningProps = Omit<
   PositioningProps,


### PR DESCRIPTION
## Previous Behavior

Headless components position surfaces exclusively with native CSS anchor positioning. That covers `position`, `align`, `offset`, `coverTarget`, `matchTargetSize`, `pinned` and `fallbackPositions`, but it structurally cannot express several behaviours the canonical positioning contract offers — it flips between discrete fallbacks rather than sliding, it resolves collisions against the viewport or containing block rather than an element you choose, and it needs a real DOM node to anchor to.

Options such as `autoSize`, `flipBoundary` and `shift` are correctly rejected by the type after #36623, but there was no supported path to obtain them. `PolyfillsAndFallbacks.mdx` told consumers to write their own measurement-based positioner.

## New Behavior

`positioning` accepts an `engine`:

```tsx
// default — CSS anchor positioning (also what you get by omitting `engine`)
<Menu positioning={{ position: 'below', engine: 'default' }} />

// delegated
import { usePositioning } from '@fluentui/react-positioning';

<Menu positioning={{ flipBoundary: scrollBox, engine: usePositioning }} />
```

**No adapter.** `usePositioning` from `@fluentui/react-positioning` satisfies the `PositioningEngine` contract as-is — asserted by a compiling type binding in `positioningEngine.test.tsx`. This PR adds no wrapper, no subpath and no invented contract.

**Nothing is bundled unless you supply it.** No default entry point references a JavaScript positioner. `@floating-ui/*` is now in the package's `verify-bundle-isolation` forbidden list, so the guarantee is CI-enforced rather than documented. I confirmed the check actually catches a leak before relying on it.

**The engine is passed uncalled, and the component invokes it** with options it has already merged. This is the load-bearing decision: `useMenu` derives `position: 'after'`, `align: 'top'` and a six-entry fallback chain from `isSubmenu`, which lives in menu context and is not observable at the call site. Any shape where the *consumer* calls the positioner inverts that ownership and needs a back-channel to undo it — `@fluentui/react-positioning` exposes no channel to push options into an already-invoked positioner (checked against `PositioningImperativeRef`, `PositioningConfigurationProvider`, and the options argument). Invoking it from the component means submenus and context menus keep their derived placement with **zero consumer configuration**.

**Two concerns stay with headless regardless of engine**, because they belong to the surface rather than the positioner:

- the top-layer reset — `[popover]:popover-open` applies `inset: 0; margin: auto`, and a JS positioner writes only `left`/`top`, leaving `right`/`bottom` at `0` and stretching the surface across the viewport. The reset is deliberately partial: `inset` ends up `0px auto auto 0px`, since `top`/`left` are the positioner's translate origin.
- reporting resolved placement through `data-placement`, mapped from physical to logical vocabulary via the public `onPositioningEnd` option. Consumer styling keyed on placement — arrows especially — keeps working across engines.

**Typing.** `positioning={{ flipBoundary: el }}` is still a compile error without an engine, and legal with one. No `never` mapping is needed: the engine branch requires `engine`, and `PositioningProps` is a weak type, so both the fresh-literal and through-a-variable cases are already rejected. Four `@ts-expect-error` assertions cover this and fail in both directions.

### Notes for reviewers

- **Rules of hooks.** The engine is invoked as a hook, so its identity must be stable. A module-scope import always is; `engine={o => usePositioning(o)}` is not and fails as a hook-order error. I built a dev-time guard naming the cause, then removed it — the failure is already loud and immediate, and it cost a conditional hook plus a lint suppression to improve a message. The constraint is documented on `PositioningEngine` and in the positioning docs.
- **React Compiler suppression.** `preserve-manual-memoization` is disabled at file scope in `usePositioning.ts`. Dynamic hook dispatch can't be traced by the compiler, verified by substituting a static call. Memoization is explicit and correct; only the automatic optimisation is lost.
- **ESLint override.** `PositioningEngine.stories.tsx` opts out of the barrel-import rule. That rule steers v9 stories to `@fluentui/react-components`, which would tell headless consumers to pull the entire suite for one hook. `docs/architecture/layers.md` rule 3 also states stories may depend on anything.
- **Coverage gap.** Component-derived placement reaching an engine was verified in a browser during design exploration, but those scenarios are not in the suite. `FlipBoundary.cy.tsx` covers the simpler claim that an engine-only option takes effect.

### Verification

type-check · lint · **1043** unit tests · **219** Cypress tests · bundle isolation · React 17/18/19 integration targets · API reports regenerated — all passing.

## Related Issue(s)

Follows #36623 (narrowed the positioning prop, introduced the headless-local resolver this extends).
Related: #36662.
