### PR TITLE
feat: add badge support for headless Avatar and base types/hooks

### DIFF
--- a/change/@fluentui-react-avatar-11a82559-4bf0-480d-8dc0-9bfaa3d3cd31.json
+++ b/change/@fluentui-react-avatar-11a82559-4bf0-480d-8dc0-9bfaa3d3cd31.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "feat: add badge support for Avatar base hooks",
+  "packageName": "@fluentui/react-avatar",
+  "email": "dmytrokirpa@microsoft.com"
+}

--- a/change/@fluentui-react-headless-components-preview-71f786c2-ba8c-4c7b-bb59-8325370e078d.json
+++ b/change/@fluentui-react-headless-components-preview-71f786c2-ba8c-4c7b-bb59-8325370e078d.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "feat: add badge support for Avatar",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "dmytrokirpa@microsoft.com"
+}

--- a/packages/react-components/react-avatar/library/etc/react-avatar.api.md
+++ b/packages/react-components/react-avatar/library/etc/react-avatar.api.md
@@ -13,6 +13,7 @@ import type { JSXElement } from '@fluentui/react-utilities';
 import type { PopoverProps } from '@fluentui/react-popover';
 import type { PopoverSurface } from '@fluentui/react-popover';
 import type { PresenceBadge } from '@fluentui/react-badge';
+import type { PresenceBadgeBaseProps } from '@fluentui/react-badge';
 import { Provider } from 'react';
 import { ProviderProps } from 'react';
 import * as React_2 from 'react';
@@ -24,10 +25,15 @@ import type { TooltipProps } from '@fluentui/react-tooltip';
 export const Avatar: ForwardRefComponent<AvatarProps>;
 
 // @public (undocumented)
-export type AvatarBaseProps = ComponentProps<Omit<AvatarSlots, 'badge'>> & Pick<AvatarProps, 'name'>;
+export type AvatarBaseProps = ComponentProps<AvatarBaseSlots> & Pick<AvatarProps, 'active' | 'name'>;
 
 // @public (undocumented)
-export type AvatarBaseState = ComponentState<Omit<AvatarSlots, 'badge'>> & Pick<AvatarState, 'activeAriaLabelElement'>;
+export type AvatarBaseSlots = Omit<AvatarSlots, 'badge'> & {
+    badge?: Slot<PresenceBadgeBaseProps>;
+};
+
+// @public (undocumented)
+export type AvatarBaseState = ComponentState<AvatarBaseSlots> & Pick<AvatarState, 'active' | 'activeAriaLabelElement'>;
 
 // @public (undocumented)
 export const avatarClassNames: SlotClassNames<AvatarSlots>;

