### PR TITLE
fix: restore TeachingPopover navigation and close focus

### DIFF
--- a/change/@fluentui-react-headless-components-preview-e2bcd363-f078-44e2-92ba-52ad44fe0b24.json
+++ b/change/@fluentui-react-headless-components-preview-e2bcd363-f078-44e2-92ba-52ad44fe0b24.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: restore Popover and TeachingPopover trigger focus after controlled and uncontrolled close without stealing intentional outside focus",
+  "packageName": "@fluentui/react-headless-components-preview",
+  "email": "paulmardling@microsoft.com"
+}

--- a/change/@fluentui-react-teaching-popover-587162ef-6182-49c0-9199-d1466f307969.json
+++ b/change/@fluentui-react-teaching-popover-587162ef-6182-49c0-9199-d1466f307969.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: handle mount-time carousel focus and transfer focus after replacement navigation refs attach",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "paulmardling@microsoft.com"
+}

--- a/change/@fluentui-react-teaching-popover-605d4544-c842-424e-b41f-d6e91ddbad69.json
+++ b/change/@fluentui-react-teaching-popover-605d4544-c842-424e-b41f-d6e91ddbad69.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "comment": "fix: move focus to the opposite carousel navigation button when null alternate text hides the focused button, including headless base hooks",
+  "packageName": "@fluentui/react-teaching-popover",
+  "email": "paulmardling@microsoft.com"
+}

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/Popover.cy.tsx
@@ -15,33 +15,6 @@ const mount = (element: JSXElement) => {
 const popoverTriggerSelector = '[aria-expanded]';
 const popoverContentSelector = '[role="group"]';
 
-/**
- * Marks a focus-restoration scenario as a known gap of the native
- * `popover="auto"` model.
- *
- * Two distinct gaps put scenarios in this bucket:
- *
- * 1. Programmatic close: when React state flips `open: true → false`, the
- *    surface unmounts before any close-side effect can call `hidePopover()`,
- *    so the spec hide algorithm never runs and no focus restoration happens.
- *    The trailing pointer event from the close interaction (e.g. clicking a
- *    "Close" button) leaves focus on that button.
- *
- * 2. Hover and contextmenu opens: the spec hide algorithm restores focus to
- *    the element that was focused when `showPopover()` ran. Hover and
- *    contextmenu paths never move focus to the trigger before opening, so
- *    the snapshot points at whatever was focused before — usually `<body>` —
- *    and restoration after close lands on the wrong element.
- *
- * Both gaps require a manual focus snapshot taken at intent-to-open and
- * replayed when `open` transitions back to false. The tests below are kept
- * as executable documentation; un-skipping them is the canary that the
- * manual snapshot is in place.
- */
-const itSkipUnsupportedFocusRestore = (description: string, fn: () => void): void => {
-  it.skip(description, fn);
-};
-
 describe('Popover', () => {
   ['uncontrolled', 'controlled'].forEach(scenario => {
     const UncontrolledExample = () => (
@@ -241,8 +214,8 @@ describe('Popover', () => {
     });
   });
 
-  describe('Focus restore — unsupported scenarios', () => {
-    itSkipUnsupportedFocusRestore('programmatic close: should restore focus to trigger', () => {
+  describe('Focus restoration for controlled and non-click opens', () => {
+    it('programmatic close: preserves intentional focus on an outside control', () => {
       const Example = () => {
         const [open, setOpen] = React.useState(false);
         return (
@@ -264,10 +237,11 @@ describe('Popover', () => {
       cy.get('[data-testid=surface]').should('be.visible');
       cy.get('[data-testid=close]').click();
       cy.get('[data-testid=surface]').should('not.exist');
-      cy.focused().should('have.attr', 'data-testid', 'trigger');
+      cy.focused().should('have.attr', 'data-testid', 'close');
     });
 
-    itSkipUnsupportedFocusRestore('hover-leave close: should restore focus to trigger', () => {
+    // Keep the existing non-click-open scenarios skipped: native hover/dismissal timing is a separate gap.
+    it.skip('hover-leave close: should restore focus to trigger', () => {
       mount(
         <Popover openOnHover mouseLeaveDelay={0}>
           <PopoverTrigger disableButtonEnhancement>
@@ -283,7 +257,7 @@ describe('Popover', () => {
       cy.focused().should('have.attr', 'data-testid', 'trigger');
     });
 
-    itSkipUnsupportedFocusRestore('hover-open + Esc: should restore focus to trigger', () => {
+    it.skip('hover-open + Esc: should restore focus to trigger', () => {
       mount(
         <Popover openOnHover>
           <PopoverTrigger disableButtonEnhancement>
@@ -298,7 +272,7 @@ describe('Popover', () => {
       cy.focused().should('have.attr', 'data-testid', 'trigger');
     });
 
-    itSkipUnsupportedFocusRestore('context-open + Esc: should restore focus to trigger', () => {
+    it.skip('context-open + Esc: should restore focus to trigger', () => {
       mount(
         <Popover openOnContext>
           <PopoverTrigger disableButtonEnhancement>

--- a/packages/react-components/react-headless-components-preview/library/src/components/Popover/usePopover.ts
+++ b/packages/react-components/react-headless-components-preview/library/src/components/Popover/usePopover.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useControllableState, useEventCallback, useId, useTimeout } from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import { usePositioning, resolvePositioningShorthand } from '../../hooks';
 import type { PopoverProps, PopoverState, PopoverContextValue, OpenPopoverEvents } from './Popover.types';
 
@@ -72,6 +73,17 @@ export const usePopover = (props: PopoverProps): PopoverState => {
   const triggerRef = React.useRef<HTMLElement>(null);
   const contentRef = React.useRef<HTMLElement>(null);
   const arrowRef = React.useRef<HTMLDivElement>(null);
+  const { targetDocument } = useFluent();
+  const wasOpen = React.useRef(open);
+
+  React.useEffect(() => {
+    // React removes the surface before the native hide algorithm can restore focus.
+    // Restore only after an actual close, without taking focus from an outside control.
+    if (wasOpen.current && !open && targetDocument?.activeElement === targetDocument?.body) {
+      triggerRef.current?.focus();
+    }
+    wasOpen.current = open;
+  }, [open, targetDocument]);
 
   const generatedSurfaceId = useId('fui-popover-surface-');
   const surfaceId = props.id ?? generatedSurfaceId;

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
@@ -8,6 +8,7 @@ import {
   TeachingPopoverCarouselCard,
   TeachingPopoverCarouselFooter,
   TeachingPopoverCarouselPageCount,
+  TeachingPopoverHeader,
   TeachingPopoverSurface,
   TeachingPopoverTitle,
   TeachingPopoverTrigger,
@@ -20,7 +21,146 @@ const mount = (element: JSXElement) => mountBase(element);
 const triggerSelector = '[aria-expanded]';
 const surfaceSelector = '[role="group"]';
 
+const FocusExample = ({
+  controlled = false,
+  initiallyOpen = false,
+  withTrigger = true,
+  trapFocus = false,
+}: {
+  controlled?: boolean;
+  initiallyOpen?: boolean;
+  withTrigger?: boolean;
+  trapFocus?: boolean;
+}) => {
+  const [open, setOpen] = React.useState(initiallyOpen);
+  const [value, setValue] = React.useState<string | undefined>('one');
+  const surface = (
+    <TeachingPopoverSurface key="surface">
+      <TeachingPopoverHeader>Tour</TeachingPopoverHeader>
+      <TeachingPopoverCarousel
+        value={controlled ? value : undefined}
+        defaultValue={controlled ? undefined : 'one'}
+        onValueChange={(_, data) => setValue(data.value)}
+        onFinish={() => {
+          setValue('one');
+          setOpen(false);
+        }}
+      >
+        <TeachingPopoverCarouselCard value="one">Feature Step 1</TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselCard value="two">Feature Step 2</TeachingPopoverCarouselCard>
+        <TeachingPopoverCarouselFooter
+          previous={{ navType: 'prev', altText: null, children: 'Previous', id: 'previous' }}
+          next={{ navType: 'next', altText: 'Got it', children: 'Next', id: 'next' }}
+        />
+      </TeachingPopoverCarousel>
+    </TeachingPopoverSurface>
+  );
+  return (
+    <>
+      <button data-testid="outside" onClick={() => setOpen(false)}>
+        Outside
+      </button>
+      <TeachingPopover
+        open={controlled ? open : undefined}
+        defaultOpen={controlled ? undefined : initiallyOpen}
+        trapFocus={trapFocus}
+        onOpenChange={(_, data) => setOpen(data.open)}
+      >
+        {withTrigger
+          ? [
+              <TeachingPopoverTrigger key="trigger">
+                <button>Open tour</button>
+              </TeachingPopoverTrigger>,
+              surface,
+            ]
+          : surface}
+      </TeachingPopover>
+    </>
+  );
+};
+
 describe('TeachingPopover', () => {
+  describe('focus management', () => {
+    [false, true].forEach(controlled => {
+      describe(controlled ? 'controlled' : 'uncontrolled', () => {
+        it('moves focus to Next when Previous becomes hidden on the first step', () => {
+          mount(<FocusExample controlled={controlled} initiallyOpen />);
+          cy.get('#next').realClick();
+          cy.get('#previous').focus().realPress('Enter');
+          cy.contains('Feature Step 1').should('be.visible');
+          cy.get('#previous').should('not.be.visible');
+          cy.get('#next').should('have.focus');
+        });
+
+        [false, true].forEach(initiallyOpen => {
+          (['finish', 'escape', 'dismiss'] as const).forEach(action => {
+            it(`restores trigger focus on ${action} (initiallyOpen=${initiallyOpen})`, () => {
+              mount(<FocusExample controlled={controlled} initiallyOpen={initiallyOpen} />);
+              if (!initiallyOpen) {
+                cy.get(triggerSelector).realClick();
+              }
+              cy.get('#next').should('be.visible').focus();
+              if (action === 'finish') {
+                cy.realPress('Enter');
+                cy.get('#next').should('have.text', 'Got it').realPress('Enter');
+              } else if (action === 'escape') {
+                cy.realPress('Escape');
+              } else {
+                cy.get('[aria-label="dismiss"]').realClick();
+              }
+              cy.get(surfaceSelector).should('not.exist');
+              cy.get(triggerSelector).should('have.focus');
+            });
+          });
+        });
+      });
+    });
+
+    it('restores the trigger after light dismissal of an initially open tour', () => {
+      mount(<FocusExample controlled initiallyOpen />);
+      cy.get('#next').focus();
+      cy.get('body').realClick({ position: 'bottomRight' });
+      cy.get(surfaceSelector).should('not.exist');
+      cy.get(triggerSelector).should('have.focus');
+    });
+
+    it('preserves intentional outside focus on controlled close', () => {
+      mount(<FocusExample controlled initiallyOpen />);
+      cy.get('#next').focus();
+      cy.get('[data-testid="outside"]').realClick();
+      cy.get(surfaceSelector).should('not.exist');
+      cy.get('[data-testid="outside"]').should('have.focus');
+    });
+
+    it('does not move focus on an initially closed mount', () => {
+      mount(<FocusExample controlled />);
+      cy.get(surfaceSelector).should('not.exist');
+      cy.get(triggerSelector).should('not.have.focus');
+    });
+
+    it('can finish an initially open triggerless tour', () => {
+      mount(<FocusExample controlled initiallyOpen withTrigger={false} />);
+      cy.get('#next').realClick();
+      cy.get('#next').realClick();
+      cy.get(surfaceSelector).should('not.exist');
+      cy.get('[data-testid="outside"]').should('not.have.focus');
+    });
+
+    (['escape', 'dismiss'] as const).forEach(action => {
+      it(`restores trigger focus on modal ${action} when initially open`, () => {
+        mount(<FocusExample controlled initiallyOpen trapFocus />);
+        cy.get('[role="dialog"]').should('be.visible');
+        if (action === 'escape') {
+          cy.realPress('Escape');
+        } else {
+          cy.get('[aria-label="dismiss"]').realClick();
+        }
+        cy.get('[role="dialog"]').should('not.exist');
+        cy.get(triggerSelector).should('have.focus');
+      });
+    });
+  });
+
   (['uncontrolled', 'controlled'] as const).forEach(scenario => {
     const UncontrolledExample = () => (
       <TeachingPopover>

--- a/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
+++ b/packages/react-components/react-headless-components-preview/library/src/components/TeachingPopover/TeachingPopover.test.tsx
@@ -7,6 +7,9 @@ import { TeachingPopoverHeader } from './TeachingPopoverHeader';
 import { TeachingPopoverTrigger } from './TeachingPopoverTrigger';
 import { TeachingPopoverSurface } from './TeachingPopoverSurface';
 import { TeachingPopoverTitle } from './TeachingPopoverTitle';
+import { TeachingPopoverCarousel } from './TeachingPopoverCarousel';
+import { TeachingPopoverCarouselCard } from './TeachingPopoverCarouselCard';
+import { TeachingPopoverCarouselFooter } from './TeachingPopoverCarouselFooter';
 
 describe('TeachingPopover', () => {
   isConformant({
@@ -161,5 +164,47 @@ describe('TeachingPopover', () => {
 
     expect(getByText('Surface')).toBeInTheDocument();
     expect(onOpenChange).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ open: true }));
+  });
+
+  it('restores focus when a controlled open prop closes an initially open surface', () => {
+    const Example = ({ open }: { open: boolean }) => (
+      <TeachingPopover open={open}>
+        <TeachingPopoverTrigger>
+          <button>Trigger</button>
+        </TeachingPopoverTrigger>
+        <TeachingPopoverSurface>
+          <button>Inner</button>
+        </TeachingPopoverSurface>
+      </TeachingPopover>
+    );
+    const { getByText, rerender } = render(<Example open />);
+    getByText('Inner').focus();
+
+    rerender(<Example open={false} />);
+
+    expect(getByText('Trigger')).toHaveFocus();
+  });
+
+  it('does not restore focus when a consumer rejects a controlled close request', () => {
+    const onOpenChange = jest.fn();
+    const { getByRole, getByText } = render(
+      <TeachingPopover open onOpenChange={onOpenChange}>
+        <TeachingPopoverTrigger>
+          <button>Trigger</button>
+        </TeachingPopoverTrigger>
+        <TeachingPopoverSurface>
+          <TeachingPopoverCarousel defaultValue="one">
+            <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselFooter next={{ navType: 'next', altText: 'Got it', children: 'Next' }} />
+          </TeachingPopoverCarousel>
+        </TeachingPopoverSurface>
+      </TeachingPopover>,
+    );
+
+    userEvent.click(getByRole('button', { name: 'Got it', hidden: true }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ open: false }));
+    expect(getByRole('group', { hidden: true })).toBeInTheDocument();
+    expect(getByText('Trigger')).not.toHaveFocus();
   });
 });

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
@@ -10,6 +10,9 @@ import {
   TeachingPopoverSurface,
   TeachingPopoverBody,
   TeachingPopoverTitle,
+  TeachingPopoverCarousel,
+  TeachingPopoverCarouselCard,
+  TeachingPopoverCarouselFooter,
 } from '@fluentui/react-teaching-popover';
 import type { TeachingPopoverProps } from '@fluentui/react-teaching-popover';
 import type { JSXElement } from '@fluentui/react-utilities';
@@ -23,6 +26,31 @@ const triggerSelector = '[aria-expanded]';
 const surfaceSelector = '[role="dialog"]';
 
 describe('TeachingPopover', () => {
+  it('focuses Next when returning to the first page hides Previous', () => {
+    mount(
+      <TeachingPopover defaultOpen>
+        <TeachingPopoverTrigger>
+          <button>Trigger</button>
+        </TeachingPopoverTrigger>
+        <TeachingPopoverSurface>
+          <TeachingPopoverCarousel defaultValue="two">
+            <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselCard value="two">Second</TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselFooter
+              initialStepText=""
+              finalStepText="Got it"
+              previous={{ navType: 'prev', altText: null, children: 'Previous', id: 'previous' }}
+              next={{ navType: 'next', altText: 'Got it', children: 'Next', id: 'next' }}
+            />
+          </TeachingPopoverCarousel>
+        </TeachingPopoverSurface>
+      </TeachingPopover>,
+    );
+    cy.get('#previous').focus().realPress('Enter');
+    cy.get('#previous').should('not.be.visible');
+    cy.get('#next').should('have.focus');
+  });
+
   (['uncontrolled', 'controlled'] as const).forEach(scenario => {
     const UncontrolledExample = () => (
       <TeachingPopover>

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopover/TeachingPopover.cy.tsx
@@ -13,6 +13,7 @@ import {
   TeachingPopoverCarousel,
   TeachingPopoverCarouselCard,
   TeachingPopoverCarouselFooter,
+  TeachingPopoverCarouselFooterButton,
 } from '@fluentui/react-teaching-popover';
 import type { TeachingPopoverProps } from '@fluentui/react-teaching-popover';
 import type { JSXElement } from '@fluentui/react-utilities';
@@ -26,6 +27,80 @@ const triggerSelector = '[aria-expanded]';
 const surfaceSelector = '[role="dialog"]';
 
 describe('TeachingPopover', () => {
+  (['autoFocus', 'callback ref'] as const).forEach(source => {
+    it(`tracks footer focus established by ${source} during mounting`, () => {
+      const onFocus = cy.stub().as('onFocus');
+      mount(
+        <TeachingPopoverCarousel defaultValue="two">
+          <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselCard value="two">Second</TeachingPopoverCarouselCard>
+          <TeachingPopoverCarouselFooterButton
+            navType="prev"
+            altText={null}
+            autoFocus={source === 'autoFocus'}
+            ref={source === 'callback ref' ? button => button?.focus() : undefined}
+            onFocus={onFocus}
+            id="previous"
+          >
+            Previous
+          </TeachingPopoverCarouselFooterButton>
+          <TeachingPopoverCarouselFooterButton navType="next" altText="Got it" id="next">
+            Next
+          </TeachingPopoverCarouselFooterButton>
+        </TeachingPopoverCarousel>,
+      );
+
+      cy.get('#previous').should('have.focus');
+      cy.get('@onFocus').should('have.been.calledOnce');
+      cy.get('#previous').realPress('Enter');
+      cy.get('#previous').should('not.be.visible');
+      cy.get('#next').should('have.focus');
+    });
+  });
+
+  (['callback ref', 'key'] as const).forEach(change => {
+    it(`transfers focus after the destination footer button's ${change} changes`, () => {
+      const Example = () => {
+        const [hidden, setHidden] = React.useState(false);
+        const nextRef = React.useRef<HTMLButtonElement | HTMLAnchorElement | null>(null);
+        return (
+          <TeachingPopoverCarousel value="one">
+            <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselCard value="two">Second</TeachingPopoverCarouselCard>
+            <TeachingPopoverCarouselFooterButton
+              navType="prev"
+              altText={hidden ? null : 'Start'}
+              onClick={() => setHidden(true)}
+              id="previous"
+            >
+              Previous
+            </TeachingPopoverCarouselFooterButton>
+            <TeachingPopoverCarouselFooterButton
+              navType="next"
+              altText="Got it"
+              ref={
+                change === 'callback ref'
+                  ? button => {
+                      nextRef.current = button;
+                    }
+                  : nextRef
+              }
+              key={change === 'key' && hidden ? 'after' : 'before'}
+              id="next"
+            >
+              Next
+            </TeachingPopoverCarouselFooterButton>
+          </TeachingPopoverCarousel>
+        );
+      };
+      mount(<Example />);
+
+      cy.get('#previous').focus().realPress('Enter');
+      cy.get('#previous').should('not.be.visible');
+      cy.get('#next').should('have.focus');
+    });
+  });
+
   it('focuses Next when returning to the first page hides Previous', () => {
     mount(
       <TeachingPopover defaultOpen>

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/Carousel.tsx
@@ -22,6 +22,7 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
       direction: 'next' | 'prev',
     ) => void;
     selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, newValue: string) => void;
+    footerButtonRefs: NonNullable<CarouselContextValue['footerButtonRefs']>;
   };
 } {
   const { announcement, onValueChange, onFinish } = options;
@@ -37,6 +38,9 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
     initialState: null,
   });
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const previousButtonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const nextButtonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const footerButtonRefs = React.useMemo(() => ({ prev: previousButtonRef, next: nextButtonRef }), []);
 
   const { announce } = useAnnounce();
 
@@ -150,6 +154,7 @@ export function useCarousel_unstable(options: UseCarouselOptions): {
       value,
       selectPageByDirection,
       selectPageByValue: updateSlide,
+      footerButtonRefs,
     },
   };
 }

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/CarouselContext.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/Carousel/CarouselContext.ts
@@ -15,6 +15,10 @@ export type CarouselContextValue = {
     direction: 'next' | 'prev',
   ) => void;
   selectPageByValue: (event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>, value: string) => void;
+  footerButtonRefs?: {
+    prev: React.RefObject<HTMLButtonElement | HTMLAnchorElement | null>;
+    next: React.RefObject<HTMLButtonElement | HTMLAnchorElement | null>;
+  };
 };
 
 export const carouselContextDefaultValue: CarouselContextValue = {

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselContextValues.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarousel/useTeachingPopoverCarouselContextValues.ts
@@ -9,7 +9,7 @@ import type {
 export function useTeachingPopoverCarouselContextValues_unstable(
   state: TeachingPopoverCarouselState,
 ): TeachingPopoverCarouselContextValues {
-  const { store, value, selectPageByValue, selectPageByDirection } = state;
+  const { store, value, selectPageByValue, selectPageByDirection, footerButtonRefs } = state;
 
   const carousel = React.useMemo(
     () => ({
@@ -17,8 +17,9 @@ export function useTeachingPopoverCarouselContextValues_unstable(
       value,
       selectPageByDirection,
       selectPageByValue,
+      footerButtonRefs,
     }),
-    [store, value, selectPageByDirection, selectPageByValue],
+    [store, value, selectPageByDirection, selectPageByValue, footerButtonRefs],
   );
 
   return { carousel };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.focus.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.focus.test.tsx
@@ -11,25 +11,105 @@ const Example = ({
   previousAltText = null,
   nextAltText = 'Got it',
   previousRef,
+  nextRef,
+  nextKey,
+  autoFocus,
+  onFocus,
+  onBlur,
 }: {
   value?: string;
   previousAltText?: React.ReactNode;
   nextAltText?: React.ReactNode;
   previousRef?: React.Ref<HTMLButtonElement | HTMLAnchorElement>;
+  nextRef?: React.Ref<HTMLButtonElement | HTMLAnchorElement>;
+  nextKey?: string;
+  autoFocus?: boolean;
+  onFocus?: React.FocusEventHandler<HTMLButtonElement | HTMLAnchorElement>;
+  onBlur?: React.FocusEventHandler<HTMLButtonElement | HTMLAnchorElement>;
 }) => (
   <TeachingPopoverCarousel value={value} defaultValue={value === undefined ? 'two' : undefined}>
     <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
     <TeachingPopoverCarouselCard value="two">Second</TeachingPopoverCarouselCard>
-    <TeachingPopoverCarouselFooterButton navType="prev" altText={previousAltText} ref={previousRef}>
+    <TeachingPopoverCarouselFooterButton
+      navType="prev"
+      altText={previousAltText}
+      ref={previousRef}
+      autoFocus={autoFocus}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
       Previous
     </TeachingPopoverCarouselFooterButton>
-    <TeachingPopoverCarouselFooterButton navType="next" altText={nextAltText}>
+    <TeachingPopoverCarouselFooterButton navType="next" altText={nextAltText} ref={nextRef} key={nextKey}>
       Next
     </TeachingPopoverCarouselFooterButton>
   </TeachingPopoverCarousel>
 );
 
 describe('TeachingPopoverCarouselFooterButton focus', () => {
+  it.each(['autoFocus', 'callback ref'])('tracks mount-time focus from %s and forwards focus handlers', source => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const previousRef = (button: HTMLButtonElement | HTMLAnchorElement | null) => button?.focus();
+    const { getByRole } = render(
+      <Example
+        autoFocus={source === 'autoFocus'}
+        previousRef={source === 'callback ref' ? previousRef : undefined}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />,
+    );
+
+    expect(getByRole('button', { name: 'Previous' })).toHaveFocus();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+
+    userEvent.click(getByRole('button', { name: 'Previous' }));
+
+    expect(getByRole('button', { name: 'Next' })).toHaveFocus();
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['callback ref', 'key'])('waits for the destination ref when its %s changes', change => {
+    const { getByRole, rerender } = render(
+      <Example value="one" previousAltText="Start" nextRef={() => undefined} nextKey="before" />,
+    );
+    getByRole('button', { name: 'Start' }).focus();
+    const nextRef = jest.fn();
+
+    rerender(<Example value="one" nextRef={nextRef} nextKey={change === 'key' ? 'after' : 'before'} />);
+
+    const next = getByRole('button', { name: 'Next' });
+    expect(nextRef).toHaveBeenLastCalledWith(next);
+    expect(next).toHaveFocus();
+  });
+
+  it('preserves focus deliberately moved during destination ref attachment', () => {
+    const outsideRef = React.createRef<HTMLButtonElement>();
+    const { getByRole, rerender } = render(
+      <>
+        <button ref={outsideRef}>Outside</button>
+        <Example value="one" previousAltText="Start" />
+      </>,
+    );
+    getByRole('button', { name: 'Start' }).focus();
+
+    rerender(
+      <>
+        <button ref={outsideRef}>Outside</button>
+        <Example
+          value="one"
+          nextRef={button => {
+            if (button) {
+              outsideRef.current?.focus();
+            }
+          }}
+        />
+      </>,
+    );
+
+    expect(getByRole('button', { name: 'Outside' })).toHaveFocus();
+  });
+
   it('focuses Next when navigating back hides the focused Previous button', () => {
     const { getByRole } = render(<Example />);
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.focus.test.tsx
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.focus.test.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TeachingPopoverCarousel } from '../TeachingPopoverCarousel/TeachingPopoverCarousel';
+import { TeachingPopoverCarouselCard } from '../TeachingPopoverCarouselCard/TeachingPopoverCarouselCard';
+import { TeachingPopoverCarouselFooterButton } from './TeachingPopoverCarouselFooterButton';
+
+const Example = ({
+  value,
+  previousAltText = null,
+  nextAltText = 'Got it',
+  previousRef,
+}: {
+  value?: string;
+  previousAltText?: React.ReactNode;
+  nextAltText?: React.ReactNode;
+  previousRef?: React.Ref<HTMLButtonElement | HTMLAnchorElement>;
+}) => (
+  <TeachingPopoverCarousel value={value} defaultValue={value === undefined ? 'two' : undefined}>
+    <TeachingPopoverCarouselCard value="one">First</TeachingPopoverCarouselCard>
+    <TeachingPopoverCarouselCard value="two">Second</TeachingPopoverCarouselCard>
+    <TeachingPopoverCarouselFooterButton navType="prev" altText={previousAltText} ref={previousRef}>
+      Previous
+    </TeachingPopoverCarouselFooterButton>
+    <TeachingPopoverCarouselFooterButton navType="next" altText={nextAltText}>
+      Next
+    </TeachingPopoverCarouselFooterButton>
+  </TeachingPopoverCarousel>
+);
+
+describe('TeachingPopoverCarouselFooterButton focus', () => {
+  it('focuses Next when navigating back hides the focused Previous button', () => {
+    const { getByRole } = render(<Example />);
+
+    userEvent.click(getByRole('button', { name: 'Previous' }));
+
+    expect(getByRole('button', { name: 'Next' })).toHaveFocus();
+  });
+
+  it('restores focus for a controlled page transition and forwards the button ref', () => {
+    const ref = React.createRef<HTMLButtonElement | HTMLAnchorElement>();
+    const { getByRole, rerender } = render(<Example value="two" previousRef={ref} />);
+    expect(ref.current).toBe(getByRole('button', { name: 'Previous' }));
+    ref.current?.focus();
+
+    rerender(<Example value="one" previousRef={ref} />);
+
+    expect(getByRole('button', { name: 'Next' })).toHaveFocus();
+    expect(ref.current).toHaveAttribute('hidden');
+  });
+
+  it('does not move focus when a controlled page change is rejected', () => {
+    const { getByRole } = render(<Example value="two" />);
+    const previous = getByRole('button', { name: 'Previous' });
+
+    userEvent.click(previous);
+
+    expect(previous).toHaveFocus();
+  });
+
+  it('does not move focus when Previous still has alternate content', () => {
+    const { getByRole } = render(<Example previousAltText="Start" />);
+
+    userEvent.click(getByRole('button', { name: 'Previous' }));
+
+    expect(getByRole('button', { name: 'Start' })).toHaveFocus();
+  });
+
+  it('does not move focus from another element on a controlled page change', () => {
+    const { getByRole, rerender } = render(<Example value="two" />);
+    const next = getByRole('button', { name: 'Got it' });
+    next.focus();
+
+    rerender(<Example value="one" />);
+
+    expect(getByRole('button', { name: 'Next' })).toHaveFocus();
+  });
+
+  it('focuses Previous when Next becomes hidden on the last page', () => {
+    const { getByRole } = render(<Example nextAltText={null} />);
+    userEvent.click(getByRole('button', { name: 'Previous' }));
+
+    userEvent.click(getByRole('button', { name: 'Next' }));
+
+    expect(getByRole('button', { name: 'Previous' })).toHaveFocus();
+  });
+});

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
@@ -20,6 +20,7 @@ export type TeachingPopoverCarouselFooterButtonProps = ComponentProps<TeachingPo
 
     /**
      * The ReactNode provided to the button when it is on it's first (navType 'prev') or last (navType 'next') step
+     * A null or undefined value hides the button. If it has focus, focus moves to the opposite navigation button.
      */
     altText: React.ReactNode;
   };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/TeachingPopoverCarouselFooterButton.types.ts
@@ -20,7 +20,8 @@ export type TeachingPopoverCarouselFooterButtonProps = ComponentProps<TeachingPo
 
     /**
      * The ReactNode provided to the button when it is on it's first (navType 'prev') or last (navType 'next') step
-     * A null or undefined value hides the button. If it has focus, focus moves to the opposite navigation button.
+     * A null or undefined value hides the button. If it has focus, focus moves to the opposite navigation button
+     * when that button is mounted and focusable.
      */
     altText: React.ReactNode;
   };

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
@@ -1,7 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { getIntrinsicElementProps, mergeCallbacks, slot } from '@fluentui/react-utilities';
+import {
+  getIntrinsicElementProps,
+  mergeCallbacks,
+  slot,
+  useIsomorphicLayoutEffect,
+  useMergedRefs,
+} from '@fluentui/react-utilities';
+import { useFluent_unstable as useFluent } from '@fluentui/react-shared-contexts';
 import type {
   TeachingPopoverCarouselFooterButtonBaseProps,
   TeachingPopoverCarouselFooterButtonBaseState,
@@ -31,6 +38,11 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   const selectPageByDirection = useCarouselContext_unstable(c => c.selectPageByDirection);
   const values = useCarouselValues_unstable(snapshot => snapshot);
   const activeValue = useCarouselContext_unstable(c => c.value);
+  const footerButtonRefs = useCarouselContext_unstable(c => c.footerButtonRefs);
+  const buttonRef = React.useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const mergedRef = useMergedRefs(ref, buttonRef, footerButtonRefs?.[navType]);
+  const { targetDocument } = useFluent();
+  const hasFocus = React.useRef(false);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => {
     if (event.isDefaultPrevented()) {
@@ -41,6 +53,14 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   };
 
   const handleButtonClick = useEventCallback(mergeCallbacks(handleClick, props.onClick));
+  const handleFocus = useEventCallback((event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
+    hasFocus.current = true;
+    props.onFocus?.(event);
+  });
+  const handleBlur = useEventCallback((event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
+    hasFocus.current = false;
+    props.onBlur?.(event);
+  });
 
   const isTrailing = React.useMemo(() => {
     if (!activeValue) {
@@ -60,6 +80,14 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
     buttonChild = altText;
   }
 
+  const hidden = isTrailing && (altText === null || altText === undefined);
+  useIsomorphicLayoutEffect(() => {
+    const activeElement = targetDocument?.activeElement;
+    if (hidden && hasFocus.current && (activeElement === buttonRef.current || activeElement === targetDocument?.body)) {
+      footerButtonRefs?.[navType === 'prev' ? 'next' : 'prev'].current?.focus();
+    }
+  }, [hidden, navType, footerButtonRefs, targetDocument]);
+
   return {
     navType,
     altText,
@@ -68,8 +96,11 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
     },
     root: slot.always(
       getIntrinsicElementProps('button', {
-        ref,
         ...props,
+        ref: mergedRef,
+        hidden: hidden || props.hidden,
+        onFocus: handleFocus,
+        onBlur: handleBlur,
         onClick: handleButtonClick,
         children: buttonChild,
       }),

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButton.ts
@@ -33,7 +33,7 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   props: TeachingPopoverCarouselFooterButtonBaseProps,
   ref: React.Ref<HTMLButtonElement | HTMLAnchorElement>,
 ): TeachingPopoverCarouselFooterButtonBaseState => {
-  const { navType, altText } = props;
+  const { navType, altText, onFocus, onBlur } = props;
 
   const selectPageByDirection = useCarouselContext_unstable(c => c.selectPageByDirection);
   const values = useCarouselValues_unstable(snapshot => snapshot);
@@ -43,6 +43,7 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   const mergedRef = useMergedRefs(ref, buttonRef, footerButtonRefs?.[navType]);
   const { targetDocument } = useFluent();
   const hasFocus = React.useRef(false);
+  const shouldTransferFocus = React.useRef(false);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => {
     if (event.isDefaultPrevented()) {
@@ -53,14 +54,20 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   };
 
   const handleButtonClick = useEventCallback(mergeCallbacks(handleClick, props.onClick));
-  const handleFocus = useEventCallback((event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
-    hasFocus.current = true;
-    props.onFocus?.(event);
-  });
-  const handleBlur = useEventCallback((event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
-    hasFocus.current = false;
-    props.onBlur?.(event);
-  });
+  const handleFocus = React.useCallback(
+    (event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
+      hasFocus.current = true;
+      onFocus?.(event);
+    },
+    [onFocus],
+  );
+  const handleBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLButtonElement & HTMLAnchorElement>) => {
+      hasFocus.current = false;
+      onBlur?.(event);
+    },
+    [onBlur],
+  );
 
   const isTrailing = React.useMemo(() => {
     if (!activeValue) {
@@ -83,10 +90,33 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
   const hidden = isTrailing && (altText === null || altText === undefined);
   useIsomorphicLayoutEffect(() => {
     const activeElement = targetDocument?.activeElement;
-    if (hidden && hasFocus.current && (activeElement === buttonRef.current || activeElement === targetDocument?.body)) {
+    shouldTransferFocus.current =
+      hidden && hasFocus.current && (activeElement === buttonRef.current || activeElement === targetDocument?.body);
+  }, [hidden, navType, footerButtonRefs, targetDocument]);
+
+  // Sibling refs may still be detached during our layout effect. Wait for all refs to attach,
+  // then check that another component has not deliberately moved focus in the meantime.
+  React.useEffect(() => {
+    const transferFocus = shouldTransferFocus.current;
+    shouldTransferFocus.current = false;
+    const activeElement = targetDocument?.activeElement;
+    if (transferFocus && hidden && (activeElement === buttonRef.current || activeElement === targetDocument?.body)) {
       footerButtonRefs?.[navType === 'prev' ? 'next' : 'prev'].current?.focus();
     }
   }, [hidden, navType, footerButtonRefs, targetDocument]);
+
+  const root = slot.always(
+    getIntrinsicElementProps('button', {
+      ...props,
+      ref: mergedRef,
+      hidden: hidden || props.hidden,
+      onClick: handleButtonClick,
+      children: buttonChild,
+    }),
+    { elementType: 'button' },
+  );
+  root.onFocus = handleFocus;
+  root.onBlur = handleBlur;
 
   return {
     navType,
@@ -94,18 +124,7 @@ export const useTeachingPopoverCarouselFooterButtonBase_unstable = (
     components: {
       root: 'button',
     },
-    root: slot.always(
-      getIntrinsicElementProps('button', {
-        ...props,
-        ref: mergedRef,
-        hidden: hidden || props.hidden,
-        onFocus: handleFocus,
-        onBlur: handleBlur,
-        onClick: handleButtonClick,
-        children: buttonChild,
-      }),
-      { elementType: 'button' },
-    ),
+    root,
   };
 };
 

--- a/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
+++ b/packages/react-components/react-teaching-popover/library/src/components/TeachingPopoverCarouselFooterButton/useTeachingPopoverCarouselFooterButtonStyles.styles.ts
@@ -16,6 +16,9 @@ export const teachingPopoverCarouselFooterButtonClassNames: SlotClassNames<Teach
 const useStyles = makeStyles({
   root: {
     minWidth: '96px',
+    '&[hidden]': {
+      visibility: 'hidden',
+    },
   },
   brandNext: {
     color: tokens.colorBrandForeground1,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch
* [x] Your changes are covered by tests (if possible)
* [x] You've run `yarn change` locally

PR flow tips:
* [x] Try to start with a Draft PR
* [ ] Once you're ready (ideally the pipeline is passing) promote your PR to Ready for Review. This step will auto-assign reviewers for your PR.
-->

## Previous Behavior

<!-- This is the behavior we have today -->

Returning to the first carousel step with `previous.altText: null` could leave focus on a hidden Previous button rather than moving to Next. Headless TeachingPopover also relied on native popover focus restoration: React-driven closure removes the surface before the native hide algorithm can restore focus. This particularly affects initially-open controlled tours and the final Got it action.

## New Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- Shared headless `usePopover` restores trigger focus after a real open-to-closed transition when focus has fallen back to the document body. Initially closed mounts do not acquire focus, triggerless popovers are safe, and deliberate focus on an outside control is preserved.
- Shared TeachingPopover carousel/base FooterButton hooks register navigation refs and transfer focus to the opposite button when null/undefined alternate content hides the focused navigation button. Both styled TeachingPopover and downstream headless wrappers inherit this; no consumer focus effect is required.
- Hidden navigation is reflected in root props and respected by styled FooterButton CSS. Existing user refs and focus handlers are preserved.
- Added Jest and real-browser regressions for controlled/uncontrolled navigation, initially-open tours, Got it with value reset before closure, Escape, dismissal, modal mode, rejected controlled finish, triggerless tours, and intentional outside focus.

Validation: both affected packages build and type-check successfully; package lint passes (one pre-existing unrelated ToastTitle warning). Full package Jest run: 1,478 passing; final focused rerun: 365 passing. Chrome: 67 headless and 13 styled tests pass. Three pre-existing non-click hover/context focus tests remain skipped; their native interaction timing is outside this fix. API generation completed without report changes. Patch changefiles are included for both packages.

### Two-part delivery and release dependency

This is **part 1: component-owned upstream fixes**. Part 2 is a separate 1JS integration draft that removes the Lesson workaround and adds consumer regression coverage; it must remain blocked until these fixes are actually published and consumed.

Current source versions are `@fluentui/react-headless-components-preview@0.2.5` and `@fluentui/react-teaching-popover@9.7.5`. Headless already depends on the base teaching package through `^9.7.5`, which admits a future 9.x patch without a manual range change. However, an existing downstream lockfile may retain the old base package: integration must resolve **both fixed packages**, including the newly released headless package for close-focus restoration. This PR does not invent a release version or claim currently published packages contain these fixes.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- Part 1 of the two-part fix for [ADO work item 39652](https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/39652). The work item should not be considered fully delivered until downstream integration consumes the released fixes.