### PR TITLE
fix(react-provider): validate serialized theme tokens

### DIFF
--- a/apps/public-docsite-v9/src/Concepts/Theming.mdx
+++ b/apps/public-docsite-v9/src/Concepts/Theming.mdx
@@ -112,6 +112,10 @@ export const customDarkTheme = createDarkTheme(customBrandRamp);
 
 A theme is a flat object containing `{ [token name]: CSS value }` pairs. You can copy the object and overwrite any tokens you wish.
 
+Theme names and values are developer-authored CSS. If theme customization is based on dynamic data, validate it against
+an application-specific schema before constructing the theme. Fluent UI contains generated declarations structurally,
+but does not determine whether a valid CSS value or URL is appropriate for your application.
+
 ```tsx
 import { webLightTheme, Theme } from '@fluentui/react-components';
 

--- a/apps/public-docsite-v9/src/Utilities/Theme/createCSSRuleFromTheme/createCSSRuleFromThemeDescription.md
+++ b/apps/public-docsite-v9/src/Utilities/Theme/createCSSRuleFromTheme/createCSSRuleFromThemeDescription.md
@@ -1,1 +1,5 @@
 This API allows you to create CSS from a theme and apply this CSS, for example, to `<body>`.
+
+The selector and theme are developer-authored CSS. Validate dynamic data against an application-specific schema before
+using it to construct a theme. The generated declarations are structurally contained, but the API does not determine
+whether a valid CSS value or URL is appropriate for your application.

--- a/change/@fluentui-react-provider-8f64011f-66bb-4fae-bf5e-e52d91e39408.json
+++ b/change/@fluentui-react-provider-8f64011f-66bb-4fae-bf5e-e52d91e39408.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: structurally validate serialized theme tokens",
+  "packageName": "@fluentui/react-provider",
+  "email": "paulmardling@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/react-v9/contributing/patterns/extending-tokens.md
+++ b/docs/react-v9/contributing/patterns/extending-tokens.md
@@ -4,6 +4,9 @@ It's often useful for an app to extend the base set of tokens from Fluent UI.
 
 ⚠ Warning that adding more tokens adds more CSS variables which can effect run time performance as each DOM Node carries all the tokens.
 
+Theme names and values are developer-authored CSS. Validate dynamic data against an application-specific schema before
+using it to construct or extend a theme.
+
 ```tsx
 import { makeStyles, themeToTokensObject, webLightTheme, FluentProvider, Theme } from '@fluentui/react-components';
 

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
@@ -76,4 +76,29 @@ describe('FluentProvider (node)', () => {
       </div>"
     `);
   });
+
+  it('omits invalid theme entries from the server style element', () => {
+    const logWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const theme = {
+      invalidToken: 'url(resource/*);token/**/)',
+      validToken: 'green',
+    } as unknown as PartialTheme;
+
+    const html = renderToStaticMarkup(<FluentProvider theme={theme} />);
+
+    expect(parseHTMLString(html)).toMatchInlineSnapshot(`
+      "<div
+        dir="ltr"
+        class="fui-FluentProvider fui-FluentProvider1"
+      >
+        <style id="fui-FluentProvider1">
+          .fui-FluentProvider1 {
+            --validToken: green;
+          }
+        </style>
+      </div>"
+    `);
+    expect(html.match(/<style/g)).toHaveLength(1);
+    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalidToken"'));
+  });
 });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
@@ -77,10 +77,9 @@ describe('FluentProvider (node)', () => {
     `);
   });
 
