### PR TITLE
fix(merge-styles): contain server-rendered CSS output

### DIFF
--- a/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
+++ b/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Normalize declaration value serialization in merge-styles.",
+  "comment": "fix(merge-styles): normalize declaration value serialization.",
   "packageName": "@fluentui/merge-styles",
   "email": "paulmardling@microsoft.com"
 }

--- a/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
+++ b/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Normalize declaration value serialization in merge-styles.",
+  "packageName": "@fluentui/merge-styles",
+  "email": "paulmardling@microsoft.com"
+}

--- a/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
+++ b/change/@fluentui-merge-styles-6233b26c-88b5-4e77-b69c-cf9baf7d76dd.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix(merge-styles): normalize declaration value serialization.",
+  "comment": "fix(merge-styles): contain serialized CSS output for server rendering.",
   "packageName": "@fluentui/merge-styles",
   "email": "paulmardling@microsoft.com"
 }

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -485,11 +485,11 @@ renderStatic(() => ReactDOM.renderToString(<App/>);
 
 - Rehydration on the client may result in mismatched rules. You can apply a namespace on the server side to ensure there aren't name collisions.
 
-### Untrusted data in style values
+### Untrusted style data
 
-The `css` returned by `renderStatic` (and by `Stylesheet.getRules`) is raw CSS text that is normally written into a `<style>` element. A `<style>` element is HTML raw text, so a declaration value containing `</style>` would otherwise terminate it and inject markup.
+The `css` returned by `renderStatic` (and by `Stylesheet.getRules`) is raw CSS text that is normally written into a `<style>` element. A `<style>` element is HTML raw text, so a case-insensitive `</style` sequence would otherwise terminate it and inject markup.
 
-To prevent that, `merge-styles` emits `<` and `>` inside declaration values as the CSS code point escapes `\3C ` and `\3E `. This is semantics-preserving - the escapes decode back to the same characters, including inside quoted strings and `url()`. Likewise, `Stylesheet.serialize` emits `<` as `\u003C` so its output can be embedded in an inline `<script>` for rehydration.
+To prevent that, `merge-styles` escapes these sequences at the CSS serialization boundary. Declaration values also emit `<` and `>` as the CSS code point escapes `\3C ` and `\3E `. These escapes are semantics-preserving and decode back to the same characters without changing selectors, combinators, at-rules, custom properties, or keyframe syntax. Likewise, `Stylesheet.serialize` emits `<` as `\u003C` so its output can be embedded in an inline `<script>` for rehydration.
 
 This escaping is defense in depth, not a substitute for validating input. Applications remain responsible for:
 

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -4,10 +4,7 @@
 import { IStyle } from './IStyle';
 import { GLOBAL_STYLESHEET_KEY, SHADOW_DOM_STYLESHEET_SETTING } from './shadowConfig';
 import type { ShadowConfig } from './shadowConfig';
-
-function escapeStyleTagTerminator(css: string): string {
-  return css.replace(/<(?=\/style)/gi, '\\3C ');
-}
+import { escapeStyleTagTerminator } from './escapeForStyleTag';
 
 export const InjectionMode = {
   /**

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -5,6 +5,10 @@ import { IStyle } from './IStyle';
 import { GLOBAL_STYLESHEET_KEY, SHADOW_DOM_STYLESHEET_SETTING } from './shadowConfig';
 import type { ShadowConfig } from './shadowConfig';
 
+function escapeStyleTagTerminator(css: string): string {
+  return css.replace(/<(?=\/style)/gi, '\\3C ');
+}
+
 export const InjectionMode = {
   /**
    * Avoids style injection, use getRules() to read the styles.
@@ -374,12 +378,13 @@ export class Stylesheet {
    * Gets all rules registered with the stylesheet; only valid when
    * using InsertionMode.none.
    *
-   * The return value is raw CSS text intended for a `<style>` element. Values that went through
-   * `mergeStyles`, `fontFace` or `keyframes` have `<` and `>` escaped as CSS code points so they
-   * cannot terminate that element, but rules added via {@link Stylesheet.insertRule} are unescaped.
+   * The return value is raw CSS text intended for a `<style>` element. Any case-insensitive
+   * `</style` sequence is escaped at this serialization boundary without changing other CSS syntax.
    */
   public getRules(includePreservedRules?: boolean): string {
-    return (includePreservedRules ? this._preservedRules.join('') : '') + this._rules.join('');
+    const rules = (includePreservedRules ? this._preservedRules.join('') : '') + this._rules.join('');
+
+    return escapeStyleTagTerminator(rules);
   }
 
   /**

--- a/packages/merge-styles/src/escapeForStyleTag.test.ts
+++ b/packages/merge-styles/src/escapeForStyleTag.test.ts
@@ -1,0 +1,29 @@
+import { escapeForStyleTag, escapeStyleTagTerminator } from './escapeForStyleTag';
+
+describe('style tag escaping', () => {
+  const backslash = '\\';
+  const increasingRunLengths = [5000, 10000, 20000];
+
+  it.each(increasingRunLengths)('handles a long nonmatching backslash run of length %s', runLength => {
+    const value = new Array(runLength + 1).join(backslash) + 'x';
+
+    expect(escapeForStyleTag(value)).toBe(value);
+    expect(escapeStyleTagTerminator(value)).toBe(value);
+  });
+
+  it.each(increasingRunLengths)('handles a long matching backslash run of length %s', runLength => {
+    const backslashes = new Array(runLength + 1).join(backslash);
+
+    expect(escapeForStyleTag(`${backslashes}</style>`)).toBe(`${backslashes}${backslash}3C /style${backslash}3E `);
+    expect(escapeStyleTagTerminator(`${backslashes}</StYlE>`)).toBe(`${backslashes}${backslash}3C /StYlE>`);
+  });
+
+  it('preserves odd and even runs around mixed characters', () => {
+    expect(escapeForStyleTag(`a${backslash}<b${backslash}${backslash}>c`)).toBe(
+      `a${backslash}3C b${backslash}${backslash}${backslash}3E c`,
+    );
+    expect(escapeStyleTagTerminator(`a${backslash}</STYLE>b${backslash}${backslash}</style>c`)).toBe(
+      `a${backslash}3C /STYLE>b${backslash}${backslash}${backslash}3C /style>c`,
+    );
+  });
+});

--- a/packages/merge-styles/src/escapeForStyleTag.ts
+++ b/packages/merge-styles/src/escapeForStyleTag.ts
@@ -1,0 +1,22 @@
+const CSS_ESCAPE_MAP: Record<string, string> = {
+  '<': '\\3C ',
+  '>': '\\3E ',
+};
+
+function escapeCssCharacter(backslashes: string, character: string): string {
+  // An odd final backslash already escapes the character, so replace that pair rather than
+  // appending another escape. Even runs represent literal backslashes and must be retained.
+  const preservedBackslashes = backslashes.length % 2 === 0 ? backslashes : backslashes.slice(1);
+
+  return preservedBackslashes + CSS_ESCAPE_MAP[character];
+}
+
+export function escapeForStyleTag(value: string): string {
+  return value.replace(/(\\*)([<>])/g, (_match, backslashes: string, character: string) =>
+    escapeCssCharacter(backslashes, character),
+  );
+}
+
+export function escapeStyleTagTerminator(css: string): string {
+  return css.replace(/(\\*)<(?=\/style)/gi, (_match, backslashes: string) => escapeCssCharacter(backslashes, '<'));
+}

--- a/packages/merge-styles/src/escapeForStyleTag.ts
+++ b/packages/merge-styles/src/escapeForStyleTag.ts
@@ -3,20 +3,47 @@ const CSS_ESCAPE_MAP: Record<string, string> = {
   '>': '\\3E ',
 };
 
-function escapeCssCharacter(backslashes: string, character: string): string {
-  // An odd final backslash already escapes the character, so replace that pair rather than
-  // appending another escape. Even runs represent literal backslashes and must be retained.
-  const preservedBackslashes = backslashes.length % 2 === 0 ? backslashes : backslashes.slice(1);
+type ShouldEscape = (value: string, index: number, character: string) => boolean;
 
-  return preservedBackslashes + CSS_ESCAPE_MAP[character];
+function escapeCssCharacters(value: string, shouldEscape: ShouldEscape): string {
+  let backslashCount = 0;
+  let chunkStart = 0;
+  let result: string[] | undefined;
+
+  for (let i = 0; i < value.length; i++) {
+    const character = value.charAt(i);
+
+    if (character === '\\') {
+      backslashCount++;
+      continue;
+    }
+
+    if (shouldEscape(value, i, character)) {
+      result = result || [];
+      // An odd final backslash already escapes this character, so omit that backslash before
+      // emitting the equivalent code-point escape. Even runs represent literal backslashes.
+      result.push(value.slice(chunkStart, i - (backslashCount % 2)), CSS_ESCAPE_MAP[character]);
+      chunkStart = i + 1;
+    }
+
+    backslashCount = 0;
+  }
+
+  if (!result) {
+    return value;
+  }
+
+  result.push(value.slice(chunkStart));
+  return result.join('');
 }
 
 export function escapeForStyleTag(value: string): string {
-  return value.replace(/(\\*)([<>])/g, (_match, backslashes: string, character: string) =>
-    escapeCssCharacter(backslashes, character),
-  );
+  return escapeCssCharacters(value, (_value, _index, character) => character === '<' || character === '>');
 }
 
 export function escapeStyleTagTerminator(css: string): string {
-  return css.replace(/(\\*)<(?=\/style)/gi, (_match, backslashes: string) => escapeCssCharacter(backslashes, '<'));
+  return escapeCssCharacters(
+    css,
+    (value, index, character) => character === '<' && value.slice(index + 1, index + 7).toLowerCase() === '/style',
+  );
 }

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -126,4 +126,21 @@ describe('staticRender', () => {
     expect(css).toContain(`.odd{content:"${backslash}3C /StYlE>"}`);
     expect(css).toContain(`.even{content:"${backslash}${backslash}${backslash}3C /style>"}`);
   });
+
+  it.each([5000, 10000, 20000])(
+    'contains increasing backslash runs of length %s in raw server-rendered rules',
+    runLength => {
+      const stylesheet = Stylesheet.getInstance();
+      const backslashes = new Array(runLength + 1).join('\\');
+
+      stylesheet.insertRule(`.nonmatching{content:"${backslashes}x"}`);
+      stylesheet.insertRule(`.matching{content:"${backslashes}</style>"}`);
+
+      const css = stylesheet.getRules();
+
+      expect(css).toContain(`.nonmatching{content:"${backslashes}x"}`);
+      expect(css).toContain(`.matching{content:"${backslashes}\\3C /style>"}`);
+      expect(css).not.toMatch(/<\/style/i);
+    },
+  );
 });

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -1,6 +1,7 @@
 import { renderStatic } from './server';
 import { mergeCssSets } from './mergeStyleSets';
 import { keyframes } from './keyframes';
+import { Stylesheet } from './Stylesheet';
 
 describe('staticRender', () => {
   it('can render content', () => {
@@ -110,5 +111,19 @@ describe('staticRender', () => {
     expect(css).toContain('@media (width < 1000px)');
     expect(css).toContain('--custom-property:value;');
     expect(css).toContain('from{opacity:0;}50%{opacity:0.5;}to{opacity:1;}');
+  });
+
+  it('preserves odd and even backslash escape parity in raw server-rendered rules', () => {
+    const stylesheet = Stylesheet.getInstance();
+    const backslash = '\\';
+
+    stylesheet.insertRule(`.odd{content:"${backslash}</StYlE>"}`);
+    stylesheet.insertRule(`.even{content:"${backslash}${backslash}</style>"}`);
+
+    const css = stylesheet.getRules();
+
+    expect(css).not.toMatch(/<\/style/i);
+    expect(css).toContain(`.odd{content:"${backslash}3C /StYlE>"}`);
+    expect(css).toContain(`.even{content:"${backslash}${backslash}${backslash}3C /style>"}`);
   });
 });

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -1,5 +1,6 @@
 import { renderStatic } from './server';
 import { mergeCssSets } from './mergeStyleSets';
+import { keyframes } from './keyframes';
 
 describe('staticRender', () => {
   it('can render content', () => {
@@ -51,5 +52,63 @@ describe('staticRender', () => {
 
     expect(css).not.toContain('</style');
     expect(css).not.toContain('<script');
+  });
+
+  it('contains style element terminators in structural CSS positions', () => {
+    const { css } = renderStatic(() => {
+      mergeCssSets([
+        {
+          root: {
+            selectors: {
+              '&</STYLE>.selector-sentinel': { color: 'red' },
+            },
+            'color</style>-property-sentinel': 'red',
+            '--custom</StYlE>-property-sentinel': 'value',
+          },
+        },
+      ]);
+      keyframes({
+        '50%</sTyLe>.keyframe-sentinel': { opacity: 0.5 },
+      });
+
+      return '';
+    });
+
+    expect(css).not.toMatch(/<\/style/i);
+    expect(css).toContain('\\3C /STYLE');
+    expect(css).toContain('\\3C /style');
+    expect(css).toContain('\\3C /StYlE');
+    expect(css).toContain('\\3C /sTyLe');
+    expect(css).toContain('selector-sentinel');
+    expect(css).toContain('property-sentinel');
+    expect(css).toContain('keyframe-sentinel');
+  });
+
+  it('preserves valid structural CSS syntax', () => {
+    const { css } = renderStatic(() => {
+      mergeCssSets([
+        {
+          root: {
+            '--custom-property': 'value',
+            selectors: {
+              '& > .child': { color: 'red' },
+              '@media (width < 1000px)': { color: 'blue' },
+            },
+          },
+        },
+      ]);
+      keyframes({
+        from: { opacity: 0 },
+        '50%': { opacity: 0.5 },
+        to: { opacity: 1 },
+      });
+
+      return '';
+    });
+
+    expect(css).toContain(' > .child');
+    expect(css).toContain('@media (width < 1000px)');
+    expect(css).toContain('--custom-property:value;');
+    expect(css).toContain('from{opacity:0;}50%{opacity:0.5;}to{opacity:1;}');
   });
 });

--- a/packages/merge-styles/src/server.ts
+++ b/packages/merge-styles/src/server.ts
@@ -3,9 +3,9 @@ import { InjectionMode, Stylesheet } from './Stylesheet';
 /**
  * Renders a given string and returns both html and css needed for the html.
  *
- * The returned `css` is raw CSS text meant to be placed in a `<style>` element. Declaration values
- * have `<` and `>` escaped as CSS code points so they cannot terminate that element, but callers
- * remain responsible for validating untrusted data used in style values.
+ * The returned `css` is raw CSS text meant to be placed in a `<style>` element. Sequences that
+ * could terminate that element are escaped as CSS code points, but callers remain responsible for
+ * validating untrusted style data.
  *
  * @param onRender - Function that returns a string.
  * @param namespace - Optional namespace to prepend to css classnames to avoid collisions.

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -681,6 +681,15 @@ describe('styleToClassName with specificityMultiplier', () => {
       );
     });
 
+    it.each([5000, 10000, 20000])('serializes increasing backslash runs of length %s', runLength => {
+      const backslashes = new Array(runLength + 1).join('\\');
+
+      expect(serializeRuleEntries({}, { content: `${backslashes}x` })).toBe(`content:${backslashes}x;`);
+      expect(serializeRuleEntries({}, { content: `${backslashes}</style>` })).toBe(
+        `content:${backslashes}\\3C /style\\3E ;`,
+      );
+    });
+
     it('does not escape selectors, so combinators keep working', () => {
       styleToClassName(
         {},

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -1,5 +1,5 @@
 import { InjectionMode, Stylesheet } from './Stylesheet';
-import { styleToClassName } from './styleToClassName';
+import { serializeRuleEntries, styleToClassName } from './styleToClassName';
 import { IStyleOptions } from './IStyleOptions';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
@@ -606,6 +606,36 @@ describe('styleToClassName with specificityMultiplier', () => {
 
   describe('style tag escaping', () => {
     const payload = 'red;}</style><script>alert(1)</script><style>.x{color:red';
+
+    it('preserves supported string and number serialization', () => {
+      expect(
+        serializeRuleEntries(
+          {},
+          {
+            color: 'red',
+            marginTop: 2,
+            opacity: 0.5,
+            '--scale': 3,
+          },
+        ),
+      ).toEqual('color:red;margin-top:2px;opacity:0.5;--scale:3;');
+    });
+
+    it('escapes angle brackets after array values are coerced', () => {
+      const entries = { fontFamily: ['Arial', '<fallback>'] } as unknown as Record<string, string | number>;
+
+      expect(serializeRuleEntries({}, entries)).toEqual('font-family:Arial,\\3C fallback\\3E ;');
+    });
+
+    it('escapes angle brackets after custom string coercion', () => {
+      const value = {
+        toString: jest.fn(() => '<custom>'),
+      };
+      const entries = { color: value } as unknown as Record<string, string | number>;
+
+      expect(serializeRuleEntries({}, entries)).toEqual('color:\\3C custom\\3E ;');
+      expect(value.toString).toHaveBeenCalledTimes(1);
+    });
 
     it.each(['fill', 'background', 'color', 'content', 'fontFamily', 'backgroundImage'] as const)(
       'escapes a value that would terminate the style element in %s',

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -657,6 +657,30 @@ describe('styleToClassName with specificityMultiplier', () => {
       expect(_stylesheet.getRules()).toEqual('.css-0{content:"a\\3C b\\3E c";}');
     });
 
+    it('preserves odd backslash escape parity in declaration values', () => {
+      const backslash = '\\';
+
+      expect(serializeRuleEntries({}, { content: `"${backslash}</style${backslash}>"` })).toEqual(
+        `content:"${backslash}3C /style${backslash}3E ";`,
+      );
+    });
+
+    it('preserves even backslash escape parity in declaration values', () => {
+      const backslash = '\\';
+
+      expect(
+        serializeRuleEntries({}, { content: `"${backslash}${backslash}</style${backslash}${backslash}>"` }),
+      ).toEqual(`content:"${backslash}${backslash}${backslash}3C /style${backslash}${backslash}${backslash}3E ";`);
+    });
+
+    it('preserves backslash escape parity in URLs', () => {
+      const backslash = '\\';
+
+      expect(serializeRuleEntries({}, { backgroundImage: `url("${backslash}</style${backslash}>")` })).toEqual(
+        `background-image:url("${backslash}3C /style${backslash}3E ");`,
+      );
+    });
+
     it('does not escape selectors, so combinators keep working', () => {
       styleToClassName(
         {},

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -10,6 +10,7 @@ import { rtlifyRules } from './transforms/rtlifyRules';
 import { IStyleOptions } from './IStyleOptions';
 import { tokenizeWithParentheses } from './tokenizeWithParentheses';
 import { ShadowConfig } from './shadowConfig';
+import { escapeForStyleTag } from './escapeForStyleTag';
 
 const DISPLAY_NAME = 'displayName';
 
@@ -222,25 +223,6 @@ function repeatString(target: string, count: number): string {
   }
 
   return target + repeatString(target, count - 1);
-}
-
-const CSS_ESCAPE_MAP: Record<string, string> = {
-  '<': '\\3C ',
-  '>': '\\3E ',
-};
-
-/**
- * Escapes characters that could break out of a `<style>` element during server side rendering.
- *
- * A `<style>` element is HTML raw text, so the only thing that terminates it is the literal
- * sequence `</style`. Emitting `<` and `>` as CSS code point escapes keeps the declaration
- * semantically identical (including inside quoted strings and `url()`) while making it
- * impossible for the HTML tokenizer to see a tag.
- *
- * IMPORTANT: only apply this to declaration *values*. Selectors legitimately contain `>`.
- */
-function escapeForStyleTag(value: string): string {
-  return value.replace(/[<>]/g, match => CSS_ESCAPE_MAP[match]);
 }
 
 export function serializeRuleEntries(options: IStyleOptions, ruleEntries: { [key: string]: string | number }): string {

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -266,9 +266,9 @@ export function serializeRuleEntries(options: IStyleOptions, ruleEntries: { [key
 
   // Apply punctuation.
   for (let i = 1; i < allEntries.length; i += 4) {
-    const value = allEntries[i];
+    const value = String(allEntries[i]);
 
-    allEntries.splice(i, 1, ':', typeof value === 'string' ? escapeForStyleTag(value) : value, ';');
+    allEntries.splice(i, 1, ':', escapeForStyleTag(value), ';');
   }
 
   return allEntries.join('');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [ ] Your changes are covered by tests (if possible)
* [ ] You've run `yarn change` locally


PR flow tips:
* [ ] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Declaration values were normalized during serialization, but structural CSS entries did not receive final output containment for server rendering.

## New Behavior

Declaration values remain normalized before serialization, and CSS returned for server rendering now applies narrow final containment across declaration and structural entries. A single-pass scanner preserves CSS escape parity for consecutive backslashes without repeated regex retries, while existing selectors, combinators, at-rules, custom properties, keyframes, strings, URLs, browser insertion, callbacks, and cache behavior remain unchanged.

Focused regression coverage includes declaration values, selectors, ordinary and custom property names, keyframe step names, case variants, odd and even backslash runs, long matching and nonmatching runs, URLs, and valid structural CSS syntax.

## Related Issue(s)

- Internal tracking only.

## Validation

- `yarn nx run merge-styles:code-style`
- `yarn nx run merge-styles:test`
- `yarn nx run merge-styles:build`
- `yarn nx run merge-styles:lint`
- `yarn check:change --branch origin/master --no-fetch`