### PR TITLE
feat(react-charts): support custom GaugeChart callouts

### DIFF
--- a/change/@fluentui-react-charts-41ee7c3f-230b-4ab1-a21a-5ce47ab437a8.json
+++ b/change/@fluentui-react-charts-41ee7c3f-230b-4ab1-a21a-5ce47ab437a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add custom callout rendering to GaugeChart",
+  "packageName": "@fluentui/react-charts",
+  "email": "atisjai@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/charts/react-charts/library/etc/react-charts.api.md
+++ b/packages/charts/react-charts/library/etc/react-charts.api.md
@@ -896,6 +896,15 @@ export interface GanttChartStyles extends CartesianChartStyles {
 export const GaugeChart: React_2.FunctionComponent<GaugeChartProps>;
 
 // @public
+export interface GaugeChartCalloutData {
+    chartValue: number;
+    chartValueLabel: string;
+    maxValue: number;
+    minValue: number;
+    segmentValues: YValueHover[];
+}
+
+// @public
 export interface GaugeChartProps {
     calloutProps?: Partial<ChartPopoverProps>;
     chartTitle?: string;
@@ -912,6 +921,7 @@ export interface GaugeChartProps {
     legendProps?: Partial<LegendsProps>;
     maxValue?: number;
     minValue?: number;
+    onRenderCallout?: RenderFunction<GaugeChartCalloutData>;
     roundCorners?: boolean;
     segments: GaugeChartSegment[];
     styles?: GaugeChartStyles;

--- a/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.test.tsx
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FluentProvider } from '@fluentui/react-provider';
 import { getByClass, testWithoutWait, testScreenResolutionChanges } from '../../utilities/TestUtility.test';
 import { axe, toHaveNoViolations } from 'jest-axe';
-import type { ExtendedSegment } from './GaugeChart';
+import type { ExtendedSegment, GaugeChartCalloutData } from './GaugeChart';
 import { GaugeChart, calcNeedleRotation, getSegmentLabel, getChartValueLabel, ARC_PADDING } from './GaugeChart';
 expect.extend(toHaveNoViolations);
 
@@ -377,6 +377,45 @@ describe('GaugeChart snapshot tests', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+});
+
+describe('GaugeChart custom callout', () => {
+  testWithoutWait(
+    'Should render a custom callout',
+    GaugeChart,
+    {
+      segments,
+      chartValue: 30,
+      onRenderCallout: (calloutData?: GaugeChartCalloutData) => (
+        <div data-testid="custom-gauge-callout">{calloutData?.chartValue} blocks</div>
+      ),
+    },
+    () => {
+      const chartSegments = screen.getAllByText((content, element) => element!.tagName.toLowerCase() === 'path');
+      fireEvent.mouseOver(chartSegments[0]);
+
+      expect(screen.getByTestId('custom-gauge-callout')).toHaveTextContent('30 blocks');
+    },
+  );
+
+  testWithoutWait(
+    'Should provide the default callout renderer to a custom renderer',
+    GaugeChart,
+    {
+      segments,
+      chartValue: 30,
+      onRenderCallout: (calloutData, defaultRender) => (
+        <div data-testid="wrapped-gauge-callout">{defaultRender?.(calloutData)}</div>
+      ),
+    },
+    () => {
+      const chartSegments = screen.getAllByText((content, element) => element!.tagName.toLowerCase() === 'path');
+      fireEvent.mouseOver(chartSegments[0]);
+
+      expect(screen.getByTestId('wrapped-gauge-callout')).toHaveTextContent('Current value is 30/100');
+      expect(screen.getByTestId('wrapped-gauge-callout')).toHaveTextContent('Low Risk');
+    },
+  );
 });
 
 describe('GaugeChart rendering and behavior tests', () => {

--- a/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.tsx
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.tsx
@@ -20,7 +20,13 @@ import { formatToLocaleString } from '@fluentui/chart-utilities';
 import { SVGTooltipText } from '../../utilities/SVGTooltipText';
 import type { Legend, LegendShape } from '../Legends/index';
 import { Legends, Shape } from '../Legends/index';
-import type { GaugeChartVariant, GaugeValueFormat, GaugeChartProps, GaugeChartSegment } from './GaugeChart.types';
+import type {
+  GaugeChartCalloutData,
+  GaugeChartVariant,
+  GaugeValueFormat,
+  GaugeChartProps,
+  GaugeChartSegment,
+} from './GaugeChart.types';
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { ChartPopover } from '../CommonComponents/ChartPopover';
 import { useImageExport } from '../../utilities/hooks';
@@ -129,7 +135,6 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
     const [selectedLegends, setSelectedLegends] = React.useState<string[]>(props.legendProps?.selectedLegends || []);
     const [focusedElement, setFocusedElement] = React.useState<string | undefined>('');
     const [isPopoverOpen, setPopoverOpen] = React.useState(false);
-    const [hoverXValue, setHoverXValue] = React.useState<string | number>('');
     const [hoverYValues, setHoverYValues] = React.useState<YValue[]>([]);
     const [refSelected, setRefSelected] = React.useState<HTMLElement | null>(null);
     const prevPropsRef = React.useRef<GaugeChartProps | null>(null);
@@ -383,9 +388,6 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
       const targetElement = document.getElementById(elementId!);
       _calloutAnchor = legend;
       // eslint-disable-next-line @typescript-eslint/no-shadow
-      const hoverXValue: string =
-        'Current value is ' + getChartValueLabel(props.chartValue, _minValue, _maxValue, props.chartValueFormat, true);
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const hoverYValues: YValue[] = _segments
         .filter(segment => _noLegendHighlighted() || _legendHighlighted(segment.legend))
         .map(segment => {
@@ -400,7 +402,6 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
         ['Needle', 'Chart value'].includes(legend) || _noLegendHighlighted() || _legendHighlighted(legend),
       );
       setRefSelected(targetElement);
-      setHoverXValue(hoverXValue);
       setHoverYValues(hoverYValues);
       if (isFocusEvent) {
         setFocusedElement(legend);
@@ -410,7 +411,6 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
     function _hideCallout(isBlurEvent?: boolean) {
       _calloutAnchor = '';
       setPopoverOpen(false);
-      setHoverXValue('');
       setHoverYValues([]);
       if (isBlurEvent) {
         setFocusedElement('');
@@ -486,6 +486,15 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
           </div>
         </div>
       );
+    }
+
+    function _renderCallout(calloutData?: GaugeChartCalloutData): React.ReactElement | null {
+      return calloutData
+        ? _multiValueCallout({
+            hoverXValue: `Current value is ${calloutData.chartValueLabel}`,
+            YValueHover: calloutData.segmentValues,
+          })
+        : null;
     }
 
     function _yValueHoverSubCountsExists(yValueHover?: YValueHover[]) {
@@ -708,7 +717,26 @@ export const GaugeChart: React.FunctionComponent<GaugeChartProps> = React.forwar
             }}
             isPopoverOpen={isPopoverOpen}
             customCallout={{
-              customizedCallout: _multiValueCallout({ hoverXValue, YValueHover: hoverYValues }),
+              customizedCallout:
+                (() => {
+                  const calloutData: GaugeChartCalloutData = {
+                    chartValue: props.chartValue,
+                    minValue: _minValue,
+                    maxValue: _maxValue,
+                    chartValueLabel: getChartValueLabel(
+                      props.chartValue,
+                      _minValue,
+                      _maxValue,
+                      props.chartValueFormat,
+                      true,
+                    ),
+                    segmentValues: hoverYValues,
+                  };
+
+                  return props.onRenderCallout
+                    ? props.onRenderCallout(calloutData, _renderCallout)
+                    : _renderCallout(calloutData);
+                })() ?? undefined,
             }}
           />
         )}

--- a/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.types.ts
+++ b/packages/charts/react-charts/library/src/components/GaugeChart/GaugeChart.types.ts
@@ -1,7 +1,9 @@
 import type { LegendsProps } from '../Legends/index';
 import type { AccessibilityProps, Chart } from '../../types/index';
 import type { ChartPopoverProps } from '../CommonComponents/ChartPopover.types';
+import type { YValueHover } from '../CommonComponents/CartesianChart.types';
 import type { TitleStyles } from '../../utilities/Common.styles';
+import type { RenderFunction } from '../../utilities/index';
 
 /**
  * Gauge Chart segment interface.
@@ -43,6 +45,37 @@ export type GaugeValueFormat = 'percentage' | 'fraction';
  * {@docCategory GaugeChart}
  */
 export type GaugeChartVariant = 'single-segment' | 'multiple-segments';
+
+/**
+ * Data provided to a custom GaugeChart callout renderer.
+ * {@docCategory GaugeChart}
+ */
+export interface GaugeChartCalloutData {
+  /**
+   * Current value of the gauge.
+   */
+  chartValue: number;
+
+  /**
+   * Minimum value of the gauge.
+   */
+  minValue: number;
+
+  /**
+   * Maximum value of the gauge.
+   */
+  maxValue: number;
+
+  /**
+   * Formatted current value displayed in the default callout.
+   */
+  chartValueLabel: string;
+
+  /**
+   * Segment values displayed in the default callout.
+   */
+  segmentValues: YValueHover[];
+}
 
 /**
  * Gauge Chart properties
@@ -138,6 +171,11 @@ export interface GaugeChartProps {
    * Props for the callout in the chart
    */
   calloutProps?: Partial<ChartPopoverProps>;
+
+  /**
+   * Defines a custom callout renderer. The second argument can be used to render the default callout content.
+   */
+  onRenderCallout?: RenderFunction<GaugeChartCalloutData>;
 
   /**
    * Specifies the variant of GaugeChart to be rendered


### PR DESCRIPTION
## Previous Behavior

`GaugeChart` always rendered its built-in callout content. Consumers could style the popover, but could not replace or wrap its content, add domain-specific units, or identify which gauge segment opened the callout.

## New Behavior

- Adds `onRenderCallout` for replacing or wrapping the default GaugeChart callout.
- Adds `GaugeChartCalloutData` with the active legend, chart value, effective minimum and maximum, formatted value, and visible segment values.
- Supplies the existing renderer as `defaultRender` so custom content can compose with the standard callout.
- Adds a `GaugeChartCustomCallout` Storybook example demonstrating temperature units.

### Preview

Open the [PR demo site](https://fluentuipr.z22.web.core.windows.net/pull/36730/) and select **Charts / GaugeChart / Gauge Chart Custom Callout**.

## Validation

- `yarn nx run react-charts:test --testPathPatterns=GaugeChart.test.tsx --runInBand`
- `yarn nx run react-charts:lint`
- `yarn nx run react-charts-stories:lint`

## Related Issue(s)

No linked issue; this API addition follows consumer feedback requesting customizable GaugeChart callouts and support for non-percentage units.