--- a/packages/react-components/react-avatar/library/src/Avatar.ts
+++ b/packages/react-components/react-avatar/library/src/Avatar.ts
@@ -6,6 +6,7 @@ export type {
   AvatarSize,
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
+  AvatarBaseSlots,
   AvatarSlots,
   AvatarBaseState,
   AvatarState,

--- a/packages/react-components/react-avatar/library/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/Avatar.types.ts
@@ -1,4 +1,4 @@
-import type { PresenceBadge } from '@fluentui/react-badge';
+import type { PresenceBadge, PresenceBadgeBaseProps } from '@fluentui/react-badge';
 import type { ComponentProps, ComponentState, JSXElement, Slot } from '@fluentui/react-utilities';
 
 /**
@@ -47,6 +47,13 @@ export type AvatarSlots = {
    * Badge to show the avatar's presence status.
    */
   badge?: Slot<typeof PresenceBadge>;
+};
+
+export type AvatarBaseSlots = Omit<AvatarSlots, 'badge'> & {
+  /**
+   * Badge to show the avatar's presence status.
+   */
+  badge?: Slot<PresenceBadgeBaseProps>;
 };
 
 /**
@@ -155,7 +162,7 @@ export type AvatarProps = Omit<ComponentProps<AvatarSlots>, 'color'> & {
   size?: AvatarSize;
 };
 
-export type AvatarBaseProps = ComponentProps<Omit<AvatarSlots, 'badge'>> & Pick<AvatarProps, 'name'>;
+export type AvatarBaseProps = ComponentProps<AvatarBaseSlots> & Pick<AvatarProps, 'active' | 'name'>;
 
 /**
  * State used in rendering Avatar
@@ -173,4 +180,4 @@ export type AvatarState = ComponentState<AvatarSlots> &
     activeAriaLabelElement?: JSXElement;
   };
 
-export type AvatarBaseState = ComponentState<Omit<AvatarSlots, 'badge'>> & Pick<AvatarState, 'activeAriaLabelElement'>;
+export type AvatarBaseState = ComponentState<AvatarBaseSlots> & Pick<AvatarState, 'active' | 'activeAriaLabelElement'>;

--- a/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/index.ts
@@ -6,6 +6,7 @@ export type {
   AvatarSize,
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   AvatarSizes,
+  AvatarBaseSlots,
   AvatarSlots,
   AvatarBaseState,
   AvatarState,

--- a/packages/react-components/react-avatar/library/src/components/Avatar/renderAvatar.tsx
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/renderAvatar.tsx
@@ -4,10 +4,10 @@
 import { assertSlots } from '@fluentui/react-utilities';
 import type { JSXElement } from '@fluentui/react-utilities';
 
-import type { AvatarSlots, AvatarBaseState } from './Avatar.types';
+import type { AvatarBaseSlots, AvatarBaseState } from './Avatar.types';
 
 export const renderAvatar_unstable = (state: AvatarBaseState): JSXElement => {
-  assertSlots<AvatarSlots>(state);
+  assertSlots<AvatarBaseSlots>(state);
 
   return (
     <state.root>

--- a/packages/react-components/react-avatar/library/src/components/Avatar/useAvatar.tsx
+++ b/packages/react-components/react-avatar/library/src/components/Avatar/useAvatar.tsx
@@ -20,7 +20,6 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   const {
     size = contextSize ?? (32 as const),
     shape = contextShape ?? 'circular',
-    active = 'unset',
     activeAppearance = 'ring',
     idForColor,
     color: propColor = 'neutral',
@@ -53,58 +52,15 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
   }
 
   const badge: AvatarState['badge'] = slot.optional(props.badge, {
-    defaultProps: { size: getBadgeSize(size), id: state.root.id + '__badge' },
+    defaultProps: { ...state.badge, size: getBadgeSize(size) },
     elementType: PresenceBadge,
   });
-
-  let activeAriaLabelElement: AvatarState['activeAriaLabelElement'] = state.activeAriaLabelElement;
-
-  // Enhance aria-label and/or aria-labelledby to include badge and active state
-  // Only process if aria attributes were not explicitly provided by the user
-  const userProvidedAriaLabel = props['aria-label'] !== undefined;
-  const userProvidedAriaLabelledby = props['aria-labelledby'] !== undefined;
-
-  if (!userProvidedAriaLabel && !userProvidedAriaLabelledby) {
-    if (props.name) {
-      if (badge) {
-        // eslint-disable-next-line react-hooks/immutability
-        state.root['aria-labelledby'] = state.root.id + ' ' + badge.id;
-      }
-    } else if (state.initials) {
-      // root's aria-label should be the name, but fall back to being labelledby the initials if name is missing
-      // eslint-disable-next-line react-hooks/immutability
-      state.root['aria-labelledby'] = state.initials.id + (badge ? ' ' + badge.id : '');
-      // eslint-disable-next-line react-hooks/immutability
-      delete state.root['aria-label'];
-    }
-    // Add the active state to the aria label
-    if (active === 'active' || active === 'inactive') {
-      const activeText = DEFAULT_STRINGS[active];
-      if (state.root['aria-labelledby']) {
-        // If using aria-labelledby, render a hidden span and append it to the labelledby
-        const activeId = state.root.id + '__active';
-        // eslint-disable-next-line react-hooks/immutability
-        state.root['aria-labelledby'] += ' ' + activeId;
-        activeAriaLabelElement = (
-          <span hidden id={activeId}>
-            {activeText}
-          </span>
-        );
-      } else if (state.root['aria-label']) {
-        // Otherwise, just append it to the aria-label
-        // eslint-disable-next-line react-hooks/immutability
-        state.root['aria-label'] += ' ' + activeText;
-      }
-    }
-  }
 
   return {
     ...state,
     size,
     shape,
-    active,
     activeAppearance,
-    activeAriaLabelElement,
     color,
     badge,
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -117,7 +73,7 @@ export const useAvatar_unstable = (props: AvatarProps, ref: React.Ref<HTMLElemen
  */
 export const useAvatarBase_unstable = (props: AvatarBaseProps, ref?: React.Ref<HTMLElement>): AvatarBaseState => {
   const { dir } = useFluent();
-  const { name, image: imageProp, initials: initialsProp, ...rest } = props;
+  const { name, image: imageProp, initials: initialsProp, badge, active = 'unset', ...rest } = props;
 
   const baseId = useId('avatar-');
 
@@ -176,25 +132,52 @@ export const useAvatarBase_unstable = (props: AvatarBaseProps, ref?: React.Ref<H
     });
   }
 
