### PR TITLE
fix(react-headless-components-preview): default aria-hidden on NavCategoryItem's expandIcon slot

### DIFF
--- a/change/@fluentui-react-headless-components-preview-e4e832ae-9516-48ff-bcdb-4c477a4cc4d8.json
+++ b/change/@fluentui-react-headless-components-preview-e4e832ae-9516-48ff-bcdb-4c477a4cc4d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: default aria-hidden on NavCategoryItem's expandIcon slot",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "array.knight@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/Nav.test.tsx
@@ -202,4 +202,34 @@ describe('Nav', () => {
     expect(link.tagName).toBe('A');
     expect(link).toHaveAttribute('href', 'https://example.com');
   });
+
+  it('hides NavCategoryItem expandIcon from assistive technology by default', () => {
+    const result = render(
+      <Nav>
+        <NavCategory value="cat1">
+          <NavCategoryItem expandIcon={{ children: <img alt="expand" src="chevron.png" /> }}>
+            Category 1
+          </NavCategoryItem>
+        </NavCategory>
+      </Nav>,
+    );
+
+    expect(result.getByRole('button', { name: 'Category 1' })).toBeInTheDocument();
+    expect(result.getByAltText('expand').parentElement).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('allows a consumer to override NavCategoryItem expandIcon aria-hidden', () => {
+    const result = render(
+      <Nav>
+        <NavCategory value="cat1">
+          <NavCategoryItem expandIcon={{ 'aria-hidden': false, children: <img alt="expand" src="chevron.png" /> }}>
+            Category 1
+          </NavCategoryItem>
+        </NavCategory>
+      </Nav>,
+    );
+
+    expect(result.getByRole('button', { name: 'Category 1 expand' })).toBeInTheDocument();
+    expect(result.getByAltText('expand').parentElement).toHaveAttribute('aria-hidden', 'false');
+  });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/useNavCategoryItem.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Nav/NavCategoryItem/useNavCategoryItem.ts
@@ -53,6 +53,7 @@ export const useNavCategoryItem = (
       elementType: 'span',
     }),
     expandIcon: slot.optional(expandIcon, {
+      defaultProps: { 'aria-hidden': true },
       elementType: 'span',
     }),
     components: {


### PR DESCRIPTION
Griffel's `@fluentui/react-nav` marks the decorative expand chevron `aria-hidden: true` by default on both `useNavCategoryItem_unstable` and `useNavCategoryItemBase_unstable`. The headless `useNavCategoryItem` re-implements the `expandIcon` slot with `slot.optional` (no default glyph, unlike the base hook's `slot.always`) but dropped that `aria-hidden` default in the process. As a result, any `expandIcon` a consumer supplies (other than an untitled Fluent icon, which self-hides via `@fluentui/react-icons`) leaks into the button's accessible name.

This restores `defaultProps: { 'aria-hidden': true }` on the slot, matching the base hook. It remains overridable: `slot.always` spreads `{...defaultProps, ...props}`, so a consumer passing `expandIcon={{ 'aria-hidden': false, ... }}` still wins.

Fixes #36685.

Extracted from #36656 — each in-tree fix from that PR as an isolated change.