### PR TITLE
fix(react-charts): handle stale legend overflow counts

### DIFF
--- a/change/@fluentui-react-charts-3f02f58f-3997-43e1-8ad8-9d65a171efd6.json
+++ b/change/@fluentui-react-charts-3f02f58f-3997-43e1-8ad8-9d65a171efd6.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent Legends overflow crashes after dynamic item changes",
+  "packageName": "@fluentui/react-charts",
+  "email": "171317405+jakesalvesen@users.noreply.github.com"
+}

--- a/packages/charts/react-charts/library/src/components/Legends/Legends.test.tsx
+++ b/packages/charts/react-charts/library/src/components/Legends/Legends.test.tsx
@@ -229,6 +229,39 @@ describe.skip('Legends - controlled legend selection', () => {
   });
 });
 
+describe('Legends - dynamic overflow', () => {
+  const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+  const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 250 });
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 50 });
+  });
+
+  afterEach(() => {
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'clientWidth');
+    }
+    if (originalOffsetWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'offsetWidth');
+    }
+  });
+
+  it('does not throw when legends shrink while overflow is being reconciled', () => {
+    const result = render(<Legends legends={legends} overflowText="Overflow Items" />);
+
+    expect(result.getByText('+14 Overflow Items')).toBeTruthy();
+    result.rerender(<Legends legends={legends.slice(0, 3)} overflowText="Overflow Items" />);
+
+    expect(result.queryByText(/Overflow Items/)).toBeNull();
+    expect(result.container.querySelectorAll('button[role="option"]:not([data-overflowing])').length).toBe(3);
+  });
+});
+
 describe('Legends - axe-core', () => {
   test('Should pass accessibility tests', async () => {
     const { container } = render(<Legends legends={legends} />);

--- a/packages/charts/react-charts/library/src/components/Legends/OverflowMenu.tsx
+++ b/packages/charts/react-charts/library/src/components/Legends/OverflowMenu.tsx
@@ -15,7 +15,7 @@ export const OverflowMenu: React.FC<{
   let displayLabel = title;
   displayLabel = title === '' ? `+${overflowCount} items` : `+${overflowCount} ${title}`;
 
-  if (!isOverflowing) {
+  if (!isOverflowing || overflowCount > itemIds.length) {
     return null;
   }
   const remainingItemsCount = itemIds.length - overflowCount;
@@ -23,6 +23,9 @@ export const OverflowMenu: React.FC<{
   const menuList = [];
   for (let i = remainingItemsCount; i < itemIds.length; i++) {
     const buttonElement = items[i];
+    if (!buttonElement) {
+      continue;
+    }
     const value = `${buttonElement.props['data-title'] ?? i}`;
     if (buttonElement.props['data-selected']) {
       checkedLegends.push(value);


### PR DESCRIPTION
## Previous Behavior

`Legends` could crash while reconciling a dynamic item-count change. When an overflowed list shrank, `useOverflowMenu()` could briefly return the previous `overflowCount`. Subtracting that stale count from the current item count could produce a negative index and dereference `items[index].props` for a missing item.

The initial guard in this PR avoided the crash but could unmount the overflow trigger while `isOverflowing` stayed true. The registration effect did not rerun, leaving the overflow manager measuring a detached trigger.

## New Behavior

- Selects overflow menu entries from current item IDs using the public `useOverflowVisibility()` snapshot instead of a count-derived array offset.
- Keeps the trigger mounted whenever `isOverflowing` is true, preserving its DOM identity and overflow registration during a still-overflowing shrink.
- Derives the trigger label from the entries actually displayed in the menu.
- Removes the redundant missing-item guard: `itemIds` and `items` are built synchronously from the same legend data; the overflow snapshot is the stale value.
- Preserves selection, event forwarding, and full-list ARIA position metadata. No public API or styling changes.
- Retains the patch change file for `@fluentui/react-charts`.

## Regression Coverage

- Retains the original 17-to-3 shrink case.
- Adds 17-to-10 shrink coverage asserting the same connected, registered trigger and the correct count.
- Opens the menu after 17-to-10 shrink and checks the exact remaining overflow entries, absence of removed legends, selection, and ARIA metadata.
- Resizes after 17-to-10 shrink (250 -> 200 -> 300px), checking visible/overflow counts and persistent trigger identity.
- Checks 17-to-0-to-17 recovery.

The layout mock reports zero width for detached elements. Reintroducing the old stale-count early-return condition makes the trigger-identity and post-shrink resize regressions fail; restoring the fix passes both.

## Validation

Local validation with Node 24.20.0 and Yarn 4.18.0:

- Focused `Legends.test.tsx`: **17 passed, 4 skipped, 5 snapshots passed**.
- Full `react-charts:test` with `TZ=UTC`: **917 passed, 86 skipped, 321 snapshots passed**. No snapshot updates; the previously reported HeatMap date snapshot failures pass with this timezone.
- `react-charts:lint`: **0 errors, 438 package warnings**.
- Scoped Prettier check through `react-charts:format:check`: **passed** for both changed files.
- `react-charts:type-check`: **blocked before reaching the chart type-check**. The unchanged `react-provider` and `react-button` dependency builds fail during the Windows Griffel/Babel style transform because a generated module path loses part of the checkout path. No build tooling was changed. Upstream CI is still needed for this gate.

## Related Issue(s)

- Fixes #36641
- Related overflow coverage: #32121 / #36490
- Related fallback-color instability: #31364