+  const badgeSlot: AvatarBaseState['badge'] = slot.optional(badge, {
+    defaultProps: { id: root.id + '__badge' },
+    elementType: 'div',
+  });
+
   let activeAriaLabelElement: AvatarBaseState['activeAriaLabelElement'];
 
-  // Resolve aria-label and/or aria-labelledby if not provided by the user
-  if (!root['aria-label'] && !root['aria-labelledby']) {
+  // Resolve aria-label and/or aria-labelledby, including the badge, if not provided by the user
+  const userProvidedAriaLabel = props['aria-label'] !== undefined;
+  const userProvidedAriaLabelledby = props['aria-labelledby'] !== undefined;
+  if (!userProvidedAriaLabel && !userProvidedAriaLabelledby) {
     if (name) {
       root['aria-label'] = name;
+      if (badgeSlot) {
+        root['aria-labelledby'] = root.id + ' ' + badgeSlot.id;
+      }
     } else if (initials) {
       // root's aria-label should be the name, but fall back to being labelledby the initials if name is missing
-      root['aria-labelledby'] = initials.id;
+      root['aria-labelledby'] = initials.id + (badgeSlot ? ' ' + badgeSlot.id : '');
+    }
+
+    if (active === 'active' || active === 'inactive') {
+      const activeText = DEFAULT_STRINGS[active];
+      if (root['aria-labelledby']) {
+        const activeId = root.id + '__active';
+        root['aria-labelledby'] += ' ' + activeId;
+        activeAriaLabelElement = (
+          <span hidden id={activeId}>
+            {activeText}
+          </span>
+        );
+      } else if (root['aria-label']) {
+        root['aria-label'] += ' ' + activeText;
+      }
     }
   }
 
   return {
+    active,
     activeAriaLabelElement,
-    components: { root: 'span', initials: 'span', icon: 'span', image: 'img' },
+    components: { root: 'span', initials: 'span', icon: 'span', image: 'img', badge: 'div' },
     root,
     initials,
     icon,
     image,
+    badge: badgeSlot,
   };
 };
 

--- a/packages/react-components/react-avatar/library/src/index.ts
+++ b/packages/react-components/react-avatar/library/src/index.ts
@@ -16,6 +16,7 @@ export type {
   AvatarSizes,
   AvatarSize,
   AvatarBaseProps,
+  AvatarBaseSlots,
   AvatarBaseState,
 } from './Avatar';
 export { getInitials, partitionAvatarGroupItems } from './utils/index';

