### PR TITLE
fix(react-charts): preserve grouped chart category and series names

### DIFF
--- a/change/@fluentui-react-charts-4cf8158b-99a6-4a15-be4a-32361805e4ac.json
+++ b/change/@fluentui-react-charts-4cf8158b-99a6-4a15-be4a-32361805e4ac.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "Handle grouped chart category and series names consistently",
+  "packageName": "@fluentui/react-charts",
+  "email": "paulmardling@microsoft.com"
+}

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
@@ -59,14 +59,12 @@ const X1_INNER_PADDING = 0.1;
 const VERTICAL_BAR_GAP = 1;
 const MIN_BAR_HEIGHT = 1;
 
-// This interface used for - While forming datapoints from given prop "data" in code
-interface GVDataPoint {
-  [key: string]: number | string;
-}
-
-// While forming datapoints from given prop "data" in code. These datapoints are used for to draw graph easily.
-interface GVSingleDataPoint {
-  [key: string]: GVDataPoint;
+interface GVSingleDatasetPoint {
+  barPointsByLegend: Record<string, GVBarChartSeriesPoint[]>;
+  groupSeries: YValueHover[];
+  indexNum: number;
+  stackCallOutAccessibilityData?: AccessibilityProps;
+  xAxisPoint: string;
 }
 
 type GVBCLineSeries = LineSeries<string, number>;
@@ -84,7 +82,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   const _useRtl: boolean = useRtl();
   let _domainMargin: number = MIN_DOMAIN_MARGIN;
   let _xAxisLabels: string[] = [];
-  let _datasetForBars: any[] = [];
+  let _datasetForBars: GVSingleDatasetPoint[] = [];
   let _margins: Margins = { top: 0, right: 0, bottom: 0, left: 0 };
   let _groupedVerticalBarGraph: JSXElement[] = [];
   let _yMax: number = 0;
@@ -138,8 +136,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _createDataset = (barData: GroupedVerticalBarChartData[], lineData: GVBCLineSeries[]) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const datasetForBars: any = [];
+    const datasetForBars: GVSingleDatasetPoint[] = [];
 
     const linePointsByX: Record<string, YValueHover[]> = Object.create(null);
     const visitedX = new Set<string>();
@@ -159,35 +156,35 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
     });
 
     barData.forEach((point: GroupedVerticalBarChartData, index: number) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const singleDatasetPointForBars: any = Object.create(null);
+      const barPointsByLegend: Record<string, GVBarChartSeriesPoint[]> = Object.create(null);
       const legendToBarPoint: Record<string, GVBarChartSeriesPoint> = Object.create(null);
 
       point.series.forEach((seriesPoint: GVBarChartSeriesPoint) => {
-        if (!singleDatasetPointForBars[seriesPoint.legend]) {
-          singleDatasetPointForBars[seriesPoint.legend] = [{ ...seriesPoint }];
+        if (!barPointsByLegend[seriesPoint.legend]) {
+          barPointsByLegend[seriesPoint.legend] = [{ ...seriesPoint }];
           legendToBarPoint[seriesPoint.legend] = { ...seriesPoint };
         } else {
-          singleDatasetPointForBars[seriesPoint.legend].push({ ...seriesPoint });
+          barPointsByLegend[seriesPoint.legend].push({ ...seriesPoint });
           legendToBarPoint[seriesPoint.legend].data += seriesPoint.data;
         }
       });
 
-      singleDatasetPointForBars.xAxisPoint = point.name;
-      singleDatasetPointForBars.indexNum = index;
-      singleDatasetPointForBars.groupSeries = [
-        ...Object.values(legendToBarPoint),
-        ...(linePointsByX[point.name] ?? []),
-      ];
-      singleDatasetPointForBars.stackCallOutAccessibilityData = point.stackCallOutAccessibilityData;
-      datasetForBars.push(singleDatasetPointForBars);
+      datasetForBars.push({
+        barPointsByLegend,
+        xAxisPoint: point.name,
+        indexNum: index,
+        groupSeries: [...Object.values(legendToBarPoint), ...(linePointsByX[point.name] ?? [])],
+        stackCallOutAccessibilityData: point.stackCallOutAccessibilityData,
+      });
       visitedX.add(point.name);
     });
 
     Object.keys(linePointsByX).forEach(xPoint => {
       if (!visitedX.has(xPoint)) {
         datasetForBars.push({
+          barPointsByLegend: Object.create(null),
           xAxisPoint: xPoint,
+          indexNum: datasetForBars.length,
           groupSeries: linePointsByX[xPoint],
         });
       }
@@ -475,7 +472,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
 
     const xScale1 = _createX1Scale();
     const allGroupsBars: JSXElement[] = [];
-    _datasetForBars.forEach((singleSet: GVSingleDataPoint) => {
+    _datasetForBars.forEach(singleSet => {
       allGroupsBars.push(
         _buildGraph(singleSet, xScale0, xScale1, yScalePrimary, yScaleSecondary, containerHeight, xElement!),
       );
@@ -519,8 +516,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _buildGraph = (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    singleSet: any,
+    singleSet: GVSingleDatasetPoint,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     xScale0: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -534,7 +530,9 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
     const barLabelsForGroup: JSXElement[] = [];
 
     // Get the actual legends present at this x-axis point
-    const presentLegends = _barLegends.filter(key => Object.prototype.hasOwnProperty.call(singleSet, key));
+    const presentLegends = _barLegends.filter(key =>
+      Object.prototype.hasOwnProperty.call(singleSet.barPointsByLegend, key),
+    );
     const effectiveGroupWidth = calcRequiredWidth(_barWidth, presentLegends.length, X1_INNER_PADDING);
 
     // For stacked bars, center the single bar group in the available space
@@ -544,7 +542,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
       .range(_useRtl ? [effectiveGroupWidth, 0] : [0, effectiveGroupWidth])
       .paddingInner(X1_INNER_PADDING);
     _barLegends.forEach((legendTitle: string, legendIndex: number) => {
-      const barPoints = singleSet[legendTitle];
+      const barPoints = singleSet.barPointsByLegend[legendTitle];
       if (barPoints) {
         const yBarScale = barPoints[0].useSecondaryYScale && yScaleSecondary ? yScaleSecondary : yScalePrimary;
 
@@ -955,7 +953,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
       data: point.y,
       yAxisCalloutData: point.yAxisCalloutData as string | undefined,
     };
-    const groupData = _datasetForBars.find((singleSet: { xAxisPoint: string }) => singleSet.xAxisPoint === point.x);
+    const groupData = _datasetForBars.find(singleSet => singleSet.xAxisPoint === point.x);
 
     _showCallout(target, pointData, groupData, _getDotId(seriesIdx, pointIdx));
   };

--- a/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
+++ b/packages/charts/react-charts/library/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
@@ -95,7 +95,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   let _xAxisOuterPadding: number = 0;
   let _barLegends: string[] = [];
   let _lineLegends: string[] = [];
-  let _legendColorMap: Record<string, [string, string]> = {};
+  let _legendColorMap: Record<string, [string, string]> = Object.create(null);
   const { cartesianChartRef, legendsRef: _legendsRef } = useImageExport(props.componentRef, props.hideLegend);
   const Y_ORIGIN: number = 0;
   const _rectRef = React.useRef<SVGRectElement>(null);
@@ -141,7 +141,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const datasetForBars: any = [];
 
-    const linePointsByX: Record<string, YValueHover[]> = {};
+    const linePointsByX: Record<string, YValueHover[]> = Object.create(null);
     const visitedX = new Set<string>();
     lineData.forEach(series => {
       series.data.forEach(point => {
@@ -160,8 +160,8 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
 
     barData.forEach((point: GroupedVerticalBarChartData, index: number) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const singleDatasetPointForBars: any = {};
-      const legendToBarPoint: Record<string, GVBarChartSeriesPoint> = {};
+      const singleDatasetPointForBars: any = Object.create(null);
+      const legendToBarPoint: Record<string, GVBarChartSeriesPoint> = Object.create(null);
 
       point.series.forEach((seriesPoint: GVBarChartSeriesPoint) => {
         if (!singleDatasetPointForBars[seriesPoint.legend]) {
@@ -265,7 +265,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _processDataV2 = (dataV2: (BarSeries<string, number> | LineSeries<string, number>)[]) => {
-    const barPointsByX: Record<string, GroupedVerticalBarChartData> = {};
+    const barPointsByX: Record<string, GroupedVerticalBarChartData> = Object.create(null);
     const lineData: GVBCLineSeries[] = [];
 
     dataV2.forEach(series => {
@@ -303,7 +303,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
       ({ barData, lineData } = _processDataV2(props.dataV2));
     }
 
-    _legendColorMap = {};
+    _legendColorMap = Object.create(null);
     let colorIndex = 0;
 
     return {
@@ -360,7 +360,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
   };
 
   const _mapCategoryToValues = (barData: GroupedVerticalBarChartData[], lineData: GVBCLineSeries[]) => {
-    const categoryToValues: Record<string, number[]> = {};
+    const categoryToValues: Record<string, number[]> = Object.create(null);
     barData.forEach(point => {
       if (!categoryToValues[point.name]) {
         categoryToValues[point.name] = [];
@@ -534,7 +534,7 @@ export const GroupedVerticalBarChart: React.FC<GroupedVerticalBarChartProps> = R
     const barLabelsForGroup: JSXElement[] = [];
 
     // Get the actual legends present at this x-axis point
-    const presentLegends = _barLegends.filter(key => key in singleSet);
+    const presentLegends = _barLegends.filter(key => Object.prototype.hasOwnProperty.call(singleSet, key));
     const effectiveGroupWidth = calcRequiredWidth(_barWidth, presentLegends.length, X1_INNER_PADDING);
 
     // For stacked bars, center the single bar group in the available space

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
@@ -1347,3 +1347,51 @@ describe('VegaDeclarativeChart - Security', () => {
     );
   });
 });
+
+describe('VegaDeclarativeChart - Grouped Bar Special Names', () => {
+  it.each([
+    {
+      name: 'category',
+      pollutionKey: 'vegaRenderPrototypeProbe',
+      values: [
+        { category: '__proto__', series: 'vegaRenderPrototypeProbe', value: 10 },
+        { category: 'constructor', series: 'vegaRenderPrototypeProbe', value: 20 },
+        { category: 'prototype', series: 'vegaRenderPrototypeProbe', value: 30 },
+      ],
+    },
+    {
+      name: 'series',
+      pollutionKey: undefined,
+      values: [
+        { category: 'A', series: '__proto__', value: 10 },
+        { category: 'A', series: 'constructor', value: 20 },
+        { category: 'A', series: 'prototype', value: 30 },
+      ],
+    },
+  ])('should render special $name names as ordinary data', ({ values, pollutionKey }) => {
+    const spec: VegaLiteSpec = {
+      mark: 'bar',
+      data: { values },
+      encoding: {
+        x: { field: 'category', type: 'nominal' },
+        y: { field: 'value', type: 'quantitative' },
+        color: { field: 'series', type: 'nominal' },
+        xOffset: { field: 'series' },
+      },
+    };
+
+    try {
+      const { container } = render(<VegaDeclarativeChart chartSchema={{ vegaLiteSpec: spec }} />);
+
+      expect(container.querySelectorAll('rect[role="option"]')).toHaveLength(3);
+      if (pollutionKey) {
+        expect(Object.prototype).not.toHaveProperty(pollutionKey);
+      }
+    } finally {
+      if (pollutionKey) {
+        Reflect.deleteProperty(Object.prototype, pollutionKey);
+        Reflect.deleteProperty(Object, pollutionKey);
+      }
+    }
+  });
+});

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaDeclarativeChart.test.tsx
@@ -4,6 +4,16 @@ import { VegaDeclarativeChart } from './VegaDeclarativeChart';
 import type { VegaDeclarativeChartProps, VegaLiteSpec } from './VegaDeclarativeChart';
 import { resetIdsForTests } from '@fluentui/react-utilities';
 
+const groupedBarSpecialNames = [
+  '__proto__',
+  'constructor',
+  'prototype',
+  'xAxisPoint',
+  'indexNum',
+  'groupSeries',
+  'stackCallOutAccessibilityData',
+];
+
 // Suppress console warnings for cleaner test output
 beforeAll(() => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -1362,13 +1372,11 @@ describe('VegaDeclarativeChart - Grouped Bar Special Names', () => {
     {
       name: 'series',
       pollutionKey: undefined,
-      values: [
-        { category: 'A', series: '__proto__', value: 10 },
-        { category: 'A', series: 'constructor', value: 20 },
-        { category: 'A', series: 'prototype', value: 30 },
-      ],
+      values: groupedBarSpecialNames.map((series, index) => ({ category: 'A', series, value: index + 1 })),
     },
   ])('should render special $name names as ordinary data', ({ values, pollutionKey }) => {
+    const originalConstructor = Object.prototype.constructor;
+    const originalPrototypeProperties = Object.getOwnPropertyNames(Object.prototype);
     const spec: VegaLiteSpec = {
       mark: 'bar',
       data: { values },
@@ -1383,7 +1391,13 @@ describe('VegaDeclarativeChart - Grouped Bar Special Names', () => {
     try {
       const { container } = render(<VegaDeclarativeChart chartSchema={{ vegaLiteSpec: spec }} />);
 
-      expect(container.querySelectorAll('rect[role="option"]')).toHaveLength(3);
+      const bars = Array.from(container.querySelectorAll('rect[role="option"]'));
+      expect(bars).toHaveLength(values.length);
+      values.forEach(({ category, series, value }) => {
+        expect(bars.some(bar => bar.getAttribute('aria-label') === `${category}. ${series}, ${value}.`)).toBe(true);
+      });
+      expect(Object.prototype.constructor).toBe(originalConstructor);
+      expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(originalPrototypeProperties);
       if (pollutionKey) {
         expect(Object.prototype).not.toHaveProperty(pollutionKey);
       }

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapter.ts
@@ -2757,7 +2757,7 @@ export function transformVegaLiteToGroupedVerticalBarChartProps(
   const { colorScheme, colorRange } = extractColorConfig(encoding);
 
   // Group data by x value (name), then by color (series)
-  const groupedData: { [key: string]: { [legend: string]: number } } = {};
+  const groupedData: Record<string, Record<string, number>> = Object.create(null);
   const colorIndex = new Map<string, number>();
   let currentColorIndex = 0;
 
@@ -2774,7 +2774,7 @@ export function transformVegaLiteToGroupedVerticalBarChartProps(
     const legend = String(groupValue);
 
     if (!groupedData[xKey]) {
-      groupedData[xKey] = {};
+      groupedData[xKey] = Object.create(null);
     }
 
     groupedData[xKey][legend] = yValue;

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
@@ -10,6 +10,15 @@ import {
 import type { VegaLiteSpec } from './VegaLiteTypes';
 
 const colorMap = new Map<string, string>();
+const specialNames = [
+  '__proto__',
+  'constructor',
+  'prototype',
+  'xAxisPoint',
+  'indexNum',
+  'groupSeries',
+  'stackCallOutAccessibilityData',
+];
 
 describe('VegaLiteSchemaAdapter', () => {
   beforeEach(() => {
@@ -21,6 +30,7 @@ describe('VegaLiteSchemaAdapter', () => {
     test('Should preserve special category names without modifying Object.prototype', () => {
       const legend = 'vegaCategoryPrototypeProbe';
       const originalConstructor = Object.prototype.constructor;
+      const originalPrototypeProperties = Object.getOwnPropertyNames(Object.prototype);
       const spec: VegaLiteSpec = {
         mark: 'bar',
         data: {
@@ -47,6 +57,7 @@ describe('VegaLiteSchemaAdapter', () => {
           { name: 'prototype', series: [expect.objectContaining({ data: 30, legend })] },
         ]);
         expect(Object.prototype.constructor).toBe(originalConstructor);
+        expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(originalPrototypeProperties);
         expect(Object.prototype).not.toHaveProperty(legend);
       } finally {
         Reflect.deleteProperty(Object.prototype, legend);
@@ -54,15 +65,13 @@ describe('VegaLiteSchemaAdapter', () => {
       }
     });
 
-    test('Should preserve special series names', () => {
+    test('Should preserve special series names without modifying Object.prototype', () => {
+      const originalConstructor = Object.prototype.constructor;
+      const originalPrototypeProperties = Object.getOwnPropertyNames(Object.prototype);
       const spec: VegaLiteSpec = {
         mark: 'bar',
         data: {
-          values: [
-            { category: 'A', series: '__proto__', value: 10 },
-            { category: 'A', series: 'constructor', value: 20 },
-            { category: 'A', series: 'prototype', value: 30 },
-          ],
+          values: specialNames.map((series, index) => ({ category: 'A', series, value: index + 1 })),
         },
         encoding: {
           x: { field: 'category', type: 'nominal' },
@@ -77,13 +86,11 @@ describe('VegaLiteSchemaAdapter', () => {
       expect(result.data).toEqual([
         {
           name: 'A',
-          series: [
-            expect.objectContaining({ data: 10, legend: '__proto__' }),
-            expect.objectContaining({ data: 20, legend: 'constructor' }),
-            expect.objectContaining({ data: 30, legend: 'prototype' }),
-          ],
+          series: specialNames.map((legend, index) => expect.objectContaining({ legend, data: index + 1 })),
         },
       ]);
+      expect(Object.prototype.constructor).toBe(originalConstructor);
+      expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(originalPrototypeProperties);
     });
   });
 

--- a/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
+++ b/packages/charts/react-charts/library/src/components/VegaDeclarativeChart/VegaLiteSchemaAdapterUT.test.tsx
@@ -3,6 +3,7 @@ import {
   transformVegaLiteToVerticalBarChartProps,
   transformVegaLiteToHistogramProps,
   transformVegaLiteToPolarChartProps,
+  transformVegaLiteToGroupedVerticalBarChartProps,
   getVegaLiteLegendsProps,
   getVegaLiteTitles,
 } from './VegaLiteSchemaAdapter';
@@ -14,6 +15,76 @@ describe('VegaLiteSchemaAdapter', () => {
   beforeEach(() => {
     // Clear colorMap before each test to ensure test isolation
     colorMap.clear();
+  });
+
+  describe('transformVegaLiteToGroupedVerticalBarChartProps', () => {
+    test('Should preserve special category names without modifying Object.prototype', () => {
+      const legend = 'vegaCategoryPrototypeProbe';
+      const originalConstructor = Object.prototype.constructor;
+      const spec: VegaLiteSpec = {
+        mark: 'bar',
+        data: {
+          values: [
+            { category: '__proto__', series: legend, value: 10 },
+            { category: 'constructor', series: legend, value: 20 },
+            { category: 'prototype', series: legend, value: 30 },
+          ],
+        },
+        encoding: {
+          x: { field: 'category', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+          color: { field: 'series', type: 'nominal' },
+          xOffset: { field: 'series' },
+        },
+      };
+
+      try {
+        const result = transformVegaLiteToGroupedVerticalBarChartProps(spec, { current: colorMap }, false);
+
+        expect(result.data).toEqual([
+          { name: '__proto__', series: [expect.objectContaining({ data: 10, legend })] },
+          { name: 'constructor', series: [expect.objectContaining({ data: 20, legend })] },
+          { name: 'prototype', series: [expect.objectContaining({ data: 30, legend })] },
+        ]);
+        expect(Object.prototype.constructor).toBe(originalConstructor);
+        expect(Object.prototype).not.toHaveProperty(legend);
+      } finally {
+        Reflect.deleteProperty(Object.prototype, legend);
+        Reflect.deleteProperty(Object, legend);
+      }
+    });
+
+    test('Should preserve special series names', () => {
+      const spec: VegaLiteSpec = {
+        mark: 'bar',
+        data: {
+          values: [
+            { category: 'A', series: '__proto__', value: 10 },
+            { category: 'A', series: 'constructor', value: 20 },
+            { category: 'A', series: 'prototype', value: 30 },
+          ],
+        },
+        encoding: {
+          x: { field: 'category', type: 'nominal' },
+          y: { field: 'value', type: 'quantitative' },
+          color: { field: 'series', type: 'nominal' },
+          xOffset: { field: 'series' },
+        },
+      };
+
+      const result = transformVegaLiteToGroupedVerticalBarChartProps(spec, { current: colorMap }, false);
+
+      expect(result.data).toEqual([
+        {
+          name: 'A',
+          series: [
+            expect.objectContaining({ data: 10, legend: '__proto__' }),
+            expect.objectContaining({ data: 20, legend: 'constructor' }),
+            expect.objectContaining({ data: 30, legend: 'prototype' }),
+          ],
+        },
+      ]);
+    });
   });
 
   describe('transformVegaLiteToLineChartProps', () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally


PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Certain valid category and series names were not preserved consistently by grouped charts.

## New Behavior

- Preserve category and series names as literal data throughout grouped-chart transformation and rendering.
- Keep legend-indexed bar data separate from per-category rendering metadata.
- Keep existing ordering, color, and rendering behavior for ordinary names.
- Add focused adapter and end-to-end rendering regression coverage.

## Validation

- [x] Focused `react-charts` tests (129 passed, 3 skipped; 39 snapshots passed unchanged)
- [x] `yarn nx run react-charts:type-check`
- [x] `yarn nx run react-charts:lint`
- [x] `yarn nx run react-charts:format -- --check`
- [x] `yarn beachball check --branch origin/master --no-fetch`
- [x] Patch change file generated with `yarn change`

## Related Issue(s)

- N/A