-  it('omits invalid theme entries from the server style element', () => {
-    const logWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  it('contains theme entries in the server style element', () => {
     const theme = {
-      invalidToken: 'url(resource/*);token/**/)',
+      customToken: 'url(resource/*);token/**/)',
       validToken: 'green',
     } as unknown as PartialTheme;
 
@@ -93,12 +92,12 @@ describe('FluentProvider (node)', () => {
       >
         <style id="fui-FluentProvider1">
           .fui-FluentProvider1 {
+            --customToken: url(resource)\\3B token);
             --validToken: green;
           }
         </style>
       </div>"
     `);
     expect(html.match(/<style/g)).toHaveLength(1);
-    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalidToken"'));
   });
 });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider-node.test.tsx
@@ -79,7 +79,7 @@ describe('FluentProvider (node)', () => {
 
   it('contains theme entries in the server style element', () => {
     const theme = {
-      customToken: 'url(resource/*);token/**/)',
+      customToken: 'url(\\x")',
       validToken: 'green',
     } as unknown as PartialTheme;
 
@@ -92,7 +92,7 @@ describe('FluentProvider (node)', () => {
       >
         <style id="fui-FluentProvider1">
           .fui-FluentProvider1 {
-            --customToken: url(resource)\\3B token);
+            --customToken: url(\\x\\22);
             --validToken: green;
           }
         </style>

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider.types.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/FluentProvider.types.ts
@@ -40,7 +40,12 @@ export type FluentProviderProps = Omit<ComponentProps<FluentProviderSlots>, 'dir
   /** Provides the document, can be undefined during SSR render. */
   targetDocument?: Document;
 
-  /** Sets the theme used in a scope. */
+  /**
+   * Sets the theme used in a scope.
+   *
+   * Theme names and values are developer-authored CSS. Validate dynamic data against an application-specific schema
+   * before using it to construct a theme.
+   */
   theme?: PartialTheme;
 
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
@@ -58,6 +58,30 @@ describe('createCSSRuleFromTheme', () => {
   });
 
   it.each([
+    { value: String.raw`<`, expected: String.raw`\3C ` },
+    { value: String.raw`\<`, expected: String.raw`\3C ` },
+    { value: String.raw`\\<`, expected: String.raw`\\\3C ` },
+    { value: String.raw`\\\<`, expected: String.raw`\\\3C ` },
+  ])('preserves backslash parity when escaping angle brackets in %j', ({ value, expected }) => {
+    expect(createCSSRuleFromTheme(value, undefined)).toBe(`${expected} {}`);
+  });
+
+  it.each([5_000, 10_000, 20_000, 100_000])(
+    'serializes matching and nonmatching backslash runs of length %i',
+    runLength => {
+      const backslashes = '\\'.repeat(runLength);
+      const theme = {
+        fontFamilyBase: `"${backslashes}x"`,
+        fontFamilyMonospace: `"${backslashes}<"`,
+      } as PartialTheme;
+
+      expect(createCSSRuleFromTheme(`.selector${backslashes}<`, theme)).toBe(
+        `.selector${backslashes}\\3C  { --fontFamilyBase: "${backslashes}x"; --fontFamilyMonospace: "${backslashes}\\3C ";  }`,
+      );
+    },
+  );
+
+  it.each([
     { description: 'font family fallbacks', value: '"Segoe UI", system-ui, sans-serif' },
     { description: 'system and functional colors', value: 'color-mix(in srgb, CanvasText 40%, transparent)' },
     { description: 'nested functions and fallbacks', value: 'clamp(1rem, calc(var(--scale, 1) * 2vw), 3rem)' },
@@ -73,6 +97,17 @@ describe('createCSSRuleFromTheme', () => {
     { description: 'escaped delimiters', value: String.raw`red\;blue` },
     { description: 'escaped quotes', value: String.raw`"escaped \"quote\""` },
     { description: 'escaped unquoted URL characters', value: String.raw`url(image\20 name.png)` },
+    { description: 'uppercase hexadecimal escaped URL name', value: String.raw`\55rl(resource/*)` },
+    { description: 'mixed hexadecimal escaped URL name', value: String.raw`u\52l(resource/*)` },
+    { description: 'uppercase hexadecimal escaped URL suffix', value: String.raw`ur\4c(resource/*)` },
+    { description: 'lowercase hexadecimal escaped URL name', value: String.raw`\75rl(resource/*)` },
+    { description: 'mixed simple and hexadecimal escaped URL name', value: String.raw`\U\72L(resource/*)` },
+    { description: 'hexadecimal escaped URL name with a space terminator', value: String.raw`\55 rl(resource/*)` },
+    {
+      description: 'hexadecimal escaped URL name with a CRLF terminator',
+      value: String.raw`u\52${'\r\n'}l(resource/*)`,
+    },
+    { description: 'zero-padded hexadecimal escaped URL name', value: String.raw`\000055rl(resource/*)` },
     { description: 'escaped generic function names', value: String.raw`f\6f o((x); y)` },
     { description: 'quoted URL functions with nested blocks', value: String.raw`url("image" (x); fallback)` },
     { description: 'backslash and line feed', value: 'first\\\nsecond' },
@@ -154,6 +189,7 @@ describe('createCSSRuleFromTheme', () => {
     { description: 'unterminated comment', value: 'red /* comment' },
     { description: 'unterminated escape', value: 'red\\' },
     { description: 'escaped whitespace in a generic function name', value: String.raw`ur\ l(resource{)` },
+    { description: 'non-URL escaped function name', value: String.raw`\54rl(resource/*)` },
   ])('repairs a value with $description without affecting later tokens', ({ value }) => {
     const ruleText = createCSSRuleFromTheme('.selector', {
       customToken: value,
@@ -166,6 +202,24 @@ describe('createCSSRuleFromTheme', () => {
     const rule = styleElement.sheet?.cssRules[0] as CSSStyleRule;
     expect(rule.style.getPropertyValue('--colorBrandBackground')).toBe('blue');
     expect(logWarnSpy).not.toHaveBeenCalled();
+
+    styleElement.remove();
+  });
+
+  it.each([
+    String.raw`\55rl(resource.png)`,
+    String.raw`u\52l(resource.png)`,
+    String.raw`ur\4c(resource.png)`,
+    String.raw`\55 rl(resource.png)`,
+  ])('preserves escaped unquoted URL syntax through CSSOM for %j', value => {
+    const styleElement = document.createElement('style');
+    styleElement.textContent = createCSSRuleFromTheme('.selector', {
+      customToken: value,
+    } as unknown as PartialTheme);
+    document.head.appendChild(styleElement);
+
+    const rule = styleElement.sheet?.cssRules[0] as CSSStyleRule;
+    expect(rule.style.getPropertyValue('--customToken')).toBe(value);
 
     styleElement.remove();
   });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
@@ -2,6 +2,7 @@ import {
   teamsDarkTheme,
   teamsHighContrastTheme,
   teamsLightTheme,
+  themeToTokensObject,
   webDarkTheme,
   webLightTheme,
 } from '@fluentui/react-theme';
@@ -72,6 +73,8 @@ describe('createCSSRuleFromTheme', () => {
     { description: 'escaped delimiters', value: String.raw`red\;blue` },
     { description: 'escaped quotes', value: String.raw`"escaped \"quote\""` },
     { description: 'escaped unquoted URL characters', value: String.raw`url(image\20 name.png)` },
+    { description: 'escaped generic function names', value: String.raw`f\6f o((x); y)` },
+    { description: 'quoted URL functions with nested blocks', value: String.raw`url("image" (x); fallback)` },
     { description: 'backslash and line feed', value: 'first\\\nsecond' },
     { description: 'backslash and carriage return', value: 'first\\\rsecond' },
     { description: 'backslash and form feed', value: 'first\\\fsecond' },
@@ -87,15 +90,28 @@ describe('createCSSRuleFromTheme', () => {
     const theme = {
       'custom-token_1': 0,
       customÜnicode: 'red',
+      'custom\\ token': 'blue',
+      'custom\\3A token': 'green',
+      'custom\\<token': 'purple',
     } as unknown as PartialTheme;
 
     expect(createCSSRuleFromTheme('.selector', theme)).toBe(
-      '.selector { --custom-token_1: 0; --customÜnicode: red;  }',
+      '.selector { --custom-token_1: 0; --customÜnicode: red; --custom\\ token: blue; --custom\\3A token: green; --custom\\3C token: purple;  }',
     );
     expect(logWarnSpy).not.toHaveBeenCalled();
   });
 
-  it.each(['', 'token name', 'token:name', 'token;name', 'token\\name'])(
+  it('serializes escaped custom token names consistently with themeToTokensObject', () => {
+    const escapedColonTheme = { ...webLightTheme, 'custom\\3A token': 'red' };
+    const escapedAngleTheme = { ...webLightTheme, 'custom\\<token': 'red' };
+
+    expect(createCSSRuleFromTheme('.selector', escapedColonTheme)).toContain('--custom\\3A token: red;');
+    expect(createCSSRuleFromTheme('.selector', escapedAngleTheme)).toContain('--custom\\3C token: red;');
+    expect(themeToTokensObject(escapedColonTheme)['custom\\3A token']).toBe('var(--custom\\3A token)');
+    expect(themeToTokensObject(escapedAngleTheme)['custom\\<token']).toBe('var(--custom\\<token)');
+  });
+
+  it.each(['', 'token name', 'token:name', 'token;name', 'token\\', 'token\\\nname'])(
     'omits unsupported custom token name %j',
     tokenName => {
       const result = createCSSRuleFromTheme('.selector', { [tokenName]: 'red' } as PartialTheme);
@@ -106,20 +122,55 @@ describe('createCSSRuleFromTheme', () => {
   );
 
   it.each([
-    { description: 'top-level delimiter', value: 'red;blue' },
-    { description: 'unmatched closing delimiter', value: 'red}' },
+    { description: 'top-level semicolon', value: 'red;blue', containedValue: 'red\\3B blue' },
+    { description: 'unmatched closing block delimiter', value: 'red}', containedValue: 'red\\7D ' },
+    {
+      description: 'unquoted URL tokenization',
+      value: 'url(resource/*);token/**/)',
+      containedValue: 'url(resource/*)\\3B token/**/)',
+    },
+    {
+      description: 'escaped unquoted URL tokenization',
+      value: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*);token/**/)',
+      containedValue: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*)\\3B token/**/)',
+    },
+  ])('contains a value with $description without affecting later tokens', ({ value, containedValue }) => {
+    const theme = {
+      customToken: value,
+      colorBrandBackground: 'blue',
+    } as unknown as PartialTheme;
+
+    expect(createCSSRuleFromTheme('.selector', theme)).toBe(
+      `.selector { --customToken: ${containedValue}; --colorBrandBackground: blue;  }`,
+    );
+    expect(logWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
     { description: 'mismatched delimiters', value: 'calc([1px)]' },
     { description: 'unterminated function', value: 'calc(1px' },
     { description: 'unterminated string', value: '"red' },
-    { description: 'unescaped string newline', value: '"red\nblue"' },
+    { description: 'unescaped string newline', value: '"red\n; color: red' },
     { description: 'unterminated comment', value: 'red /* comment' },
     { description: 'unterminated escape', value: 'red\\' },
-    { description: 'invalid unquoted URL tokenization', value: 'url(resource/*);token/**/)' },
-    {
-      description: 'invalid escaped unquoted URL tokenization',
-      value: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*);token/**/)',
-    },
     { description: 'escaped whitespace in a generic function name', value: String.raw`ur\ l(resource{)` },
+  ])('repairs a value with $description without affecting later tokens', ({ value }) => {
+    const ruleText = createCSSRuleFromTheme('.selector', {
+      customToken: value,
+      colorBrandBackground: 'blue',
+    } as unknown as PartialTheme);
+    const styleElement = document.createElement('style');
+    styleElement.textContent = ruleText;
+    document.head.appendChild(styleElement);
+
+    const rule = styleElement.sheet?.cssRules[0] as CSSStyleRule;
+    expect(rule.style.getPropertyValue('--colorBrandBackground')).toBe('blue');
+    expect(logWarnSpy).not.toHaveBeenCalled();
+
+    styleElement.remove();
+  });
+
+  it.each([
     { description: 'non-finite number', value: Number.POSITIVE_INFINITY },
     { description: 'non-primitive value', value: { color: 'red' } },
   ])('omits a value with $description without affecting later tokens', ({ value }) => {

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
@@ -81,6 +81,23 @@ describe('createCSSRuleFromTheme', () => {
     },
   );
 
+  it.each([5_000, 10_000, 20_000, 100_000])('serializes deep block patterns of length %i', depth => {
+    const openingBlocks = '('.repeat(depth);
+    const matchingBlocks = `${openingBlocks}${')'.repeat(depth)}`;
+    const nonmatchingBlocks = `${openingBlocks}${']'.repeat(depth)}`;
+    const mixedBlocks = `${'([{'.repeat(depth)}${')'.repeat(depth)}`;
+
+    expect(createCSSRuleFromTheme('.selector', { customToken: matchingBlocks } as unknown as PartialTheme)).toContain(
+      `--customToken: ${matchingBlocks};`,
+    );
+    expect(
+      createCSSRuleFromTheme('.selector', { customToken: nonmatchingBlocks } as unknown as PartialTheme),
+    ).toContain(`--customToken: ${nonmatchingBlocks}${')'.repeat(depth)};`);
+    expect(createCSSRuleFromTheme('.selector', { customToken: mixedBlocks } as unknown as PartialTheme)).toContain(
+      `--customToken: ${'([{'.repeat(depth)}${'}])'.repeat(depth)};`,
+    );
+  });
+
   it.each([
     { description: 'font family fallbacks', value: '"Segoe UI", system-ui, sans-serif' },
     { description: 'system and functional colors', value: 'color-mix(in srgb, CanvasText 40%, transparent)' },
@@ -108,6 +125,9 @@ describe('createCSSRuleFromTheme', () => {
       value: String.raw`u\52${'\r\n'}l(resource/*)`,
     },
     { description: 'zero-padded hexadecimal escaped URL name', value: String.raw`\000055rl(resource/*)` },
+    { description: 'hash token followed by a parenthesized block', value: '#url(/* ) */; x)' },
+    { description: 'at-keyword followed by a parenthesized block', value: '@url(/* ) */; x)' },
+    { description: 'escaped hash token followed by a parenthesized block', value: String.raw`#\75rl(/* ) */; x)` },
     { description: 'escaped generic function names', value: String.raw`f\6f o((x); y)` },
     { description: 'quoted URL functions with nested blocks', value: String.raw`url("image" (x); fallback)` },
     { description: 'backslash and line feed', value: 'first\\\nsecond' },
@@ -169,6 +189,11 @@ describe('createCSSRuleFromTheme', () => {
       value: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*);token/**/)',
       containedValue: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*)\\3B token/**/)',
     },
+    {
+      description: 'malformed unquoted URL content',
+      value: 'url(\\x")',
+      containedValue: 'url(\\x\\22 )',
+    },
   ])('contains a value with $description without affecting later tokens', ({ value, containedValue }) => {
     const theme = {
       customToken: value,
@@ -190,6 +215,11 @@ describe('createCSSRuleFromTheme', () => {
     { description: 'unterminated escape', value: 'red\\' },
     { description: 'escaped whitespace in a generic function name', value: String.raw`ur\ l(resource{)` },
     { description: 'non-URL escaped function name', value: String.raw`\54rl(resource/*)` },
+    { description: 'malformed unquoted URL content', value: 'url(\\x")' },
+    { description: 'malformed unquoted URL content after whitespace', value: "url( \\x')" },
+    { description: 'malformed unquoted URL content after an escaped delimiter', value: 'url(\\)")' },
+    { description: 'unterminated unquoted URL', value: 'url(resource' },
+    { description: 'unterminated escape in an unquoted URL', value: 'url(resource\\' },
   ])('repairs a value with $description without affecting later tokens', ({ value }) => {
     const ruleText = createCSSRuleFromTheme('.selector', {
       customToken: value,
@@ -211,7 +241,14 @@ describe('createCSSRuleFromTheme', () => {
     String.raw`u\52l(resource.png)`,
     String.raw`ur\4c(resource.png)`,
     String.raw`\55 rl(resource.png)`,
-  ])('preserves escaped unquoted URL syntax through CSSOM for %j', value => {
+    '#url(/* ) */; x)',
+    '@url(/* ) */; x)',
+    String.raw`#\75rl(/* ) */; x)`,
+  ])('preserves token semantics through CSSOM for %j', value => {
+    const baselineStyleElement = document.createElement('style');
+    baselineStyleElement.textContent = `.selector { --customToken: ${value}; }`;
+    document.head.appendChild(baselineStyleElement);
+
     const styleElement = document.createElement('style');
     styleElement.textContent = createCSSRuleFromTheme('.selector', {
       customToken: value,
@@ -219,8 +256,10 @@ describe('createCSSRuleFromTheme', () => {
     document.head.appendChild(styleElement);
 
     const rule = styleElement.sheet?.cssRules[0] as CSSStyleRule;
-    expect(rule.style.getPropertyValue('--customToken')).toBe(value);
+    const baselineRule = baselineStyleElement.sheet?.cssRules[0] as CSSStyleRule;
+    expect(rule.style.getPropertyValue('--customToken')).toBe(baselineRule.style.getPropertyValue('--customToken'));
 
+    baselineStyleElement.remove();
     styleElement.remove();
   });
 

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.test.ts
@@ -1,7 +1,25 @@
+import {
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+  teamsLightTheme,
+  webDarkTheme,
+  webLightTheme,
+} from '@fluentui/react-theme';
 import type { PartialTheme } from '@fluentui/react-theme';
 import { createCSSRuleFromTheme } from './createCSSRuleFromTheme';
 
 describe('createCSSRuleFromTheme', () => {
+  const noop = () => undefined;
+  let logWarnSpy: jest.Spied<typeof console.warn>;
+
+  beforeEach(() => {
+    logWarnSpy = jest.spyOn(console, 'warn').mockImplementation(noop);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('handles undefined theme', () => {
     expect(createCSSRuleFromTheme('.selector', undefined)).toMatchInlineSnapshot(`".selector {}"`);
   });
@@ -36,5 +54,94 @@ describe('createCSSRuleFromTheme', () => {
     expect(result).not.toContain('<');
     expect(result).not.toContain('>');
     expect(result).toContain('\\3C /style\\3E \\3C script\\3E alert("xss")\\3C /script\\3E ');
+  });
+
+  it.each([
+    { description: 'font family fallbacks', value: '"Segoe UI", system-ui, sans-serif' },
+    { description: 'system and functional colors', value: 'color-mix(in srgb, CanvasText 40%, transparent)' },
+    { description: 'nested functions and fallbacks', value: 'clamp(1rem, calc(var(--scale, 1) * 2vw), 3rem)' },
+    { description: 'multiple shadows', value: '0 1px 2px rgb(0 0 0 / 20%), 0 4px 8px rgba(0, 0, 0, 0.1)' },
+    { description: 'CSS-wide values', value: 'revert-layer' },
+    {
+      description: 'data URLs with nested delimiters',
+      value: 'url(data:image/svg+xml;charset=utf-8,%3Csvg%3E;%3C/svg%3E)',
+    },
+    { description: 'quoted delimiters', value: '"value; with { delimiters }"' },
+    { description: 'balanced blocks', value: 'custom({ value; [other] })' },
+    { description: 'comments', value: 'calc(1px /* ; } */ + 2px)' },
+    { description: 'escaped delimiters', value: String.raw`red\;blue` },
+    { description: 'escaped quotes', value: String.raw`"escaped \"quote\""` },
+    { description: 'escaped unquoted URL characters', value: String.raw`url(image\20 name.png)` },
+    { description: 'backslash and line feed', value: 'first\\\nsecond' },
+    { description: 'backslash and carriage return', value: 'first\\\rsecond' },
+    { description: 'backslash and form feed', value: 'first\\\fsecond' },
+    { description: 'multiline whitespace', value: 'calc(\n  1px + 2px\n)' },
+  ])('preserves $description', ({ value }) => {
+    const result = createCSSRuleFromTheme('.selector', { customToken: value } as unknown as PartialTheme);
+
+    expect(result).toBe(`.selector { --customToken: ${value};  }`);
+    expect(logWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves supported custom token names and finite numeric values', () => {
+    const theme = {
+      'custom-token_1': 0,
+      customÜnicode: 'red',
+    } as unknown as PartialTheme;
+
+    expect(createCSSRuleFromTheme('.selector', theme)).toBe(
+      '.selector { --custom-token_1: 0; --customÜnicode: red;  }',
+    );
+    expect(logWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(['', 'token name', 'token:name', 'token;name', 'token\\name'])(
+    'omits unsupported custom token name %j',
+    tokenName => {
+      const result = createCSSRuleFromTheme('.selector', { [tokenName]: 'red' } as PartialTheme);
+
+      expect(result).toBe('.selector {  }');
+      expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(tokenName)));
+    },
+  );
+
+  it.each([
+    { description: 'top-level delimiter', value: 'red;blue' },
+    { description: 'unmatched closing delimiter', value: 'red}' },
+    { description: 'mismatched delimiters', value: 'calc([1px)]' },
+    { description: 'unterminated function', value: 'calc(1px' },
+    { description: 'unterminated string', value: '"red' },
+    { description: 'unescaped string newline', value: '"red\nblue"' },
+    { description: 'unterminated comment', value: 'red /* comment' },
+    { description: 'unterminated escape', value: 'red\\' },
+    { description: 'invalid unquoted URL tokenization', value: 'url(resource/*);token/**/)' },
+    {
+      description: 'invalid escaped unquoted URL tokenization',
+      value: '\\000075\r\n\\000072\r\n\\00006c\r\n(resource/*);token/**/)',
+    },
+    { description: 'escaped whitespace in a generic function name', value: String.raw`ur\ l(resource{)` },
+    { description: 'non-finite number', value: Number.POSITIVE_INFINITY },
+    { description: 'non-primitive value', value: { color: 'red' } },
+  ])('omits a value with $description without affecting later tokens', ({ value }) => {
+    const theme = {
+      invalidToken: value,
+      colorBrandBackground: 'blue',
+    } as unknown as PartialTheme;
+
+    expect(createCSSRuleFromTheme('.selector', theme)).toBe('.selector { --colorBrandBackground: blue;  }');
+    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalidToken"'));
+    expect(logWarnSpy.mock.calls[0][0]).not.toContain(String(value));
+  });
+
+  it('serializes all values from exported themes', () => {
+    for (const theme of [webLightTheme, webDarkTheme, teamsLightTheme, teamsDarkTheme, teamsHighContrastTheme]) {
+      const result = createCSSRuleFromTheme('.selector', theme);
+
+      for (const [tokenName, tokenValue] of Object.entries(theme)) {
+        expect(result).toContain(`--${tokenName}: ${tokenValue};`);
+      }
+    }
+
+    expect(logWarnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
@@ -12,7 +12,7 @@ const THEME_TOKEN_NAME_PATTERN =
 const NAME_CHARACTER_PATTERN = /^[-_a-z0-9\u0080-\uFFFF]$/i;
 const ESCAPE_AT_START_PATTERN = /^\\(?:[0-9a-f]{1,6}(?:\r\n|[ \t\n\r\f])?|[^\n\r\f])/i;
 const URL_FUNCTION_PATTERN =
-  /^(?:u|\\(?:u|0{0,4}75(?:\r\n|[ \t\n\r\f])?))(?:r|\\(?:r|0{0,4}72(?:\r\n|[ \t\n\r\f])?))(?:l|\\(?:l|0{0,4}6c(?:\r\n|[ \t\n\r\f])?))$/i;
+  /^(?:u|\\(?:u|0{0,4}[57]5(?:\r\n|[ \t\n\r\f])?))(?:r|\\(?:r|0{0,4}[57]2(?:\r\n|[ \t\n\r\f])?))(?:l|\\(?:l|0{0,4}[46]c(?:\r\n|[ \t\n\r\f])?))$/i;
 
 /**
  * Escapes characters that could break out of a <style> tag during SSR.
@@ -21,13 +21,13 @@ const URL_FUNCTION_PATTERN =
  * We only need to ensure the generated text cannot terminate the style tag and inject HTML.
  */
 function escapeForStyleTag(value: string): string {
-  // Escape as CSS code points so the resulting CSS still represents the same characters.
-  // Using CSS escapes prevents the HTML parser from seeing a literal '<' / '>' and closing <style>.
-  return value.replace(
-    /(\\*)([<>])/g,
-    (_match, backslashes: string, bracket: '<' | '>') =>
-      backslashes.slice(backslashes.length % 2) + CSS_ESCAPE_MAP[bracket],
-  );
+  // Consume each backslash run once so matching does not retry overlapping suffixes.
+  return value.replace(/\\+[<>]?|[<>]/g, match => {
+    const bracket = match[match.length - 1] as '<' | '>' | '\\';
+    const runLength = bracket === '\\' ? match.length : match.length - 1;
+
+    return bracket === '\\' ? match : match.slice(runLength % 2, runLength) + CSS_ESCAPE_MAP[bracket];
+  });
 }
 
 function containThemeTokenValue(value: string): string {

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
@@ -33,6 +33,7 @@ function escapeForStyleTag(value: string): string {
 function containThemeTokenValue(value: string): string {
   const result = value.split('');
   const blocks: string[] = [];
+  const blockIndexes: Record<string, number[]> = { ')': [], ']': [], '}': [] };
   let identifier = '';
   let quote = '';
   let comment = false;
@@ -79,18 +80,23 @@ function containThemeTokenValue(value: string): string {
         continue;
       }
       if (character === ')') {
-        blocks.pop();
+        const closingBlock = blocks.pop()!;
+        blockIndexes[closingBlock].pop();
         urlState = 0;
-      } else if (character === '\\') {
+        continue;
+      }
+      if (character === '"' || character === "'") {
+        result[i] = character === '"' ? '\\22 ' : '\\27 ';
+      }
+      if (character === '\\') {
         const escape = value.slice(i).match(ESCAPE_AT_START_PATTERN)?.[0];
         if (escape) {
           i += escape.length - 1;
         } else if (nextCharacter === undefined) {
           result[i] = '\\\n';
         }
-      } else {
-        urlState = 2;
       }
+      urlState = 2;
       continue;
     }
 
@@ -114,7 +120,7 @@ function containThemeTokenValue(value: string): string {
     }
 
     const functionNameIsUrl = URL_FUNCTION_PATTERN.test(identifier);
-    identifier = '';
+    identifier = character === '#' || character === '@' ? character : '';
 
     if (character === '/' && nextCharacter === '*') {
       comment = true;
@@ -122,19 +128,20 @@ function containThemeTokenValue(value: string): string {
     } else if (character === '"' || character === "'") {
       quote = character;
     } else if (character === '(' || character === '[' || character === '{') {
-      blocks.push(character === '(' ? ')' : character === '[' ? ']' : '}');
+      const closingBlock = character === '(' ? ')' : character === '[' ? ']' : '}';
+      blockIndexes[closingBlock].push(blocks.push(closingBlock) - 1);
       if (character === '(' && functionNameIsUrl) {
         urlState = 1;
       }
     } else if (character === ')' || character === ']' || character === '}') {
-      const blockIndex = blocks.lastIndexOf(character);
-      if (blockIndex >= 0) {
-        result[i] =
-          blocks
-            .splice(blockIndex + 1)
-            .reverse()
-            .join('') + character;
+      const blockIndex = blockIndexes[character].pop();
+      if (blockIndex !== undefined) {
+        const repairedBlocks = blocks.splice(blockIndex + 1).reverse();
+        for (const closingBlock of repairedBlocks) {
+          blockIndexes[closingBlock].pop();
+        }
         blocks.pop();
+        result[i] = repairedBlocks.join('') + character;
       } else if (character === '}') {
         result[i] = CSS_ESCAPE_MAP[character];
       }

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
@@ -3,18 +3,16 @@ import type { PartialTheme } from '@fluentui/react-theme';
 const CSS_ESCAPE_MAP = {
   '<': '\\3C ',
   '>': '\\3E ',
+  ';': '\\3B ',
+  '{': '\\7B ',
+  '}': '\\7D ',
 };
-const THEME_TOKEN_NAME_PATTERN = /^[-_a-zA-Z0-9\u0080-\uFFFF]+$/;
-const OPENING_DELIMITERS: Record<string, string> = {
-  '(': ')',
-  '[': ']',
-  '{': '}',
-};
-const CLOSING_DELIMITERS = new Set(Object.values(OPENING_DELIMITERS));
-type DelimiterFrame = {
-  closingDelimiter: string;
-  urlState?: 'leading' | 'value' | 'trailing';
-};
+const THEME_TOKEN_NAME_PATTERN =
+  /^(?:[-_a-z0-9\u0080-\uFFFF]|\\(?:[0-9a-f]{1,6}(?:\r\n|[ \t\n\r\f])?|[^0-9a-f\n\r\f]))+$/i;
+const NAME_CHARACTER_PATTERN = /^[-_a-z0-9\u0080-\uFFFF]$/i;
+const ESCAPE_AT_START_PATTERN = /^\\(?:[0-9a-f]{1,6}(?:\r\n|[ \t\n\r\f])?|[^\n\r\f])/i;
+const URL_FUNCTION_PATTERN =
+  /^(?:u|\\(?:u|0{0,4}75(?:\r\n|[ \t\n\r\f])?))(?:r|\\(?:r|0{0,4}72(?:\r\n|[ \t\n\r\f])?))(?:l|\\(?:l|0{0,4}6c(?:\r\n|[ \t\n\r\f])?))$/i;
 
 /**
  * Escapes characters that could break out of a <style> tag during SSR.
@@ -25,293 +23,127 @@ type DelimiterFrame = {
 function escapeForStyleTag(value: string): string {
   // Escape as CSS code points so the resulting CSS still represents the same characters.
   // Using CSS escapes prevents the HTML parser from seeing a literal '<' / '>' and closing <style>.
-  return value.replace(/[<>]/g, match => CSS_ESCAPE_MAP[match as keyof typeof CSS_ESCAPE_MAP]);
-}
-
-function isNewline(character: string): boolean {
-  return character === '\n' || character === '\r' || character === '\f';
-}
-
-function isWhitespace(character: string): boolean {
-  return character === ' ' || character === '\t' || isNewline(character);
-}
-
-function isNameCodePoint(character: string): boolean {
-  return /^[-_a-zA-Z0-9\u0080-\uFFFF]$/.test(character);
-}
-
-function consumeEscape(value: string, escapeIndex: number): number | undefined {
-  const nextCharacter = value[escapeIndex + 1];
-  if (nextCharacter === undefined || isNewline(nextCharacter)) {
-    return undefined;
-  }
-
-  if (/^[0-9a-fA-F]$/.test(nextCharacter)) {
-    let index = escapeIndex + 1;
-    let hexDigits = 0;
-
-    while (hexDigits < 6 && /^[0-9a-fA-F]$/.test(value[index])) {
-      index++;
-      hexDigits++;
-    }
-
-    if (isWhitespace(value[index])) {
-      if (value[index] === '\r' && value[index + 1] === '\n') {
-        index++;
-      }
-
-      return index;
-    }
-
-    return index - 1;
-  }
-
-  return escapeIndex + 1;
-}
-
-function decodeIdentifier(value: string): string | undefined {
-  let decodedValue = '';
-
-  for (let i = 0; i < value.length; i++) {
-    const character = value[i];
-
-    if (character === '\\') {
-      const nextCharacter = value[i + 1];
-      if (nextCharacter === undefined || isNewline(nextCharacter)) {
-        return undefined;
-      }
-
-      if (/^[0-9a-fA-F]$/.test(nextCharacter)) {
-        let escapeEndIndex = i + 1;
-        let hexDigits = 0;
-
-        while (hexDigits < 6 && /^[0-9a-fA-F]$/.test(value[escapeEndIndex])) {
-          escapeEndIndex++;
-          hexDigits++;
-        }
-
-        const codePoint = Number.parseInt(value.slice(i + 1, escapeEndIndex), 16);
-        decodedValue +=
-          codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
-            ? '\uFFFD'
-            : String.fromCodePoint(codePoint);
-
-        if (isWhitespace(value[escapeEndIndex])) {
-          if (value[escapeEndIndex] === '\r' && value[escapeEndIndex + 1] === '\n') {
-            escapeEndIndex++;
-          }
-
-          i = escapeEndIndex;
-        } else {
-          i = escapeEndIndex - 1;
-        }
-      } else {
-        decodedValue += nextCharacter;
-        i++;
-      }
-
-      continue;
-    }
-
-    if (!isNameCodePoint(character)) {
-      return undefined;
-    }
-
-    decodedValue += character;
-  }
-
-  return decodedValue;
-}
-
-function findUrlFunctionParentheses(value: string): Set<number> {
-  const openingParentheses = new Set<number>();
-  let identifierStart: number | undefined;
-
-  for (let i = 0; i < value.length; i++) {
-    const character = value[i];
-
-    if (isNameCodePoint(character)) {
-      identifierStart ??= i;
-      continue;
-    }
-
-    if (character === '\\') {
-      const escapeEndIndex = consumeEscape(value, i);
-      if (escapeEndIndex !== undefined) {
-        identifierStart ??= i;
-        i = escapeEndIndex;
-        continue;
-      }
-    }
-
-    if (
-      character === '(' &&
-      identifierStart !== undefined &&
-      decodeIdentifier(value.slice(identifierStart, i))?.toLowerCase() === 'url'
-    ) {
-      openingParentheses.add(i);
-    }
-
-    identifierStart = undefined;
-  }
-
-  return openingParentheses;
-}
-
-function isNonPrintable(character: string): boolean {
-  const codePoint = character.charCodeAt(0);
-  return (
-    (codePoint >= 0 && codePoint <= 8) || codePoint === 11 || (codePoint >= 14 && codePoint <= 31) || codePoint === 127
+  return value.replace(
+    /(\\*)([<>])/g,
+    (_match, backslashes: string, bracket: '<' | '>') =>
+      backslashes.slice(backslashes.length % 2) + CSS_ESCAPE_MAP[bracket],
   );
 }
 
-/**
- * Checks only the CSS structure needed to keep a value within its custom property declaration.
- * Semantic validation belongs to the application because custom tokens can represent any CSS property.
- */
-function isValidThemeTokenValue(value: string): boolean {
-  const delimiterFrames: DelimiterFrame[] = [];
-  const urlFunctionParentheses = findUrlFunctionParentheses(value);
-  let quote: '"' | "'" | undefined;
-  let inComment = false;
+function containThemeTokenValue(value: string): string {
+  const result = value.split('');
+  const blocks: string[] = [];
+  let identifier = '';
+  let quote = '';
+  let comment = false;
+  let urlState = 0;
 
   for (let i = 0; i < value.length; i++) {
     const character = value[i];
     const nextCharacter = value[i + 1];
 
-    if (inComment) {
+    if (comment) {
       if (character === '*' && nextCharacter === '/') {
-        inComment = false;
+        comment = false;
         i++;
       }
-
       continue;
     }
 
     if (quote) {
       if (character === '\\') {
-        if (nextCharacter === undefined) {
-          return false;
+        const escape = value.slice(i).match(ESCAPE_AT_START_PATTERN)?.[0];
+        if (escape) {
+          i += escape.length - 1;
+        } else if (nextCharacter === undefined) {
+          result[i] = '\\\n';
+        } else {
+          i += nextCharacter === '\r' && value[i + 2] === '\n' ? 2 : 1;
         }
-
-        if (nextCharacter === '\r' && value[i + 2] === '\n') {
-          i++;
-        }
-
-        i++;
       } else if (character === quote) {
-        quote = undefined;
-      } else if (isNewline(character)) {
-        return false;
+        quote = '';
+      } else if (/[\n\r\f]/.test(character)) {
+        result[i] = quote + character;
+        quote = '';
       }
-
       continue;
     }
 
-    const currentFrame = delimiterFrames[delimiterFrames.length - 1];
-    if (currentFrame?.urlState) {
-      if (currentFrame.urlState === 'leading') {
-        if (isWhitespace(character)) {
-          continue;
-        }
-
-        if (character === '"' || character === "'") {
-          currentFrame.urlState = undefined;
-        } else {
-          currentFrame.urlState = 'value';
-        }
-      }
-
-      if (currentFrame.urlState === 'value') {
-        if (character === ')') {
-          delimiterFrames.pop();
-          continue;
-        }
-
-        if (isWhitespace(character)) {
-          currentFrame.urlState = 'trailing';
-          continue;
-        }
-
-        if (character === '\\') {
-          const escapeEndIndex = consumeEscape(value, i);
-          if (escapeEndIndex === undefined) {
-            return false;
-          }
-
-          i = escapeEndIndex;
-          continue;
-        }
-
-        if (character === '"' || character === "'" || character === '(' || isNonPrintable(character)) {
-          return false;
-        }
-
+    if (urlState) {
+      if (urlState === 1 && /[ \t\n\r\f]/.test(character)) {
         continue;
       }
-
-      if (currentFrame.urlState === 'trailing') {
-        if (isWhitespace(character)) {
-          continue;
-        }
-
-        if (character === ')') {
-          delimiterFrames.pop();
-          continue;
-        }
-
-        return false;
+      if (urlState === 1 && (character === '"' || character === "'")) {
+        urlState = 0;
+        quote = character;
+        continue;
       }
-    }
-
-    if (character === '/' && nextCharacter === '*') {
-      inComment = true;
-      i++;
+      if (character === ')') {
+        blocks.pop();
+        urlState = 0;
+      } else if (character === '\\') {
+        const escape = value.slice(i).match(ESCAPE_AT_START_PATTERN)?.[0];
+        if (escape) {
+          i += escape.length - 1;
+        } else if (nextCharacter === undefined) {
+          result[i] = '\\\n';
+        }
+      } else {
+        urlState = 2;
+      }
       continue;
     }
 
-    if (character === '"' || character === "'") {
-      quote = character;
+    if (NAME_CHARACTER_PATTERN.test(character)) {
+      identifier += character;
       continue;
     }
 
     if (character === '\\') {
-      if (nextCharacter !== undefined && isNewline(nextCharacter)) {
-        continue;
+      const escape = value.slice(i).match(ESCAPE_AT_START_PATTERN)?.[0];
+      if (escape) {
+        identifier += escape;
+        i += escape.length - 1;
+      } else {
+        identifier = '';
+        if (nextCharacter === undefined) {
+          result[i] = '\\\n';
+        }
       }
-
-      const escapeEndIndex = consumeEscape(value, i);
-      if (escapeEndIndex === undefined) {
-        return false;
-      }
-
-      i = escapeEndIndex;
       continue;
     }
 
-    const closingDelimiter = OPENING_DELIMITERS[character];
-    if (closingDelimiter) {
-      delimiterFrames.push({
-        closingDelimiter,
-        urlState: character === '(' && urlFunctionParentheses.has(i) ? 'leading' : undefined,
-      });
-      continue;
-    }
+    const functionNameIsUrl = URL_FUNCTION_PATTERN.test(identifier);
+    identifier = '';
 
-    if (CLOSING_DELIMITERS.has(character)) {
-      if (delimiterFrames.pop()?.closingDelimiter !== character) {
-        return false;
+    if (character === '/' && nextCharacter === '*') {
+      comment = true;
+      i++;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '(' || character === '[' || character === '{') {
+      blocks.push(character === '(' ? ')' : character === '[' ? ']' : '}');
+      if (character === '(' && functionNameIsUrl) {
+        urlState = 1;
       }
-
-      continue;
-    }
-
-    if (character === ';' && delimiterFrames.length === 0) {
-      return false;
+    } else if (character === ')' || character === ']' || character === '}') {
+      const blockIndex = blocks.lastIndexOf(character);
+      if (blockIndex >= 0) {
+        result[i] =
+          blocks
+            .splice(blockIndex + 1)
+            .reverse()
+            .join('') + character;
+        blocks.pop();
+      } else if (character === '}') {
+        result[i] = CSS_ESCAPE_MAP[character];
+      }
+    } else if (character === ';' && blocks.length === 0) {
+      result[i] = CSS_ESCAPE_MAP[character];
     }
   }
 
-  return quote === undefined && !inComment && delimiterFrames.length === 0;
+  return result.join('') + quote + (comment ? '*/' : '') + blocks.reverse().join('');
 }
 
 function warnInvalidThemeToken(tokenName: string, reason: 'name' | 'value'): void {
@@ -346,15 +178,12 @@ export function createCSSRuleFromTheme(selector: string, theme: PartialTheme | u
         return cssVarRule;
       }
 
-      if (
-        (typeof tokenValue !== 'string' && (typeof tokenValue !== 'number' || !Number.isFinite(tokenValue))) ||
-        !isValidThemeTokenValue(String(tokenValue))
-      ) {
+      if (typeof tokenValue !== 'string' && (typeof tokenValue !== 'number' || !Number.isFinite(tokenValue))) {
         warnInvalidThemeToken(tokenName, 'value');
         return cssVarRule;
       }
 
-      return `${cssVarRule}--${tokenName}: ${tokenValue}; `;
+      return `${cssVarRule}--${tokenName}: ${containThemeTokenValue(String(tokenValue))}; `;
     }, '');
 
     return `${escapedSelector} { ${escapeForStyleTag(cssVarsAsString)} }`;

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/createCSSRuleFromTheme.ts
@@ -4,6 +4,18 @@ const CSS_ESCAPE_MAP = {
   '<': '\\3C ',
   '>': '\\3E ',
 };
+const THEME_TOKEN_NAME_PATTERN = /^[-_a-zA-Z0-9\u0080-\uFFFF]+$/;
+const OPENING_DELIMITERS: Record<string, string> = {
+  '(': ')',
+  '[': ']',
+  '{': '}',
+};
+const CLOSING_DELIMITERS = new Set(Object.values(OPENING_DELIMITERS));
+type DelimiterFrame = {
+  closingDelimiter: string;
+  urlState?: 'leading' | 'value' | 'trailing';
+};
+
 /**
  * Escapes characters that could break out of a <style> tag during SSR.
  *
@@ -16,17 +28,333 @@ function escapeForStyleTag(value: string): string {
   return value.replace(/[<>]/g, match => CSS_ESCAPE_MAP[match as keyof typeof CSS_ESCAPE_MAP]);
 }
 
+function isNewline(character: string): boolean {
+  return character === '\n' || character === '\r' || character === '\f';
+}
+
+function isWhitespace(character: string): boolean {
+  return character === ' ' || character === '\t' || isNewline(character);
+}
+
+function isNameCodePoint(character: string): boolean {
+  return /^[-_a-zA-Z0-9\u0080-\uFFFF]$/.test(character);
+}
+
+function consumeEscape(value: string, escapeIndex: number): number | undefined {
+  const nextCharacter = value[escapeIndex + 1];
+  if (nextCharacter === undefined || isNewline(nextCharacter)) {
+    return undefined;
+  }
+
+  if (/^[0-9a-fA-F]$/.test(nextCharacter)) {
+    let index = escapeIndex + 1;
+    let hexDigits = 0;
+
+    while (hexDigits < 6 && /^[0-9a-fA-F]$/.test(value[index])) {
+      index++;
+      hexDigits++;
+    }
+
+    if (isWhitespace(value[index])) {
+      if (value[index] === '\r' && value[index + 1] === '\n') {
+        index++;
+      }
+
+      return index;
+    }
+
+    return index - 1;
+  }
+
+  return escapeIndex + 1;
+}
+
+function decodeIdentifier(value: string): string | undefined {
+  let decodedValue = '';
+
+  for (let i = 0; i < value.length; i++) {
+    const character = value[i];
+
+    if (character === '\\') {
+      const nextCharacter = value[i + 1];
+      if (nextCharacter === undefined || isNewline(nextCharacter)) {
+        return undefined;
+      }
+
+      if (/^[0-9a-fA-F]$/.test(nextCharacter)) {
+        let escapeEndIndex = i + 1;
+        let hexDigits = 0;
+
+        while (hexDigits < 6 && /^[0-9a-fA-F]$/.test(value[escapeEndIndex])) {
+          escapeEndIndex++;
+          hexDigits++;
+        }
+
+        const codePoint = Number.parseInt(value.slice(i + 1, escapeEndIndex), 16);
+        decodedValue +=
+          codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+            ? '\uFFFD'
+            : String.fromCodePoint(codePoint);
+
+        if (isWhitespace(value[escapeEndIndex])) {
+          if (value[escapeEndIndex] === '\r' && value[escapeEndIndex + 1] === '\n') {
+            escapeEndIndex++;
+          }
+
+          i = escapeEndIndex;
+        } else {
+          i = escapeEndIndex - 1;
+        }
+      } else {
+        decodedValue += nextCharacter;
+        i++;
+      }
+
+      continue;
+    }
+
+    if (!isNameCodePoint(character)) {
+      return undefined;
+    }
+
+    decodedValue += character;
+  }
+
+  return decodedValue;
+}
+
+function findUrlFunctionParentheses(value: string): Set<number> {
+  const openingParentheses = new Set<number>();
+  let identifierStart: number | undefined;
+
+  for (let i = 0; i < value.length; i++) {
+    const character = value[i];
+
+    if (isNameCodePoint(character)) {
+      identifierStart ??= i;
+      continue;
+    }
+
+    if (character === '\\') {
+      const escapeEndIndex = consumeEscape(value, i);
+      if (escapeEndIndex !== undefined) {
+        identifierStart ??= i;
+        i = escapeEndIndex;
+        continue;
+      }
+    }
+
+    if (
+      character === '(' &&
+      identifierStart !== undefined &&
+      decodeIdentifier(value.slice(identifierStart, i))?.toLowerCase() === 'url'
+    ) {
+      openingParentheses.add(i);
+    }
+
+    identifierStart = undefined;
+  }
+
+  return openingParentheses;
+}
+
+function isNonPrintable(character: string): boolean {
+  const codePoint = character.charCodeAt(0);
+  return (
+    (codePoint >= 0 && codePoint <= 8) || codePoint === 11 || (codePoint >= 14 && codePoint <= 31) || codePoint === 127
+  );
+}
+
+/**
+ * Checks only the CSS structure needed to keep a value within its custom property declaration.
+ * Semantic validation belongs to the application because custom tokens can represent any CSS property.
+ */
+function isValidThemeTokenValue(value: string): boolean {
+  const delimiterFrames: DelimiterFrame[] = [];
+  const urlFunctionParentheses = findUrlFunctionParentheses(value);
+  let quote: '"' | "'" | undefined;
+  let inComment = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const character = value[i];
+    const nextCharacter = value[i + 1];
+
+    if (inComment) {
+      if (character === '*' && nextCharacter === '/') {
+        inComment = false;
+        i++;
+      }
+
+      continue;
+    }
+
+    if (quote) {
+      if (character === '\\') {
+        if (nextCharacter === undefined) {
+          return false;
+        }
+
+        if (nextCharacter === '\r' && value[i + 2] === '\n') {
+          i++;
+        }
+
+        i++;
+      } else if (character === quote) {
+        quote = undefined;
+      } else if (isNewline(character)) {
+        return false;
+      }
+
+      continue;
+    }
+
+    const currentFrame = delimiterFrames[delimiterFrames.length - 1];
+    if (currentFrame?.urlState) {
+      if (currentFrame.urlState === 'leading') {
+        if (isWhitespace(character)) {
+          continue;
+        }
+
+        if (character === '"' || character === "'") {
+          currentFrame.urlState = undefined;
+        } else {
+          currentFrame.urlState = 'value';
+        }
+      }
+
+      if (currentFrame.urlState === 'value') {
+        if (character === ')') {
+          delimiterFrames.pop();
+          continue;
+        }
+
+        if (isWhitespace(character)) {
+          currentFrame.urlState = 'trailing';
+          continue;
+        }
+
+        if (character === '\\') {
+          const escapeEndIndex = consumeEscape(value, i);
+          if (escapeEndIndex === undefined) {
+            return false;
+          }
+
+          i = escapeEndIndex;
+          continue;
+        }
+
+        if (character === '"' || character === "'" || character === '(' || isNonPrintable(character)) {
+          return false;
+        }
+
+        continue;
+      }
+
+      if (currentFrame.urlState === 'trailing') {
+        if (isWhitespace(character)) {
+          continue;
+        }
+
+        if (character === ')') {
+          delimiterFrames.pop();
+          continue;
+        }
+
+        return false;
+      }
+    }
+
+    if (character === '/' && nextCharacter === '*') {
+      inComment = true;
+      i++;
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+
+    if (character === '\\') {
+      if (nextCharacter !== undefined && isNewline(nextCharacter)) {
+        continue;
+      }
+
+      const escapeEndIndex = consumeEscape(value, i);
+      if (escapeEndIndex === undefined) {
+        return false;
+      }
+
+      i = escapeEndIndex;
+      continue;
+    }
+
+    const closingDelimiter = OPENING_DELIMITERS[character];
+    if (closingDelimiter) {
+      delimiterFrames.push({
+        closingDelimiter,
+        urlState: character === '(' && urlFunctionParentheses.has(i) ? 'leading' : undefined,
+      });
+      continue;
+    }
+
+    if (CLOSING_DELIMITERS.has(character)) {
+      if (delimiterFrames.pop()?.closingDelimiter !== character) {
+        return false;
+      }
+
+      continue;
+    }
+
+    if (character === ';' && delimiterFrames.length === 0) {
+      return false;
+    }
+  }
+
+  return quote === undefined && !inComment && delimiterFrames.length === 0;
+}
+
+function warnInvalidThemeToken(tokenName: string, reason: 'name' | 'value'): void {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `@fluentui/react-provider: Ignoring theme token ${JSON.stringify(
+        tokenName,
+      )} because its ${reason} is not valid for CSS custom property serialization.`,
+    );
+  }
+}
+
 /**
  * Creates a CSS rule from a theme object.
  *
  * Useful for scenarios when you want to apply theming statically to a top level elements like `body`.
+ * Theme names, values, and the selector are developer-authored CSS and must not be populated directly from untrusted
+ * data. This function structurally contains theme declarations, but does not validate whether CSS values are
+ * appropriate for a particular application.
  */
 export function createCSSRuleFromTheme(selector: string, theme: PartialTheme | undefined): string {
   const escapedSelector = escapeForStyleTag(selector);
 
   if (theme) {
     const cssVarsAsString = (Object.keys(theme) as (keyof typeof theme)[]).reduce((cssVarRule, cssVar) => {
-      return `${cssVarRule}--${cssVar}: ${theme[cssVar]}; `;
+      const tokenName = String(cssVar);
+      const tokenValue: unknown = theme[cssVar];
+
+      if (!THEME_TOKEN_NAME_PATTERN.test(tokenName)) {
+        warnInvalidThemeToken(tokenName, 'name');
+        return cssVarRule;
+      }
+
+      if (
+        (typeof tokenValue !== 'string' && (typeof tokenValue !== 'number' || !Number.isFinite(tokenValue))) ||
+        !isValidThemeTokenValue(String(tokenValue))
+      ) {
+        warnInvalidThemeToken(tokenName, 'value');
+        return cssVarRule;
+      }
+
+      return `${cssVarRule}--${tokenName}: ${tokenValue}; `;
     }, '');
 
     return `${escapedSelector} { ${escapeForStyleTag(cssVarsAsString)} }`;

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -71,6 +71,27 @@ describe('useFluentProviderThemeStyleTag', () => {
     expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--css-variable-1: 1; --css-variable-2: 2;}"`);
   });
 
+  it('should omit invalid theme entries without affecting valid CSS variables', () => {
+    const logWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const theme = {
+      invalidToken: 'url(resource/*);token/**/)',
+      validToken: 'green',
+    } as unknown as Theme;
+
+    const { result } = renderHook(() =>
+      useFluentProviderThemeStyleTag({ theme, targetDocument: document, rendererAttributes: {} }),
+    );
+
+    const tag = document.getElementById(result.current.styleTagId) as HTMLStyleElement;
+    const sheet = tag.sheet as CSSStyleSheet;
+    const rule = sheet.cssRules[0] as CSSStyleRule;
+
+    expect(rule.style.getPropertyValue('--invalidToken')).toBe('');
+    expect(rule.style.getPropertyValue('--validToken')).toBe('green');
+    expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--validToken: green;}"`);
+    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalidToken"'));
+  });
+
   it('should update style tag on theme change', () => {
     // Arrange
     let theme = defaultTheme;

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -71,10 +71,9 @@ describe('useFluentProviderThemeStyleTag', () => {
     expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--css-variable-1: 1; --css-variable-2: 2;}"`);
   });
 
-  it('should omit invalid theme entries without affecting valid CSS variables', () => {
-    const logWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  it('should contain theme entries without affecting later CSS variables', () => {
     const theme = {
-      invalidToken: 'url(resource/*);token/**/)',
+      customToken: 'red; color: red',
       validToken: 'green',
     } as unknown as Theme;
 
@@ -86,10 +85,11 @@ describe('useFluentProviderThemeStyleTag', () => {
     const sheet = tag.sheet as CSSStyleSheet;
     const rule = sheet.cssRules[0] as CSSStyleRule;
 
-    expect(rule.style.getPropertyValue('--invalidToken')).toBe('');
+    expect(rule.style.getPropertyValue('--customToken')).toBe('red\\3B  color: red');
     expect(rule.style.getPropertyValue('--validToken')).toBe('green');
-    expect(rule.cssText).toMatchInlineSnapshot(`".fui-FluentProvider1 {--validToken: green;}"`);
-    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining('"invalidToken"'));
+    expect(rule.cssText).toMatchInlineSnapshot(
+      `".fui-FluentProvider1 {--customToken: red\\\\3B  color: red; --validToken: green;}"`,
+    );
   });
 
   it('should update style tag on theme change', () => {

--- a/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
+++ b/packages/react-components/react-provider/library/src/components/FluentProvider/useFluentProviderThemeStyleTag.test.tsx
@@ -92,6 +92,22 @@ describe('useFluentProviderThemeStyleTag', () => {
     );
   });
 
+  it('should isolate malformed URL content from later CSS variables', () => {
+    const theme = {
+      customToken: 'url(\\x")',
+      validToken: 'green',
+    } as unknown as Theme;
+
+    const { result } = renderHook(() =>
+      useFluentProviderThemeStyleTag({ theme, targetDocument: document, rendererAttributes: {} }),
+    );
+
+    const tag = document.getElementById(result.current.styleTagId) as HTMLStyleElement;
+    const rule = (tag.sheet as CSSStyleSheet).cssRules[0] as CSSStyleRule;
+
+    expect(rule.style.getPropertyValue('--validToken')).toBe('green');
+  });
+
   it('should update style tag on theme change', () => {
     // Arrange
     let theme = defaultTheme;


### PR DESCRIPTION
## Previous Behavior

`createCSSRuleFromTheme` serialized theme entries without verifying that each token name and value remained within one CSS custom-property declaration. A malformed entry could invalidate declarations that followed it, and the theming documentation did not describe the trust boundary for dynamic theme data.

## New Behavior

`createCSSRuleFromTheme` now accepts CSS escape-aware custom-property names and structurally contains each token value before serialization. Valid CSS syntax remains unchanged, including colors, font-family fallbacks, quoted strings, comments, nested functions, gradients, calculations, case-insensitive escaped URL forms, hash and at-keyword token contexts, other escapes, and multiline whitespace. Angle-bracket and delimiter processing consume input linearly while preserving CSS escape parity and mixed-block recovery. Malformed lexical contexts are repaired at the token boundary so later declarations remain independently parseable; unsupported token names are omitted with a development-only warning that identifies the name without including its value.

Regression coverage exercises exported themes, escaped custom-token names, compatibility syntax, long backslash and delimiter runs, malformed-entry isolation, client stylesheet insertion, and server-rendered style output. The theming documentation clarifies that applications must validate dynamic data against an application-specific schema before constructing a theme.

## Validation

- [x] `yarn nx run react-provider:test` (126 tests, 14 snapshots)
- [x] `yarn nx run react-provider:lint`
- [x] `yarn nx run react-provider:type-check`
- [x] `yarn nx run react-provider:format:check`
- [x] `yarn nx run react-provider:build`
- [x] `yarn beachball check`
- [x] FluentProvider bundle comparison: 22.083 kB minified / 8.491 kB gzip, +1.997 kB / +790 B against master; below the repository threshold

## Related Issue(s)

- None.