--- a/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
+++ b/packages/react-components/react-headless-components-preview/library/etc/avatar.api.md
@@ -4,9 +4,9 @@
 
 ```ts
 
+import type { AvatarBaseState } from '@fluentui/react-avatar';
 import { AvatarBaseProps as AvatarProps } from '@fluentui/react-avatar';
-import { AvatarSlots } from '@fluentui/react-avatar';
-import { AvatarBaseState as AvatarState } from '@fluentui/react-avatar';
+import { AvatarBaseSlots as AvatarSlots } from '@fluentui/react-avatar';
 import type { ForwardRefComponent } from '@fluentui/react-utilities';
 import type * as React_2 from 'react';
 import { renderAvatar_unstable as renderAvatar } from '@fluentui/react-avatar';
@@ -19,7 +19,12 @@ export { AvatarProps }
 
 export { AvatarSlots }
 
-export { AvatarState }
+// @public (undocumented)
+export type AvatarState = AvatarBaseState & {
+    root: {
+        'data-active'?: string;
+    };
+};
 
 export { renderAvatar }
 

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/Avatar.test.tsx
@@ -16,5 +16,50 @@ describe('Avatar', () => {
     expect(avatar).toBeInTheDocument();
     expect(avatar).toHaveAttribute('aria-label', 'John Doe');
     expect(avatar).toHaveTextContent('JD');
+    expect(avatar).not.toHaveAttribute('data-active');
+  });
+
+  it.each(['active', 'inactive'] as const)('exposes and announces the %s state', active => {
+    const { getByRole } = render(<Avatar name="John Doe" active={active} />);
+
+    expect(getByRole('img')).toHaveAttribute('data-active', active);
+    expect(getByRole('img')).toHaveAttribute('aria-label', `John Doe ${active}`);
+  });
+
+  it('includes the badge in the accessible name', () => {
+    const { getByRole } = render(<Avatar id="avatar-id" name="John Doe" badge={{ id: 'badge-id', status: 'away' }} />);
+
+    expect(getByRole('img', { name: 'John Doe away' })).toHaveAttribute('aria-labelledby', 'avatar-id badge-id');
+    expect(getByRole('img', { name: 'away' })).toHaveAttribute('data-status', 'away');
+  });
+
+  it('preserves an explicit accessible name when a badge is present', () => {
+    const { getAllByRole } = render(
+      <Avatar aria-label="Custom avatar label" name="John Doe" active="active" badge={{}} />,
+    );
+
+    expect(getAllByRole('img')[0]).toHaveAttribute('aria-label', 'Custom avatar label');
+    expect(getAllByRole('img')[0]).not.toHaveAttribute('aria-labelledby');
+    expect(getAllByRole('img')[0]).toHaveAttribute('data-active', 'active');
+  });
+
+  it('preserves an explicit aria-labelledby when active state and a badge are present', () => {
+    const { getByTestId, container } = render(
+      <>
+        <span id="custom-avatar-label">Custom avatar label</span>
+        <Avatar
+          data-testid="avatar"
+          id="avatar-id"
+          aria-labelledby="custom-avatar-label"
+          name="John Doe"
+          active="active"
+          badge={{ id: 'badge-id' }}
+        />
+      </>,
+    );
+
+    expect(getByTestId('avatar')).toHaveAttribute('aria-labelledby', 'custom-avatar-label');
+    expect(getByTestId('avatar')).not.toHaveAttribute('aria-label');
+    expect(container.querySelector('#avatar-id__active')).toBeNull();
   });
 });

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/Avatar.types.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/Avatar.types.ts
@@ -1,5 +1,12 @@
-export type {
-  AvatarSlots,
-  AvatarBaseProps as AvatarProps,
-  AvatarBaseState as AvatarState,
-} from '@fluentui/react-avatar';
+import type { AvatarBaseState } from '@fluentui/react-avatar';
+
+export type { AvatarBaseProps as AvatarProps, AvatarBaseSlots as AvatarSlots } from '@fluentui/react-avatar';
+
+export type AvatarState = AvatarBaseState & {
+  root: {
+    /**
+     * Data attribute set when the avatar is active or inactive.
+     */
+    'data-active'?: string;
+  };
+};

--- a/packages/react-components/react-headless-components-preview/library/src/components/Avatar/useAvatar.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Avatar/useAvatar.ts
@@ -2,15 +2,31 @@
 
 import type * as React from 'react';
 import { useAvatarBase_unstable } from '@fluentui/react-avatar';
+import { slot } from '@fluentui/react-utilities';
 
 import type { AvatarProps, AvatarState } from './Avatar.types';
+import { PresenceBadge } from '../../badge';
+import { toDataAttributeValue } from '../../utils';
 
 /**
  * Returns the state for an Avatar component, given its props and ref.
  * The returned state can be modified with hooks before being passed to `renderAvatar`.
  */
 export const useAvatar = (props: AvatarProps, ref: React.Ref<HTMLElement>): AvatarState => {
-  const state: AvatarState = useAvatarBase_unstable(props, ref);
+  const baseState = useAvatarBase_unstable(props, ref);
+
+  const state: AvatarState = {
+    ...baseState,
+    components: { root: 'span', initials: 'span', icon: 'span', image: 'img', badge: PresenceBadge },
+    root: {
+      ...baseState.root,
+      'data-active': toDataAttributeValue(baseState.active !== 'unset' && baseState.active),
+    },
+    badge: slot.optional(props.badge, {
+      defaultProps: baseState.badge,
+      elementType: PresenceBadge,
+    }),
+  };
 
   return state;
 };

--- a/packages/react-components/react-headless-components-preview/stories/src/Avatar/AvatarDefault.stories.tsx
+++ b/packages/react-components/react-headless-components-preview/stories/src/Avatar/AvatarDefault.stories.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
+import { PresenceAvailableFilled } from '@fluentui/react-icons';
+
 import { Avatar } from '@fluentui/react-headless-components-preview/avatar';
 
 import styles from './avatar.module.css';
+import presenceBadgeStyles from '../PresenceBadge/presence-badge.module.css';
+
 export const Default = (): React.ReactNode => (
   <div className={styles.demo}>
     <div className={styles.demoRow}>
@@ -32,7 +36,15 @@ export const Default = (): React.ReactNode => (
     </div>
 
     <div className={styles.row}>
-      <Avatar name="Eve Park" className={`${styles.avatar} ${styles.size40} ${styles.tone3}`} />
+      <Avatar
+        name="Eve Park"
+        className={`${styles.avatar} ${styles.size40} ${styles.tone3}`}
+        badge={{
+          className: `${styles.badge} ${presenceBadgeStyles.presenceBadge}`,
+          status: 'available',
+          icon: { className: presenceBadgeStyles.presenceIcon, children: <PresenceAvailableFilled /> },
+        }}
+      />
       <div className={styles.meta}>
         <span className={styles.metaName}>Eve Park</span>
         <span className={styles.metaSub}>Product designer · Online</span>

--- a/packages/react-components/react-headless-components-preview/stories/src/Avatar/avatar.module.css
+++ b/packages/react-components/react-headless-components-preview/stories/src/Avatar/avatar.module.css
@@ -7,7 +7,6 @@
   color: var(--accent-contrast);
   font-weight: 600;
   position: relative;
-  overflow: hidden;
   flex-shrink: 0;
   user-select: none;
   letter-spacing: 0;
@@ -43,6 +42,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  border-radius: 50%;
 }
 
 .initials {
@@ -103,6 +103,12 @@
 .metaSub {
   color: var(--text-muted);
   font-size: 12.5px;
+}
+
+.badge {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline-end: 0;
 }
 
 /* Demo helpers (used by Storybook examples) */


### PR DESCRIPTION
This pull request adds badge support to the Avatar components in both `@fluentui/react-avatar` and `@fluentui/react-headless-components-preview`, allowing avatars to display presence or status badges. It includes changes to the component props and state types, updates to the hooks to handle badges, and updates to the Storybook example and CSS for proper badge positioning and styling.

**Avatar Badge Support**

* Updated `AvatarBaseProps` and `AvatarBaseState` types in `Avatar.types.ts` to include the `badge` slot, enabling badge support in base hooks. [[1]](diffhunk://#diff-1c98ab4928f5b611af0e90691766180cfc58edcf048637c52d378daf56e7dc92L158-R158) [[2]](diffhunk://#diff-1c98ab4928f5b611af0e90691766180cfc58edcf048637c52d378daf56e7dc92L176-R176)
* Modified `useAvatar_unstable` and `useAvatarBase_unstable` in `useAvatar.tsx` to handle the `badge` slot, passing badge props and rendering logic. [[1]](diffhunk://#diff-6c205d5cd26cde2e39cb14934153dbdf33d400903f58ce685c839ddac18fc58bL56-R56) [[2]](diffhunk://#diff-6c205d5cd26cde2e39cb14934153dbdf33d400903f58ce685c839ddac18fc58bL120-R120) [[3]](diffhunk://#diff-6c205d5cd26cde2e39cb14934153dbdf33d400903f58ce685c839ddac18fc58bL193-R201)
* Updated the headless Avatar hook in `useAvatar.ts` to integrate the badge slot using `PresenceBadge` and the `slot.optional` utility. [[1]](diffhunk://#diff-7e9aea9ba9d268f818d2a43e378d23a16be36c8148e6ddcc82af8daaf7bb9528R5-R8) [[2]](diffhunk://#diff-7e9aea9ba9d268f818d2a43e378d23a16be36c8148e6ddcc82af8daaf7bb9528L15-R24)

**Storybook and Styling**

* Enhanced the Storybook example in `AvatarDefault.stories.tsx` to demonstrate the new badge feature, including usage of the `PresenceAvailableFilled` icon and appropriate class names. [[1]](diffhunk://#diff-360e97561e3d60b291e128d8766b22ebdd7aa1e3ba3a1e3d77dff234cf3caf8cR2-R8) [[2]](diffhunk://#diff-360e97561e3d60b291e128d8766b22ebdd7aa1e3ba3a1e3d77dff234cf3caf8cL35-R47)
* Updated CSS in `avatar.module.css` to add `.badge` positioning and ensure avatar images are fully rounded for a consistent look with badges. [[1]](diffhunk://#diff-fc056fed51122e47e3e7e558757c471c4c58bb13ce887724459bbf178e4e571aR45) [[2]](diffhunk://#diff-fc056fed51122e47e3e7e558757c471c4c58bb13ce887724459bbf178e4e571aR108-R113) [[3]](diffhunk://#diff-fc056fed51122e47e3e7e558757c471c4c58bb13ce887724459bbf178e4e571aL10)
