### PR TITLE
fix(react): WeeklyDayPicker shows correct week number in collapsed view

### DIFF
--- a/change/@fluentui-react-36721-week-number.json
+++ b/change/@fluentui-react-36721-week-number.json
@@ -1,0 +1,5 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react",
+  "comment": "CalendarDayGrid: fixed the week number shown in collapsed single-week views (e.g. WeeklyDayPicker) to be the visible week's number instead of the first week-of-month number."
+}

--- a/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarDayGrid.test.tsx
@@ -1,9 +1,47 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { resetIds } from '@fluentui/utilities';
 import { CalendarDayGrid } from './CalendarDayGrid';
 import { defaultCalendarStrings } from '../Calendar/index';
 import { DateRangeType, DayOfWeek, FirstWeekOfYear } from '@fluentui/date-time-utilities';
 import { isConformant } from '../../common/isConformant';
 
 describe('CalendarDayGrid', () => {
+  beforeEach(() => {
+    resetIds();
+  });
+
+  // Regression test for https://github.com/microsoft/fluentui/issues/36721
+  it('shows the week number of the visible week in collapsed single-week view', () => {
+    // Fri Sep 11 2026 belongs to the week of Sep 6 - Sep 12, which is week 36.
+    const navigatedDate = new Date(2026, 8, 11);
+    const { container } = render(
+      <CalendarDayGrid
+        strings={defaultCalendarStrings}
+        selectedDate={navigatedDate}
+        navigatedDate={navigatedDate}
+        dateRangeType={DateRangeType.Week}
+        weeksToShow={1}
+        showWeekNumbers={true}
+        firstDayOfWeek={DayOfWeek.Sunday}
+        firstWeekOfYear={FirstWeekOfYear.FirstFullWeek}
+        dateTimeFormatter={{
+          formatMonthDayYear: () => 'm/d/y',
+          formatMonthYear: () => 'm/y',
+          formatDay: () => 'd',
+          formatMonth: () => 'm',
+          formatYear: () => 'y',
+        }}
+      />,
+    );
+
+    const displayedWeekNumbers = Array.from(container.querySelectorAll('th[scope="row"] span')).map(
+      cell => cell.textContent,
+    );
+    // The visible row must show 36 (its own week), not 35 (the first week-of-month number).
+    expect(displayedWeekNumbers).toContain('36');
+  });
+
   isConformant({
     Component: CalendarDayGrid,
     displayName: 'CalendarDayGrid',

--- a/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
+++ b/packages/react/src/components/CalendarDayGrid/CalendarGridRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { format } from '@fluentui/utilities';
-import { getWeekNumbersInMonth } from '@fluentui/date-time-utilities';
+import { getWeekNumber } from '@fluentui/date-time-utilities';
 import { CalendarGridDayCell } from './CalendarGridDayCell';
 import type { ICalendarDayGridProps, ICalendarDayGridStyles } from './CalendarDayGrid.types';
 import type { IProcessedStyleSet } from '@fluentui/style-utilities';
@@ -33,27 +33,28 @@ export const CalendarGridRow: React.FunctionComponent<ICalendarGridRowProps> = p
   const {
     classNames,
     week,
-    weeks,
     weekIndex,
     rowClassName,
     ariaRole,
     showWeekNumbers,
     firstDayOfWeek,
     firstWeekOfYear,
-    navigatedDate,
     strings,
   } = props;
-  const weekNumbers = showWeekNumbers
-    ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate)
+  // Derive the week number from the row's own days instead of the navigated month, so that
+  // collapsed views rendering a single week (e.g. WeeklyDayPicker) show the visible week's number.
+  const weekNumber = showWeekNumbers
+    ? getWeekNumber(week[week.length - 1].originalDate, firstDayOfWeek, firstWeekOfYear)
     : null;
 
-  const titleString = weekNumbers
-    ? strings.weekNumberFormatString && format(strings.weekNumberFormatString, weekNumbers[weekIndex])
-    : '';
+  const titleString =
+    weekNumber !== null
+      ? strings.weekNumberFormatString && format(strings.weekNumberFormatString, weekNumber)
+      : '';
 
   return (
     <tr role={ariaRole} className={rowClassName} key={weekIndex + '_' + week[0].key}>
-      {showWeekNumbers && weekNumbers && (
+      {showWeekNumbers && weekNumber !== null && (
         <th
           className={classNames.weekNumberCell}
           key={weekIndex}
@@ -61,7 +62,7 @@ export const CalendarGridRow: React.FunctionComponent<ICalendarGridRowProps> = p
           aria-label={titleString}
           scope="row"
         >
-          <span>{weekNumbers[weekIndex]}</span>
+          <span>{weekNumber}</span>
         </th>
       )}
       {week.map((day: IDayInfo, dayIndex: number) => (


### PR DESCRIPTION
Fixes #36721.

**What was wrong**

`CalendarGridRow` rendered the week number as `weekNumbers[weekIndex]`, where `weekNumbers` comes from `getWeekNumbersInMonth(...)` anchored on the 1st of the navigated month. In collapsed single-week views (`weeksToShow=1`, e.g. `WeeklyDayPicker`) only one row is visible, so `weekIndex` is always `0` and the row always showed the first week-of-month number instead of the visible week's number.

**How I reproduced it**

Built a day grid for `navigatedDate = Fri Sep 11 2026` with `dateRangeType=Week, weeksToShow=1, firstDayOfWeek=Sunday, firstWeekOfYear=FirstFullWeek` and ran the row's logic against it: the visible row (Sep 6 - Sep 12) rendered `35` while the actual week number is `36`.

**The fix**

`CalendarGridRow` now derives the week number from the row's own days — `getWeekNumber` of the last day of the week — instead of indexing into the month-anchored array. This is a 3-line change in the component plus a regression test.

**Tests**

- Verified the new values are identical to the old ones in full-month view: 561 grid rows checked across 12 months x 3 `firstDayOfWeek` values x 3 `firstWeekOfYear` values, zero differences.
- Verified the collapsed view now shows the correct week for every day of 2026 (365/365).
- Ran the existing `dateMath` week-number assertions (`getWeekNumbersInMonth` / `getWeekNumber`, all four option groups from `dateMath.test.ts`): 4/4 pass.
- Added a regression test in `CalendarDayGrid.test.tsx` that renders a collapsed single-week grid with `showWeekNumbers` and asserts the visible row shows `36` for Sep 11 2026 (it shows `35` without the fix).
- Added the required beachball change file.

Note: the repo's jest setup needs a full `yarn install`, which isn't available in this environment, so the component test above was validated through the same logic against the repo's real date-time sources rather than a jest run.
