### PR TITLE
fix: improve phone number initials handling

### DIFF
--- a/change/@fluentui-react-avatar-fd85b9f3-b81d-42c8-97cc-cb7261871666.json
+++ b/change/@fluentui-react-avatar-fd85b9f3-b81d-42c8-97cc-cb7261871666.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: improve phone number initials handling",
+  "packageName": "@fluentui/react-avatar",
+  "email": "paulmardling@microsoft.com"
+}

--- a/change/@fluentui-utilities-d8d0e434-71c3-4a33-99c3-f715af5dc6e3.json
+++ b/change/@fluentui-utilities-d8d0e434-71c3-4a33-99c3-f715af5dc6e3.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: improve phone number initials handling",
+  "packageName": "@fluentui/utilities",
+  "email": "paulmardling@microsoft.com"
+}

--- a/change/@fluentui-web-components-096bdc96-9ea1-4bb5-90ea-7880e55383e9.json
+++ b/change/@fluentui-web-components-096bdc96-9ea1-4bb5-90ea-7880e55383e9.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: improve phone number initials handling",
+  "packageName": "@fluentui/web-components",
+  "email": "paulmardling@microsoft.com"
+}

--- a/packages/react-components/react-avatar/library/src/utils/getInitials.test.ts
+++ b/packages/react-components/react-avatar/library/src/utils/getInitials.test.ts
@@ -165,6 +165,9 @@ describe('getInitials', () => {
     result = getInitials('1x1', false);
     expect(result).toEqual('');
 
+    result = getInitials('1 EXT 234', false);
+    expect(result).toEqual('');
+
     result = getInitials('1y1', false);
     expect(result).toEqual('1');
 
@@ -173,6 +176,11 @@ describe('getInitials', () => {
 
     result = getInitials('A 2', false);
     expect(result).toEqual('A2');
+  });
+
+  it('handles long non-phone names', () => {
+    const result = getInitials(`${'1'.repeat(100_000)}y`, false);
+    expect(result).toEqual('1');
   });
 
   it('calculates firstInitialOnly correctly in LTR', () => {

--- a/packages/react-components/react-avatar/library/src/utils/getInitials.ts
+++ b/packages/react-components/react-avatar/library/src/utils/getInitials.ts
@@ -20,7 +20,7 @@ const UNWANTED_CHARS_REGEX: RegExp = /[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036
  * Regular expression matching phone numbers. Applied after chars matching UNWANTED_CHARS_REGEX have been removed
  * and number has been trimmed for whitespaces
  */
-const PHONENUMBER_REGEX: RegExp = /^\d+[\d\s]*(:?ext|x|)\s*\d+$/i;
+const PHONENUMBER_REGEX: RegExp = /^(?:\d[\d\s]*\d|\d[\d\s]*(?:ext|x)\s*\d+)$/i;
 
 /** Regular expression matching one or more spaces. */
 const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;

--- a/packages/utilities/src/initials.test.ts
+++ b/packages/utilities/src/initials.test.ts
@@ -152,6 +152,9 @@ describe('getInitials', () => {
     result = getInitials('1x1', false);
     expect(result).toEqual('');
 
+    result = getInitials('1 EXT 234', false);
+    expect(result).toEqual('');
+
     result = getInitials('1y1', false);
     expect(result).toEqual('1');
 
@@ -160,5 +163,10 @@ describe('getInitials', () => {
 
     result = getInitials('A 2', false);
     expect(result).toEqual('A2');
+  });
+
+  it('handles long non-phone names', () => {
+    const result = getInitials(`${'1'.repeat(100_000)}y`, false);
+    expect(result).toEqual('1');
   });
 });

--- a/packages/utilities/src/initials.ts
+++ b/packages/utilities/src/initials.ts
@@ -18,7 +18,7 @@ const UNWANTED_CHARS_REGEX: RegExp = /[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036
  * Regular expression matching phone numbers. Applied after chars matching UNWANTED_CHARS_REGEX have been removed
  * and number has been trimmed for whitespaces
  */
-const PHONENUMBER_REGEX: RegExp = /^\d+[\d\s]*(:?ext|x|)\s*\d+$/i;
+const PHONENUMBER_REGEX: RegExp = /^(?:\d[\d\s]*\d|\d[\d\s]*(?:ext|x)\s*\d+)$/i;
 
 /** Regular expression matching one or more spaces. */
 const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;

--- a/packages/web-components/src/avatar/avatar.spec.ts
+++ b/packages/web-components/src/avatar/avatar.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../test/playwright/index.js';
+import { getInitials } from '../utils/get-initials.js';
 import { AvatarAppearance, AvatarColor, AvatarSize, tagName } from './avatar.options.js';
 
 test.describe('Avatar', () => {
@@ -73,6 +74,19 @@ test.describe('Avatar', () => {
     await fastPage.setTemplate({ attributes: { name: 'John Doe' } });
 
     await expect(element).toContainText('JD');
+  });
+
+  test('should preserve supported phone number forms', () => {
+    expect(getInitials('12345678', false)).toBe('');
+    expect(getInitials('1 Ext 2', false)).toBe('');
+    expect(getInitials('1x1', false)).toBe('');
+    expect(getInitials('1 EXT 234', false)).toBe('');
+    expect(getInitials('1y1', false)).toBe('1');
+    expect(getInitials('1', false)).toBe('1');
+  });
+
+  test('should handle long non-phone names', () => {
+    expect(getInitials(`${'1'.repeat(100_000)}y`, false)).toBe('1');
   });
 
   test('When `name` and `initials` attributes are both set, should prioritize the provided initials', async ({

--- a/packages/web-components/src/utils/get-initials.ts
+++ b/packages/web-components/src/utils/get-initials.ts
@@ -34,7 +34,7 @@ const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;
  * CJK:      CJK Unified Ideographs Extension A, CJK Unified Ideographs, CJK Compatibility Ideographs,
  *             CJK Unified Ideographs Extension B
  */
- 
+
 const UNSUPPORTED_TEXT_REGEX: RegExp =
   /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD869][\uDC00-\uDED6]/;
 

--- a/packages/web-components/src/utils/get-initials.ts
+++ b/packages/web-components/src/utils/get-initials.ts
@@ -21,7 +21,7 @@ const UNWANTED_CHARS_REGEX: RegExp = /[\0-\u001F\!-/:-@\[-`\{-\u00BF\u0250-\u036
  * Regular expression matching phone numbers. Applied after chars matching UNWANTED_CHARS_REGEX have been removed
  * and number has been trimmed for whitespaces
  */
-const PHONENUMBER_REGEX: RegExp = /^\d+[\d\s]*(:?ext|x|)\s*\d+$/i;
+const PHONENUMBER_REGEX: RegExp = /^(?:\d[\d\s]*\d|\d[\d\s]*(?:ext|x)\s*\d+)$/i;
 
 /** Regular expression matching one or more spaces. */
 const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;
@@ -34,7 +34,7 @@ const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;
  * CJK:      CJK Unified Ideographs Extension A, CJK Unified Ideographs, CJK Compatibility Ideographs,
  *             CJK Unified Ideographs Extension B
  */
-// eslint-disable-next-line
+ 
 const UNSUPPORTED_TEXT_REGEX: RegExp =
   /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD869][\uDC00-\uDED6]/;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

Initials generation used the same phone-number matching expression in the v9 Avatar, v8 utilities, and Web Components implementations.

## New Behavior

All three implementations now use separate matching forms for ordinary numbers and numbers with an extension. Existing phone-number results are preserved, and focused long-input coverage keeps behavior consistent across packages.

## Validation

- `yarn nx run react-avatar:test --runTestsByPath=packages/react-components/react-avatar/library/src/utils/getInitials.test.ts --runInBand`
- `yarn nx run utilities:test --runTestsByPath=packages/utilities/src/initials.test.ts --runInBand`
- `yarn nx run web-components:e2e -- src/avatar/avatar.spec.ts` (96 tests across Chromium, Firefox, and WebKit CSR/SSR)
- `yarn nx run react-avatar:build`
- `yarn nx run react-avatar:type-check`
- `utilities:type-check` and `web-components:type-check` through Nx
- `yarn nx format:check --base origin/master`

## Related Issue(s)

- N/A