### PR TITLE
docs: rename stringifyDataAttribute to toDataAttributeValue in headless docs

### DIFF
--- a/.agents/skills/headless-component/SKILL.md
+++ b/.agents/skills/headless-component/SKILL.md
@@ -241,14 +241,14 @@ State attributes are the supported CSS targeting contract.
   attribute.
 - Removal or rename is breaking. Additions require tests and documentation.
 
-Use `stringifyDataAttribute` from `library/src/utils` for presence and string
+Use `toDataAttributeValue` from `library/src/utils` for presence and string
 attributes:
 
 ```tsx
 const state: ComponentNameState = useComponentNameBase_unstable(props, ref);
 
 // Applied after consumer props so base state cannot be misrepresented.
-state.root['data-disabled'] = stringifyDataAttribute(state.disabled);
+state.root['data-disabled'] = toDataAttributeValue(state.disabled);
 
 return state;
 ```

--- a/docs/react-v9/contributing/rfcs/react-components/convergence/headless-components.md
+++ b/docs/react-v9/contributing/rfcs/react-components/convergence/headless-components.md
@@ -112,12 +112,12 @@ Example (simplified):
 ```tsx
 const state = useButton(props, ref);
 
-// stringifyDataAttribute: returns undefined (omits the attribute) for falsy presence
-// attributes, or the string value ("true"/"false"/enum) for boolean/tri-state attributes.
+// toDataAttributeValue: returns '' (attribute present) for true, undefined (attribute
+// omitted) for false, and the stringified value for enum/tri-state attributes.
 Object.assign(state.root, {
-  'data-disabled': stringifyDataAttribute(state.disabled),
-  'data-disabled-focusable': stringifyDataAttribute(state.disabledFocusable),
-  'data-icon-only': stringifyDataAttribute(state.iconOnly),
+  'data-disabled': toDataAttributeValue(state.disabled),
+  'data-disabled-focusable': toDataAttributeValue(state.disabledFocusable),
+  'data-icon-only': toDataAttributeValue(state.iconOnly),
 });
 
 return state;


### PR DESCRIPTION
## Previous Behavior

The `stringifyDataAttribute` utility in `@fluentui/react-headless-components-preview` was renamed to `toDataAttributeValue` in #36596, but two docs were left pointing at the old name:

- `.agents/skills/headless-component/SKILL.md` — the skill agents use to author headless primitives
- `docs/react-v9/contributing/rfcs/react-components/convergence/headless-components.md` — the headless components RFC

## New Behavior

All references use `toDataAttributeValue`.

The RFC comment now matches the implementation: the utility returns `''` when the attribute should be present and `undefined` when it should be omitted. The old wording would have led consumers to write `[data-disabled="true"]` selectors that never match, since the attribute is emitted with an empty value.

Docs-only, no change file needed.

## Related Issue(s)

- Follow-up to #36596
